### PR TITLE
Bump and clean up build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
   ext.versions = [
-    kotlin: '1.4.30',
-    agp: '3.6.1',
+    kotlin: '1.4.31',
+    agp: '4.1.2',
     layoutlib: '4.0.0-alpha02-b169460', // "should" be similar to versions.agp
-    androidTools: '26.6.0', // agp + 23.0.0 = androidTools
+    androidTools: '27.1.2', // agp + 23.0.0 = androidTools
     jcodec: '0.2.5',
     moshi: '1.11.0',
     bytebuddy: '1.10.21',
@@ -30,7 +30,7 @@ buildscript {
     tools: [
       common: "com.android.tools:common:${versions.androidTools}",
       layoutlib: "com.android.tools.layoutlib:layoutlib-api:${versions.androidTools}",
-      sdkcommon: "com.android.tools:sdk-common:${versions.androidTools}",
+      sdkcommon: "com.android.tools:sdk-common:26.6.4",
     ],
     kxml2: 'kxml2:kxml2:2.3.0',
     androidx: [

--- a/paparazzi-agent/build.gradle
+++ b/paparazzi-agent/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 
 dependencies {
-  implementation deps.kotlin.stdlib.jdk8
-
   implementation deps.bytebuddy.core
   implementation deps.bytebuddy.agent
   api deps.junit

--- a/paparazzi-agent/build.gradle
+++ b/paparazzi-agent/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 
 dependencies {

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -11,8 +11,6 @@ gradlePlugin {
 }
 
 dependencies {
-  implementation deps.kotlin.stdlib.jdk8
-
   compileOnly gradleApi()
   implementation deps.plugins.kotlin
   implementation deps.plugins.android

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -75,7 +75,7 @@ open class PrepareResourcesTask : DefaultTask() {
 
   private fun Project.compileSdkVersion(): String {
     val androidExtension = extensions.getByType(BaseExtension::class.java)
-    return androidExtension.compileSdkVersion.substringAfter(
+    return androidExtension.compileSdkVersion!!.substringAfter(
         "android-", DEFAULT_COMPILE_SDK_VERSION.toString()
     )
   }
@@ -88,7 +88,7 @@ open class PrepareResourcesTask : DefaultTask() {
 
   private fun Project.sdkFolder(): File {
     val androidExtension = extensions.getByType(BaseExtension::class.java)
-    return androidExtension.sdkDirectory!!
+    return androidExtension.sdkDirectory
   }
 
   companion object {

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   implementation deps.moshi.core
   implementation deps.moshi.adapters
   kapt deps.moshi.kotlinCodegen
-  implementation deps.kotlin.stdlib.jdk8
   implementation deps.jcodec.core
   implementation deps.jcodec.javase
   implementation project(':paparazzi-agent')

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -1,5 +1,4 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'org.jetbrains.dokka'
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -96,9 +96,6 @@ internal class PaparazziCallback(
     return viewConstructor.newInstance(*constructorArgs)
   }
 
-  override fun getNamespace(): String =
-    String.format(SdkConstants.NS_CUSTOM_RESOURCES_S, packageName)
-
   override fun resolveResourceId(id: Int): ResourceReference? = projectResources[id]
 
   override fun getOrGenerateResourceId(resource: ResourceReference): Int {
@@ -149,8 +146,6 @@ internal class PaparazziCallback(
   ): AdapterBinding? = null
 
   override fun getActionBarCallback(): ActionBarCallback = actionBarCallback
-
-  override fun supports(ideFeature: Int): Boolean = false
 
   override fun createXmlParserForPsiFile(fileName: String): XmlPullParser? =
     createXmlParserForFile(fileName)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'app.cash.paparazzi'
 
 android {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,7 +10,5 @@ android {
 }
 
 dependencies {
-  implementation deps.kotlin.stdlib.jdk8
-
   testImplementation deps.burst
 }


### PR DESCRIPTION
Bump build dependencies
-  Kotlin 1.4.31
-  AGP 4.1.2
-  tools.common 27.1.2
-  tools.layoutlib-api 27.1.2
-  tools.sdk-common stays fixed to 26.6.4 until Paparazzi is migrated from com.android.ide.common.resources.deprecated.ResourceRepository to com.android.ide.common.resources.ResourceRepository.

Remove explicit stdlib dependencies    
Clean up plugin applications