### PR TITLE
Cleanup report URL

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -23,7 +23,6 @@ import org.gradle.api.logging.LogLevel.LIFECYCLE
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
-import java.io.File
 import java.util.Locale
 
 @Suppress("unused")
@@ -85,8 +84,8 @@ class PaparazziPlugin : Plugin<Project> {
 
       testTaskProvider.configure {
         it.doLast {
-          val uri = File(project.buildDir, "reports/paparazzi/index.html").toURI()
-          project.logger.log(LIFECYCLE, "Click here for Paparazzi report: $uri")
+          val uri = project.buildDir.toPath().resolve("reports/paparazzi/index.html").toUri()
+          project.logger.log(LIFECYCLE, "See the Paparazzi report at: $uri")
         }
       }
     }


### PR DESCRIPTION
Mimics the default test runner failure output:
```
> There were failing tests. See the report at: file:///Users/jrod/Development/paparazzi/sample/build/reports/tests/testDebugUnitTest/index.html
```

Before:
```
Click here for Paparazzi report: file:/Users/jrod/Development/paparazzi/sample/build/reports/paparazzi/index.html
```

After:
```
See the Paparazzi report at: file:///Users/jrod/Development/paparazzi/sample/build/reports/paparazzi/index.html
```