### PR TITLE
Fix layoutlib publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,15 @@ subprojects {
       }
     }
   }
+
+  tasks.register('emptySourcesJar', Jar) {
+    // TODO: fetch sources from the corresponding AOSP repos.
+    archiveClassifier = 'sources'
+  }
+
+  tasks.register('emptyJavadocJar', Jar) {
+    archiveClassifier = 'javadoc'
+  }
 }
 
 task clean(type: Delete) {

--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'com.vanniktech.maven.publish'
 
+version = versions.layoutlib
+
 /**
  * Clone AOSP's prebuilts repo to get a prebuilt layoutlib jar. This big repo that takes a long time to clone!
  *
@@ -43,13 +45,10 @@ publishing {
     layoutLib(MavenPublication) {
       artifact(tasks.
           named("cloneLayoutlib").
-          map {
-            new File(it.outputs.files.getSingleFile(), 'data/layoutlib-jdk11.jar')
-          }
+          map { new File(it.outputs.files.getSingleFile(), 'data/layoutlib-jdk11.jar') }
       )
-
-      version = versions.layoutlib
+      artifact emptySourcesJar
+      artifact emptyJavadocJar
     }
   }
 }
-


### PR DESCRIPTION
* Sets artifact version via project.version vs publication.version (thanks @gabrielittner!)
* Publishes empty javadoc and sources jar required for Maven Central deploy