### PR TITLE
Update pip requirements path for Github Actions website publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build mkdocs
         run: |
-          pip3 install -r requirements.txt
+          pip3 install -r .github/workflows/requirements.txt
           mkdocs build
 
       - name: Deploy docs to website


### PR DESCRIPTION
Example failed build: https://github.com/cashapp/paparazzi/runs/3266554623