### PR TITLE
Introduce record and verify mode for image snapshots

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -17,13 +17,25 @@ package app.cash.paparazzi
 
 import com.squareup.moshi.JsonClass
 import java.util.Date
+import java.util.Locale
 
 @JsonClass(generateAdapter = true)
 data class Snapshot(
-  val name: String,
+  val name: String?,
   val testName: TestName,
   val timestamp: Date,
   val tags: List<String> = listOf(),
   val file: String? = null
 )
 
+internal fun Snapshot.toFileName(
+  delimiter: String = "_",
+  extension: String
+): String {
+  val formattedLabel = if(name != null) {
+    "$delimiter${name.toLowerCase(Locale.US).replace("\\s".toRegex(), delimiter)}"
+  } else {
+    ""
+  }
+  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.${extension}"
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import app.cash.paparazzi.SnapshotHandler.FrameHandler
+import app.cash.paparazzi.internal.ImageUtils
+import app.cash.paparazzi.internal.ImageUtils.MAX_PERCENT_DIFFERENCE
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+class SnapshotVerifier(
+  rootDirectory: File = File("src/test/snapshots")
+) : SnapshotHandler {
+  private val imagesDirectory: File = File(rootDirectory, "images")
+  private val videosDirectory: File = File(rootDirectory, "videos")
+
+  init {
+    imagesDirectory.mkdirs()
+    videosDirectory.mkdirs()
+  }
+
+  override fun newFrameHandler(
+    snapshot: Snapshot,
+    frameCount: Int,
+    fps: Int
+  ): FrameHandler {
+    return object : FrameHandler {
+      override fun handle(image: BufferedImage) {
+        // Note: does not handle videos or its frames at the moment
+        val expected = File(imagesDirectory, snapshot.toFileName(extension = "png"))
+        if (!expected.exists()) {
+          throw AssertionError("File $expected does not exist")
+        }
+
+        val goldenImage = ImageIO.read(expected)
+        ImageUtils.assertImageSimilar(
+            relativePath = expected.path,
+            image = image,
+            goldenImage = goldenImage,
+            maxPercentDifferent = MAX_PERCENT_DIFFERENCE
+        )
+      }
+
+      override fun close() = Unit
+    }
+  }
+
+  override fun close() = Unit
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -49,7 +49,7 @@ internal object ImageUtils {
 
   private val THUMBNAIL_SIZE = 1000
 
-  private val MAX_PERCENT_DIFFERENCE = 0.1
+  val MAX_PERCENT_DIFFERENCE = 0.1
 
   /** Directory where to write the thumbnails and deltas. */
   private val failureDir: File

--- a/sample/src/test/java/app/cash/paparazzi/sample/LaunchViewTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/LaunchViewTest.kt
@@ -30,14 +30,14 @@ class LaunchViewTest {
   @Test
   fun nexus7() {
     val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
-    paparazzi.snapshot(launch, "launch nexus7")
+    paparazzi.snapshot(launch)
   }
 
   @Test
   fun nexus5_differentOrientations() {
     val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
-    paparazzi.snapshot(launch, "launch nexus 5 portrait", deviceConfig = NEXUS_5)
-    paparazzi.snapshot(launch, "launch nexus 5 landscape", deviceConfig = NEXUS_5_LAND)
+    paparazzi.snapshot(launch, "portrait", deviceConfig = NEXUS_5)
+    paparazzi.snapshot(launch, "landscape", deviceConfig = NEXUS_5_LAND)
   }
 
   @Test
@@ -45,12 +45,12 @@ class LaunchViewTest {
     val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
     paparazzi.snapshot(
         view = launch,
-        name = "launch nexus 7 light",
+        name = "light",
         theme = "android:Theme.Material.Light"
     )
     paparazzi.snapshot(
         view = launch,
-        name = "launch nexus 7 light no-action-bar",
+        name = "light no_action_bar",
         theme = "android:Theme.Material.Light.NoActionBar"
     )
   }


### PR DESCRIPTION
Wanted some quick feedback before I continue down this path.  Will add
tests before merging.

Unlike the first attempt (https://github.com/cashapp/paparazzi/pull/69/files),
toggling between test modes is done via JVM system properties vs updating sources.

I removed the default snapshot index count for 2 reasons:
1) Iterative updates to tests quickly cause indexing to lose meaning.
Better to force callers to provide a label when multiple snapshots exist
in a given test method.
2) Video snapshots will use a similar index naming convention.

Will follow up with video snapshots in a separate PR.