### PR TITLE
Always write screenshot in record mode

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -100,9 +100,7 @@ internal class HtmlReportWriter(
           val original = File(imagesDirectory, "${hashes[0]}.png")
           if (isRecording) {
             val goldenFile = File(goldenImagesDirectory, snapshot.toFileName("_", "png"))
-            if (!goldenFile.exists()) {
-              original.copyTo(goldenFile)
-            }
+            original.copyTo(goldenFile, overwrite = true)
           }
           snapshot.copy(file = rootDirectory.toPath().relativize(original.toPath()).toString())
         } else {


### PR DESCRIPTION
Premature optimization is leading to a bug where a legitimate change is not written to disk unless the previous snapshot is first deleted.