### PR TITLE
Fix AGP 3.6 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
   ext.versions = [
     kotlin: '1.3.61',
-    agp: '3.6.0',
+    agp: '3.6.1',
     layoutlib: '3.4.0', // "should" be similar to versions.agp
     androidTools: '26.5.0', // agp + 23.0.0 = androidTools
     jcodec: '0.2.5',

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
   ext.versions = [
     kotlin: '1.3.61',
-    agp: '3.5.1',
+    agp: '3.6.0',
     layoutlib: '3.4.0', // "should" be similar to versions.agp
     androidTools: '26.5.0', // agp + 23.0.0 = androidTools
     jcodec: '0.2.5',

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
+
+android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -23,18 +23,17 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
 open class PrepareResourcesTask : DefaultTask() {
   // Replace with @InputDirectory once mergeResourcesProvider.outputDir is of type Provider<File>.
+  @Internal
   internal lateinit var mergeResourcesProvider: TaskProvider<MergeResources>
-    @InputDirectory get
 
+  @Nested
   internal var outputDir: Provider<Directory> = project.objects.directoryProperty()
-    @OutputDirectory get
 
   @TaskAction
   fun writeResourcesFile() {

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -29,11 +29,12 @@ import org.gradle.api.tasks.TaskProvider
 
 open class PrepareResourcesTask : DefaultTask() {
   // Replace with @InputDirectory once mergeResourcesProvider.outputDir is of type Provider<File>.
-  @Internal
-  internal lateinit var mergeResourcesProvider: TaskProvider<MergeResources>
 
-  @Nested
+  internal lateinit var mergeResourcesProvider: TaskProvider<MergeResources>
+    @Internal get
+
   internal var outputDir: Provider<Directory> = project.objects.directoryProperty()
+    @Internal get
 
   @TaskAction
   fun writeResourcesFile() {

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -23,16 +23,18 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
 open class PrepareResourcesTask : DefaultTask() {
   // Replace with @InputDirectory once mergeResourcesProvider.outputDir is of type Provider<File>.
   internal lateinit var mergeResourcesProvider: TaskProvider<MergeResources>
-    @Internal get
+    @InputDirectory get
 
   internal var outputDir: Provider<Directory> = project.objects.directoryProperty()
-    @Internal get
+    @OutputDirectory get
 
   @TaskAction
   fun writeResourcesFile() {

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -17,15 +17,18 @@ package app.cash.paparazzi.gradle
 
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.MergeResources
+import com.android.Version
 import com.android.ide.common.symbols.getPackageNameFromManifest
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.VersionNumber
+import java.io.File
 
 open class PrepareResourcesTask : DefaultTask() {
   // Replace with @InputDirectory once mergeResourcesProvider.outputDir is of type Provider<File>.
@@ -45,11 +48,35 @@ open class PrepareResourcesTask : DefaultTask() {
         .use {
           it.write(project.packageName())
           it.newLine()
-          it.write(mergeResourcesProvider.get().outputDir.get().asFile.path)
+          it.write(mergeResourcesProvider.get().outputDirAsFile().path)
           it.newLine()
           it.write(project.compileSdkVersion())
         }
   }
+
+  /**
+   * In AGP 3.6 the return type of MergeResources#getOutputDir() was changed from File to
+   * DirectoryProperty. Here we use reflection in order to support users that have not upgraded to
+   * 3.6 yet.
+   */
+  private fun MergeResources.outputDirAsFile(): File {
+    val getOutputDir = this::class.java.getDeclaredMethod("getOutputDir")
+
+    return if (agpVersion() < VersionNumber.parse("3.6.0")) {
+      getOutputDir.invoke(this) as File
+    } else {
+      (getOutputDir.invoke(this) as DirectoryProperty).asFile.get()
+    }
+  }
+
+  private fun agpVersion() = VersionNumber.parse(
+      try {
+        Version.ANDROID_GRADLE_PLUGIN_VERSION
+      } catch (e: NoClassDefFoundError) {
+        @Suppress("DEPRECATION")
+        com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+      }
+  )
 
   private fun Project.packageName(): String {
     val androidExtension = extensions.getByType(BaseExtension::class.java)

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -43,7 +43,7 @@ open class PrepareResourcesTask : DefaultTask() {
         .use {
           it.write(project.packageName())
           it.newLine()
-          it.write(mergeResourcesProvider.get().outputDir.path)
+          it.write(mergeResourcesProvider.get().outputDir.get().asFile.path)
           it.newLine()
           it.write(project.compileSdkVersion())
         }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -41,8 +41,7 @@ open class PrepareResourcesTask : DefaultTask() {
 
   @TaskAction
   fun writeResourcesFile() {
-    val out = outputDir.get()
-        .asFile
+    val out = outputDir.get().asFile
     out.delete()
     out.bufferedWriter()
         .use {

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources/gradle.properties
@@ -1,0 +1,2 @@
+VERSION_NAME=0.5.0-SNAPSHOT
+android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources/gradle.properties
@@ -1,2 +1,0 @@
-VERSION_NAME=0.5.0-SNAPSHOT
-android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/gradle.properties
@@ -1,0 +1,2 @@
+VERSION_NAME=0.5.0-SNAPSHOT
+android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-svgs/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-svgs/gradle.properties
@@ -1,0 +1,2 @@
+VERSION_NAME=0.5.0-SNAPSHOT
+android.useAndroidX=true


### PR DESCRIPTION
This is the change necessary to fix issue #120. 

Google changed the MergeResource getOutputDir public API here https://android.googlesource.com/platform/tools/base/+/44c4c5a4aed32ba7403d1279ee7fec4b3ebe8b3f%5E%21/#F14