### PR TITLE
Fail fast by re-throwing render result exceptions

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -42,6 +42,7 @@ import app.cash.paparazzi.internal.SessionParamsBuilder
 import app.cash.paparazzi.internal.WindowManagerInterceptor
 import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.Result
+import com.android.ide.common.rendering.api.Result.Status.ERROR_UNKNOWN
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.layoutlib.bridge.Bridge.cleanupThread
 import com.android.layoutlib.bridge.Bridge.prepareThread
@@ -242,7 +243,10 @@ class Paparazzi(
         for (frame in 0 until frameCount) {
           val nowNanos = (startNanos + (frame * 1_000_000_000.0 / fps)).toLong()
           withTime(nowNanos) {
-            renderSession.render(true)
+            val result = renderSession.render(true)
+            if (result.status == ERROR_UNKNOWN) {
+              throw result.exception
+            }
 
             var image = bridgeRenderSession.image
             renderExtensions.forEach {

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -107,7 +107,7 @@ class PaparazziTest {
   fun frameCallbacksExecutedAfterLayout() {
     val log = mutableListOf<String>()
 
-    val view = object: View(paparazzi.context) {
+    val view = object : View(paparazzi.context) {
       override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         Choreographer.getInstance()
@@ -140,6 +140,24 @@ class PaparazziTest {
     paparazzi.snapshot(view)
 
     assertThat(onGlobalLayout).isTrue
+  }
+
+  @Test
+  fun throwsRenderingExceptions() {
+    val view = object : View(paparazzi.context) {
+      override fun onAttachedToWindow() {
+        throw Throwable("Oops")
+      }
+    }
+
+    val thrown = try {
+      paparazzi.snapshot(view)
+      false
+    } catch (exception: Throwable) {
+      true
+    }
+
+    assertThat(thrown).isTrue
   }
 
   private val time: Long


### PR DESCRIPTION
Right now, if a crash happens internally, RenderSessionImpl catches it, returns it in the RenderResult, and proceeds to render a blank view 👎 

Instead, we wanna crash when that happens. Fail fast!