### PR TITLE
Set Environment.resDir from library merged resources task output

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -15,13 +15,15 @@
  */
 package app.cash.paparazzi
 
+import java.io.File
+
 data class Environment(
   val platformDir: String,
-  val appTestDir: String
+  val appTestDir: String,
+  val resDir: String
 ) {
   val testResDir: String = "$appTestDir/app/build/intermediates/classes/production/release/"
   val assetsDir = "$appTestDir/src/main/assets/"
-  val resDir = "$appTestDir/src/main/res"
 }
 
 fun detectEnvironment(): Environment {
@@ -30,5 +32,6 @@ fun detectEnvironment(): Environment {
   val androidHome = System.getenv("ANDROID_HOME") ?: "$userHome/Library/Android/sdk"
   // TODO: detect platformDir by finding the highest SDK in ANDROID_HOME.
   val platformDir = "$androidHome/platforms/android-28/"
-  return Environment(platformDir, userDir)
+  val resDir = File("build/intermediates/paparazzi/resources.txt").readLines().first()
+  return Environment(platformDir, userDir, resDir)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,3 @@
-import java.nio.file.Files
-import java.nio.file.Paths
-
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -16,47 +13,23 @@ dependencies {
   api project(':paparazzi')
 }
 
-def compileAndroidResources = tasks.register("compileAndroidResources", Exec) {
-  def aapt2 = Files.list(Paths.get("${project.android.sdkDirectory}/build-tools"))
-      .max(Comparator.naturalOrder())
-      .get()
-      .resolve("aapt2")
+android.libraryVariants.all { variant ->
+  def variantSlug = variant.name.capitalize()
 
-  mkdir "${buildDir}/tmp"
-  executable aapt2
-  args 'compile',
-      '--dir', "${projectDir}/src/main/res/",
-      '-o', "${buildDir}/tmp/flat_res.zip"
-}
+  def verifyPaparazzi = tasks.register("verifyPaparazzi${variantSlug}Resources") {
+    // TODO: variant-aware file path
+    def outputFile = "${project.buildDir}/intermediates/paparazzi/resources.txt"
+    outputs.file(outputFile)
+    dependsOn variant.mergeResourcesProvider
 
-def generateRJava = tasks.register("generateRJava", Exec) {
-  def aapt2 = Files.list(Paths.get("${project.android.sdkDirectory}/build-tools"))
-      .max(Comparator.naturalOrder())
-      .get()
-      .resolve("aapt2")
-  def sdkJar = android.getBootClasspath()[0]
+    doLast {
+      def out = project.file(outputFile)
+      out.delete()
+      out << variant.mergeResourcesProvider.get().outputDir << '\n'
+    }
+  }
 
-  executable aapt2
-  args 'link',
-      '-I', sdkJar,
-      '--manifest', "${projectDir}/src/main/AndroidManifest.xml",
-      '--java', "${buildDir}/generated/source/src/test/java",
-      '-o', '/dev/null',
-      "${buildDir}/tmp/flat_res.zip"
-}
-
-generateRJava.configure {
-  it.dependsOn(compileAndroidResources)
-}
-
-tasks.withType(JavaCompile).configureEach {
-  it.dependsOn(generateRJava)
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-  it.dependsOn(generateRJava)
-}
-
-sourceSets {
-  test.java.srcDirs += "${buildDir}/generated/source/src/test/java/"
+  tasks.named("test${variant.unitTestVariant.name.capitalize()}").configure {
+    it.dependsOn(verifyPaparazzi)
+  }
 }


### PR DESCRIPTION
Piggybacks on the Android Gradle Plugin's work of combining all resources from local and external dependencies.

Closes #41