### PR TITLE
Add method interceptor for View.isInEditMode

### DIFF
--- a/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/AgentTestRule.kt
+++ b/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/AgentTestRule.kt
@@ -13,8 +13,11 @@ class AgentTestRule : TestRule {
     override fun evaluate() {
       ByteBuddyAgent.install()
       InterceptorRegistrar.registerMethodInterceptors()
-
-      base.evaluate()
+      try {
+        base.evaluate()
+      } finally {
+        InterceptorRegistrar.clearMethodInterceptors()
+      }
     }
   }
 }

--- a/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -15,7 +15,7 @@ object InterceptorRegistrar {
   ) {
     methodInterceptors += {
       ByteBuddy()
-          .rebase(receiver)
+          .redefine(receiver)
           .method(ElementMatchers.named(methodName))
           .intercept(MethodDelegation.to(interceptor))
           .make()
@@ -25,5 +25,9 @@ object InterceptorRegistrar {
 
   fun registerMethodInterceptors() {
     methodInterceptors.forEach { it.invoke() }
+  }
+
+  fun clearMethodInterceptors() {
+    methodInterceptors.clear()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -34,6 +34,15 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun interceptViewEditMode() {
+    val fixtureRoot = File("src/test/projects/edit-mode-intercept")
+
+    gradleRunner
+        .withArguments("testDebug", "--stacktrace")
+        .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
   fun verifyResourcesGeneratedForJavaProject() {
     val fixtureRoot = File("src/test/projects/verify-resources-java")
 

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+  jcenter()
+}
+
+android {
+  compileSdkVersion 28
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/src/test/java/app/cash/paparazzi/plugin/test/EditModeTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/src/test/java/app/cash/paparazzi/plugin/test/EditModeTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.content.Context
+import android.widget.LinearLayout
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class EditModeTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun crashIfInEditMode() {
+    val dummy = DummyLayout(paparazzi.context)
+    paparazzi.snapshot(dummy, "edit mode")
+  }
+}
+
+class DummyLayout(context: Context) : LinearLayout(context) {
+  override fun onAttachedToWindow() {
+    if (isInEditMode) {
+      throw IllegalStateException("D'oh, isInEditMode == true")
+    }
+    super.onAttachedToWindow()
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/EditModeInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/EditModeInterceptor.kt
@@ -1,0 +1,6 @@
+package app.cash.paparazzi.internal
+
+object EditModeInterceptor {
+  @JvmStatic
+  fun intercept(): Boolean = false
+}


### PR DESCRIPTION
LayoutLib's View_Delegate currently intercepts [all calls to View.isInEditMode](https://cs.android.com/android/platform/superproject/+/master:frameworks/layoutlib/bridge/src/android/view/View_Delegate.java;l=37?q=View_Delegate) returning true.  While this default behavior makes sense for AndroidStudio's Layout Editor, which has historically not been able to render custom views very well, it gets in Paparazzi's way and requires authors to remove any isInEditMode checks that they would otherwise have wanted.

This provides a workaround, by intercepting the calls before they get intercepted by LayoutLib.