### PR TITLE
Add support for onGlobalLayout

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
@@ -35,7 +35,6 @@ class PaparazziDisplayManager : IDisplayManager.Stub() {
   }
 
   override fun registerCallback(p0: IDisplayManagerCallback?) {
-
   }
 
   override fun getDisplayInfo(p0: Int): DisplayInfo {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.paparazzi.internal
+
+import android.content.pm.ParceledListSlice
+import android.graphics.Point
+import android.hardware.display.BrightnessConfiguration
+import android.hardware.display.Curve
+import android.hardware.display.IDisplayManager
+import android.hardware.display.IDisplayManagerCallback
+import android.hardware.display.IVirtualDisplayCallback
+import android.hardware.display.WifiDisplayStatus
+import android.media.projection.IMediaProjection
+import android.view.DisplayInfo
+import android.view.Surface
+
+class PaparazziDisplayManager : IDisplayManager.Stub() {
+
+  override fun getPreferredWideGamutColorSpaceId(): Int {
+    return 0
+  }
+
+  override fun registerCallback(p0: IDisplayManagerCallback?) {
+
+  }
+
+  override fun getDisplayInfo(p0: Int): DisplayInfo {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getDisplayIds(): IntArray {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun isUidPresentOnDisplay(
+    p0: Int,
+    p1: Int
+  ): Boolean {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun startWifiDisplayScan() {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun stopWifiDisplayScan() {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun connectWifiDisplay(p0: String?) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun disconnectWifiDisplay() {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun renameWifiDisplay(
+    p0: String?,
+    p1: String?
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun forgetWifiDisplay(p0: String?) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun pauseWifiDisplay() {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun resumeWifiDisplay() {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getWifiDisplayStatus(): WifiDisplayStatus {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun requestColorMode(
+    p0: Int,
+    p1: Int
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun createVirtualDisplay(
+    p0: IVirtualDisplayCallback?,
+    p1: IMediaProjection?,
+    p2: String?,
+    p3: String?,
+    p4: Int,
+    p5: Int,
+    p6: Int,
+    p7: Surface?,
+    p8: Int,
+    p9: String?
+  ): Int {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun resizeVirtualDisplay(
+    p0: IVirtualDisplayCallback?,
+    p1: Int,
+    p2: Int,
+    p3: Int
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun setVirtualDisplaySurface(
+    p0: IVirtualDisplayCallback?,
+    p1: Surface?
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun releaseVirtualDisplay(p0: IVirtualDisplayCallback?) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun setVirtualDisplayState(
+    p0: IVirtualDisplayCallback?,
+    p1: Boolean
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getStableDisplaySize(): Point {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getBrightnessEvents(p0: String?): ParceledListSlice<*> {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getAmbientBrightnessStats(): ParceledListSlice<*> {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun setBrightnessConfigurationForUser(
+    p0: BrightnessConfiguration?,
+    p1: Int,
+    p2: String?
+  ) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getBrightnessConfigurationForUser(p0: Int): BrightnessConfiguration {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getDefaultBrightnessConfiguration(): BrightnessConfiguration {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun setTemporaryBrightness(p0: Int) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun setTemporaryAutoBrightnessAdjustment(p0: Float) {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+  override fun getMinimumBrightnessCurve(): Curve {
+    throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
+  }
+
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
@@ -29,7 +29,6 @@ import android.view.DisplayInfo
 import android.view.Surface
 
 class PaparazziDisplayManager : IDisplayManager.Stub() {
-
   override fun getPreferredWideGamutColorSpaceId(): Int {
     return 0
   }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziDisplayManager.kt
@@ -178,5 +178,4 @@ class PaparazziDisplayManager : IDisplayManager.Stub() {
   override fun getMinimumBrightnessCurve(): Curve {
     throw UnsupportedOperationException("Minimum IDisplayManager methods are supported.")
   }
-
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziWindowSession.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziWindowSession.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.paparazzi.internal
+
+import android.content.ClipData
+import android.graphics.Rect
+import android.graphics.Region
+import android.os.Bundle
+import android.os.IBinder
+import android.util.MergedConfiguration
+import android.view.DisplayCutout.ParcelableWrapper
+import android.view.IWindow
+import android.view.IWindowId
+import android.view.IWindowSession
+import android.view.InputChannel
+import android.view.InsetsState
+import android.view.SurfaceControl
+import android.view.WindowManager.LayoutParams
+
+class PaparazziWindowSession : IWindowSession.Stub() {
+  override fun addToDisplay(
+    p0: IWindow?,
+    p1: Int,
+    p2: LayoutParams?,
+    p3: Int,
+    p4: Int,
+    p5: Rect?,
+    p6: Rect?,
+    p7: Rect?,
+    p8: Rect?,
+    p9: ParcelableWrapper?,
+    p10: InputChannel?,
+    p11: InsetsState?
+  ): Int {
+    return 0
+  }
+
+  override fun relayout(
+    p0: IWindow?,
+    p1: Int,
+    p2: LayoutParams?,
+    p3: Int,
+    p4: Int,
+    p5: Int,
+    p6: Int,
+    p7: Long,
+    p8: Rect?,
+    p9: Rect?,
+    p10: Rect?,
+    p11: Rect?,
+    p12: Rect?,
+    p13: Rect?,
+    p14: Rect?,
+    p15: ParcelableWrapper?,
+    p16: MergedConfiguration?,
+    p17: SurfaceControl?,
+    p18: InsetsState?
+  ): Int {
+    return 0
+  }
+
+  override fun addToDisplayWithoutInputChannel(
+    p0: IWindow?,
+    p1: Int,
+    p2: LayoutParams?,
+    p3: Int,
+    p4: Int,
+    p5: Rect?,
+    p6: Rect?,
+    p7: InsetsState?
+  ): Int {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun remove(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun prepareToReplaceWindows(
+    p0: IBinder?,
+    p1: Boolean
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun outOfMemory(p0: IWindow?): Boolean {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun setTransparentRegion(
+    p0: IWindow?,
+    p1: Region?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun setInsets(
+    p0: IWindow?,
+    p1: Int,
+    p2: Rect?,
+    p3: Rect?,
+    p4: Region?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun getDisplayFrame(
+    p0: IWindow?,
+    p1: Rect?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun finishDrawing(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun setInTouchMode(p0: Boolean) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun getInTouchMode(): Boolean {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun performHapticFeedback(
+    p0: Int,
+    p1: Boolean
+  ): Boolean {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun performDrag(
+    p0: IWindow?,
+    p1: Int,
+    p2: SurfaceControl?,
+    p3: Int,
+    p4: Float,
+    p5: Float,
+    p6: Float,
+    p7: Float,
+    p8: ClipData?
+  ): IBinder {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun reportDropResult(
+    p0: IWindow?,
+    p1: Boolean
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun cancelDragAndDrop(
+    p0: IBinder?,
+    p1: Boolean
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun dragRecipientEntered(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun dragRecipientExited(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun setWallpaperPosition(
+    p0: IBinder?,
+    p1: Float,
+    p2: Float,
+    p3: Float,
+    p4: Float
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun wallpaperOffsetsComplete(p0: IBinder?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun setWallpaperDisplayOffset(
+    p0: IBinder?,
+    p1: Int,
+    p2: Int
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun sendWallpaperCommand(
+    p0: IBinder?,
+    p1: String?,
+    p2: Int,
+    p3: Int,
+    p4: Int,
+    p5: Bundle?,
+    p6: Boolean
+  ): Bundle {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun wallpaperCommandComplete(
+    p0: IBinder?,
+    p1: Bundle?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun onRectangleOnScreenRequested(
+    p0: IBinder?,
+    p1: Rect?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun getWindowId(p0: IBinder?): IWindowId {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun pokeDrawLock(p0: IBinder?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun startMovingTask(
+    p0: IWindow?,
+    p1: Float,
+    p2: Float
+  ): Boolean {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun finishMovingTask(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun updatePointerIcon(p0: IWindow?) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun reparentDisplayContent(
+    p0: IWindow?,
+    p1: SurfaceControl?,
+    p2: Int
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun updateDisplayContentLocation(
+    p0: IWindow?,
+    p1: Int,
+    p2: Int,
+    p3: Int
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun updateTapExcludeRegion(
+    p0: IWindow?,
+    p1: Int,
+    p2: Region?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun insetsModified(
+    p0: IWindow?,
+    p1: InsetsState?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+
+  override fun reportSystemGestureExclusionChanged(
+    p0: IWindow?,
+    p1: MutableList<Rect>?
+  ) {
+    throw UnsupportedOperationException("Minimum IWindowSession methods are supported.")
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ServiceManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ServiceManagerInterceptor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.paparazzi.internal
+
+import android.os.IBinder
+
+object ServiceManagerInterceptor {
+  @JvmStatic
+  fun intercept(
+    name: String
+  ): IBinder? {
+    return when (name) {
+      "display" -> PaparazziDisplayManager()
+      else -> null
+    }
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/WindowManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/WindowManagerInterceptor.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.paparazzi.internal
+
+import android.view.IWindowSession
+import android.view.IWindowSessionCallback
+
+object WindowManagerInterceptor {
+  @JvmStatic
+  fun intercept(
+    callback: IWindowSessionCallback
+  ): IWindowSession? {
+    return PaparazziWindowSession()
+  }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -124,6 +124,24 @@ class PaparazziTest {
     assertThat(log).containsExactly("view width=1080 height=1776")
   }
 
+  @Test
+  fun onGlobalLayoutCalls() {
+    var onGlobalLayout = false
+
+    val view = object: View(paparazzi.context) {
+      override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        viewTreeObserver.addOnGlobalLayoutListener {
+          onGlobalLayout = true
+        }
+      }
+    }
+
+    paparazzi.snapshot(view)
+
+    assertThat(onGlobalLayout).isTrue
+  }
+
   private val time: Long
     get() {
       return TimeUnit.NANOSECONDS.toMillis(System_Delegate.nanoTime() - Paparazzi.TIME_OFFSET_NANOS)


### PR DESCRIPTION
ViewRootImpl is responsible for scheduling / traversing view callbacks with the Choreographer. In order to support onGlobalLayout we must use ViewRootImpl#setView with RenderSession's rootView to allow the proper callbacks to be triggered.  The problem is that #setView interacts with DisplayManager and WindowSession which are not fully setup by layout lib. So we can use ByteBuddy to stub out the integration with those classes and provide sensible defaults to allow access to this method.