### PR TITLE
Don't swallow FileNotFoundExceptions when overridden platform dir doesn't exist

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -36,6 +36,20 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun missingPlatformDirTest() {
+    val fixtureRoot = File("src/test/projects/missing-platform-dir")
+
+    val result = gradleRunner
+        .withArguments("testDebug", "--stacktrace")
+        .forwardOutput()
+        .runFixture(fixtureRoot) { buildAndFail() }
+
+    assertThat(result.task(":testDebug")).isNull()
+    assertThat(result.output).contains("java.io.FileNotFoundException")
+    assertThat(result.output).contains("platforms/android-oops")
+  }
+
+  @Test
   fun flagDebugLinkedObjectsIsOff() {
     val fixtureRoot = File("src/test/projects/flag-debug-linked-objects-off")
 

--- a/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+  jcenter()
+}
+
+android {
+  compileSdkVersion 29
+  defaultConfig {
+    minSdkVersion 25
+  }
+}
+
+tasks.withType(Test).configureEach {
+  testLogging {
+    exceptionFormat 'FULL'
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/src/test/java/app/cash/paparazzi/plugin/test/MissingPlatformDirTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/src/test/java/app/cash/paparazzi/plugin/test/MissingPlatformDirTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.view.View
+import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.androidHome
+import app.cash.paparazzi.detectEnvironment
+import org.junit.Rule
+import org.junit.Test
+
+class MissingPlatformDirTest {
+  @get:Rule
+  val paparazzi = Paparazzi(
+    environment = detectEnvironment().copy(
+      platformDir = "${androidHome()}/platforms/android-oops",
+    )
+  )
+
+  @Test fun test() {}
+}


### PR DESCRIPTION
Closes #215

```
java.io.FileNotFoundException: /Users/jrod/Library/Android/sdk/platforms/android-28/build.prop (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at app.cash.paparazzi.DeviceConfig$Companion.loadProperties(DeviceConfig.kt:421)
```