### PR TITLE
Do not require valid test class to get test name

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -285,8 +285,9 @@ class Paparazzi(
   }
 
   private fun Description.toTestName(): TestName {
-    val packageName = testClass.`package`.name
-    val className = testClass.name.substring(packageName.length + 1)
+    val fullQualifiedName = className
+    val packageName = fullQualifiedName.substringBeforeLast('.', missingDelimiterValue = "")
+    val className = fullQualifiedName.substringAfterLast('.')
     return TestName(packageName, className, methodName)
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -11,4 +11,6 @@ android {
 
 dependencies {
   implementation deps.kotlin.stdlib.jdk8
+
+  testImplementation "com.squareup.burst:burst-junit4:1.2.0"
 }

--- a/sample/src/test/java/app/cash/paparazzi/sample/BurstTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/BurstTest.kt
@@ -1,0 +1,44 @@
+package app.cash.paparazzi.sample
+
+import android.widget.LinearLayout
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.squareup.burst.BurstJUnit4
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@Ignore("This is not supported paparazzi version this sample uses.")
+@RunWith(BurstJUnit4::class)
+class BurstTest(
+  private val config: Config
+) {
+  enum class Config(
+    val deviceConfig: DeviceConfig,
+  ) {
+    NEXUS_4(deviceConfig = DeviceConfig.NEXUS_4),
+    NEXUS_5(deviceConfig = DeviceConfig.NEXUS_5),
+    NEXUS_5_LAND(deviceConfig = DeviceConfig.NEXUS_5_LAND),
+  }
+
+  enum class Theme(val themeName: String) {
+    LIGHT("android:Theme.Material.Light"),
+    LIGHT_NO_ACTION_BAR("android:Theme.Material.Light.NoActionBar")
+  }
+
+  @get:Rule
+  var paparazzi = Paparazzi(deviceConfig = config.deviceConfig)
+
+  @Test
+  fun simple() {
+    val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
+    paparazzi.snapshot(launch)
+  }
+
+  @Test
+  fun simpleWithTheme(theme: Theme) {
+    val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
+    paparazzi.snapshot(launch, theme = theme.themeName)
+  }
+}


### PR DESCRIPTION
This enables tests using Burst, which generates test class names like
TestClass[PARAMETER].

![Screen Shot 2021-01-29 at 2 26 05 PM](https://user-images.githubusercontent.com/333672/106318562-1b460480-623e-11eb-9087-cf3061793839.png)
