### PR TITLE
Add render extension api to extend paparazzi

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2021 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import android.view.View
+import java.awt.image.BufferedImage
+
+/**
+RenderExtension is an interface that can render additional information on top of the ui Paparazzi renders for each frame
+ */
+interface RenderExtension {
+  fun render(
+    snapshot: Snapshot,
+    view: View,
+    image: BufferedImage,
+  ): BufferedImage
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/RenderExtension.kt
@@ -19,7 +19,7 @@ import android.view.View
 import java.awt.image.BufferedImage
 
 /**
-RenderExtension is an interface that can render additional information on top of the ui Paparazzi renders for each frame
+ * An extension for overlaying additional information on top of each rendered frame.
  */
 interface RenderExtension {
   fun render(


### PR DESCRIPTION
The initial thought behind adding this api was to give devs a way to add metadata to the paparazzi snapshot.

This is the first pr to set up the plumbing for adding basic accessibility snapshots, similar to [Accessibility Snapshot](https://github.com/cashapp/AccessibilitySnapshot). 