### PR TITLE
Support opening files from assets

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -29,7 +29,9 @@ import app.cash.paparazzi.agent.InterceptorRegistrar
 import app.cash.paparazzi.internal.EditModeInterceptor
 import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.LayoutPullParser
+import app.cash.paparazzi.internal.PaparazziAssetRepository
 import app.cash.paparazzi.internal.PaparazziCallback
+import app.cash.paparazzi.internal.PaparazziContext
 import app.cash.paparazzi.internal.PaparazziLogger
 import app.cash.paparazzi.internal.Renderer
 import app.cash.paparazzi.internal.ResourcesInterceptor
@@ -75,7 +77,7 @@ class Paparazzi(
     get() = RenderAction.getCurrentContext().resources
 
   val context: Context
-    get() = RenderAction.getCurrentContext()
+    get() = PaparazziContext(RenderAction.getCurrentContext(), PaparazziAssetRepository(environment.assetsDir))
 
   val contentRoot = """
         |<?xml version="1.0" encoding="utf-8"?>

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaprazziContext.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaprazziContext.kt
@@ -1,0 +1,24 @@
+package app.cash.paparazzi.internal
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.AssetManager
+import com.android.ide.common.rendering.api.AssetRepository
+import java.io.InputStream
+
+internal class PaparazziContext(base: Context, private val assetRepository: AssetRepository)
+    : ContextWrapper(base) {
+
+  override fun getAssets(): AssetManager = PaparazziAssetManager(assetRepository)
+
+}
+
+internal class PaparazziAssetManager(private val assetRepository: AssetRepository)
+    : AssetManager() {
+
+  override fun open(fileName: String): InputStream = open(fileName, ACCESS_STREAMING)
+
+  override fun open(fileName: String, mode: Int): InputStream =
+    assetRepository.openAsset("/$fileName", mode)
+
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -127,29 +127,20 @@ class PaparazziTest {
 
   @Test
   fun open_file_from_assets() {
-    val fileName = "file.txt"
     val fileContent = "file context"
 
-    tempFile("${detectEnvironment().assetsDir}/$fileName") { file ->
-      file.writeText(fileContent)
-
-      paparazzi.context.assets.open(fileName).bufferedReader().use { reader ->
-        assertThat(reader.readLine()).isEqualTo(fileContent)
-      }
-
-      paparazzi.context.assets.open(fileName, 2).bufferedReader().use { reader ->
-        assertThat(reader.readLine()).isEqualTo(fileContent)
-      }
+    val file = File.createTempFile("tmp", null, File(detectEnvironment().assetsDir)).apply {
+      writeText(fileContent)
+      deleteOnExit()
     }
-  }
 
-  private fun tempFile(path: String, action: (File) -> Unit) {
-    val file = File(path)
+    paparazzi.context.assets.open(file.name).bufferedReader().use { reader ->
+      assertThat(reader.readLine()).isEqualTo(fileContent)
+    }
 
-    val result = runCatching { action(file) }
-    file.delete()
-
-    result.exceptionOrNull()?.let { throw it }
+    paparazzi.context.assets.open(file.name, 2).bufferedReader().use { reader ->
+      assertThat(reader.readLine()).isEqualTo(fileContent)
+    }
   }
 
   private val time: Long

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -133,12 +133,12 @@ class PaparazziTest {
     tempFile("${detectEnvironment().assetsDir}/$fileName") { file ->
       file.writeText(fileContent)
 
-      paparazzi.context.assets.open(fileName).bufferedReader().use { content ->
-        assertThat(content).isEqualTo(fileContent)
+      paparazzi.context.assets.open(fileName).bufferedReader().use { reader ->
+        assertThat(reader.readLine()).isEqualTo(fileContent)
       }
 
-      paparazzi.context.assets.open(fileName, 2).bufferedReader().use { content ->
-        assertThat(content).isEqualTo(fileContent)
+      paparazzi.context.assets.open(fileName, 2).bufferedReader().use { reader ->
+        assertThat(reader.readLine()).isEqualTo(fileContent)
       }
     }
   }

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -27,6 +27,7 @@ import com.android.tools.layoutlib.java.System_Delegate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 class PaparazziTest {
@@ -122,6 +123,33 @@ class PaparazziTest {
     paparazzi.snapshot(view)
 
     assertThat(log).containsExactly("view width=1080 height=1776")
+  }
+
+  @Test
+  fun open_file_from_assets() {
+    val fileName = "file.txt"
+    val fileContent = "file context"
+
+    tempFile("${detectEnvironment().assetsDir}/$fileName") { file ->
+      file.writeText(fileContent)
+
+      paparazzi.context.assets.open(fileName).bufferedReader().use { content ->
+        assertThat(content).isEqualTo(fileContent)
+      }
+
+      paparazzi.context.assets.open(fileName, 2).bufferedReader().use { content ->
+        assertThat(content).isEqualTo(fileContent)
+      }
+    }
+  }
+
+  private fun tempFile(path: String, action: (File) -> Unit) {
+    val file = File(path)
+
+    val result = runCatching { action(file) }
+    file.delete()
+
+    result.exceptionOrNull()?.let { throw it }
   }
 
   private val time: Long


### PR DESCRIPTION
Closes #179

A common use case is to load images from assets (using `file:///android_asset/...` URI) during tests while pointing to real images URL in prod