### PR TITLE
Revert layoutlib-api bump, incompatible with layoutlib impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     ],
     tools: [
       common: "com.android.tools:common:${versions.androidTools}",
-      layoutlib: "com.android.tools.layoutlib:layoutlib-api:${versions.androidTools}",
+      layoutlib: "com.android.tools.layoutlib:layoutlib-api:26.6.0",
       sdkcommon: "com.android.tools:sdk-common:26.6.4",
     ],
     kxml2: 'kxml2:kxml2:2.3.0',

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -96,6 +96,9 @@ internal class PaparazziCallback(
     return viewConstructor.newInstance(*constructorArgs)
   }
 
+  override fun getNamespace(): String =
+    String.format(SdkConstants.NS_CUSTOM_RESOURCES_S, packageName)
+
   override fun resolveResourceId(id: Int): ResourceReference? = projectResources[id]
 
   override fun getOrGenerateResourceId(resource: ResourceReference): Int {
@@ -146,6 +149,8 @@ internal class PaparazziCallback(
   ): AdapterBinding? = null
 
   override fun getActionBarCallback(): ActionBarCallback = actionBarCallback
+
+  override fun supports(ideFeature: Int): Boolean = false
 
   override fun createXmlParserForPsiFile(fileName: String): XmlPullParser? =
     createXmlParserForFile(fileName)


### PR DESCRIPTION
[This PR](https://github.com/cashapp/paparazzi/pull/213) bumped layoutlib-api from 26.6.0 to 27.1.2, but the corresponding layoutlib.jar still relied on LayoutlibCallback#getNamespace for calls to BridgeXmlPullAttributes#getAttributeNameResource.

```
  public int getAttributeNameResource(int index) {
    String name = this.getAttributeName(index);
    String ns = this.mParser.getAttributeNamespace(index);
    if ("http://schemas.android.com/apk/res/android".equals(ns)) {
      return Bridge.getResourceId(ResourceType.ATTR, name);
    } else {
      if (this.mContext.getLayoutlibCallback().getNamespace().equals(ns)) { // boom!
```

Notably, AppBarLayout hit this code path:

```
Caused by: java.lang.NoSuchMethodError: 'java.lang.String com.android.ide.common.rendering.api.LayoutlibCallback.getNamespace()'
	at android.util.BridgeXmlPullAttributes.getAttributeNameResource(BridgeXmlPullAttributes.java:109)
	at com.android.layoutlib.bridge.android.BridgeXmlBlockParser.getAttributeNameResource(BridgeXmlBlockParser.java:452)
	at android.animation.AnimatorInflater.createStateListAnimatorFromXml(AnimatorInflater.java:226)
	at android.animation.AnimatorInflater.loadStateListAnimator(AnimatorInflater.java:170)
	at com.google.android.material.appbar.ViewUtilsLollipop.setStateListAnimatorFromAttrs(ViewUtilsLollipop.java:51)
	at com.google.android.material.appbar.AppBarLayout.<init>(AppBarLayout.java:208)
	at com.google.android.material.appbar.AppBarLayout.<init>(AppBarLayout.java:194)
```

so let's revert the bump for now.