### PR TITLE
Add method interceptors for matrix multiplication operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     androidTools: '27.2.2', // agp + 23.0.0 = androidTools
     jcodec: '0.2.5',
     moshi: '1.12.0',
-    bytebuddy: '1.11.9',
+    bytebuddy: '1.11.15',
     releasedPaparazzi: '0.7.1'
   ]
 

--- a/paparazzi-agent/build.gradle
+++ b/paparazzi-agent/build.gradle
@@ -5,4 +5,6 @@ dependencies {
   implementation deps.bytebuddy.core
   implementation deps.bytebuddy.agent
   api deps.junit
+
+  testImplementation deps.assertj
 }

--- a/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -24,7 +24,9 @@ object InterceptorRegistrar {
         .redefine(receiver)
 
       methodNamesToInterceptors.forEach {
-        builder = builder.method(ElementMatchers.named(it.first)).intercept(MethodDelegation.to(it.second))
+        builder = builder
+          .method(ElementMatchers.named(it.first))
+          .intercept(MethodDelegation.to(it.second))
       }
 
       builder

--- a/paparazzi-agent/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
+++ b/paparazzi-agent/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
@@ -1,0 +1,65 @@
+package app.cash.paparazzi.agent
+
+import net.bytebuddy.agent.ByteBuddyAgent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class InterceptorRegistrarTest {
+  @Before
+  fun setup() {
+    InterceptorRegistrar.addMethodInterceptors(
+      Utils::class.java,
+      setOf(
+        "log1" to Interceptor1::class.java,
+        "log2" to Interceptor2::class.java,
+      )
+    )
+
+    ByteBuddyAgent.install()
+    InterceptorRegistrar.registerMethodInterceptors()
+  }
+
+  @Test
+  fun test() {
+    Utils.log1()
+    Utils.log2()
+
+    assertThat(logs).containsExactly("intercept1", "intercept2")
+  }
+
+  @After
+  fun teardown() {
+    InterceptorRegistrar.clearMethodInterceptors()
+  }
+
+  object Utils {
+    fun log1() {
+      logs += "original1"
+    }
+    fun log2() {
+      logs += "original2"
+    }
+  }
+
+  object Interceptor1 {
+    @Suppress("unused")
+    @JvmStatic
+    fun intercept() {
+      logs += "intercept1"
+    }
+  }
+
+  object Interceptor2 {
+    @Suppress("unused")
+    @JvmStatic
+    fun intercept() {
+      logs += "intercept2"
+    }
+  }
+
+  companion object {
+    private val logs = mutableListOf<String>()
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -28,6 +28,8 @@ import app.cash.paparazzi.agent.AgentTestRule
 import app.cash.paparazzi.agent.InterceptorRegistrar
 import app.cash.paparazzi.internal.EditModeInterceptor
 import app.cash.paparazzi.internal.ImageUtils
+import app.cash.paparazzi.internal.MatrixMatrixMultiplicationInterceptor
+import app.cash.paparazzi.internal.MatrixVectorMultiplicationInterceptor
 import app.cash.paparazzi.internal.parsers.LayoutPullParser
 import app.cash.paparazzi.internal.PaparazziCallback
 import app.cash.paparazzi.internal.PaparazziLogger
@@ -104,6 +106,7 @@ class Paparazzi(
 
     registerFontLookupInterceptionIfResourceCompatDetected()
     registerViewEditModeInterception()
+    registerMatrixMultiplyInterception()
 
     val outerRule = AgentTestRule()
     return outerRule.apply(statement, description)
@@ -443,6 +446,17 @@ class Paparazzi(
     val viewClass = Class.forName("android.view.View")
     InterceptorRegistrar.addMethodInterceptor(
         viewClass, "isInEditMode", EditModeInterceptor::class.java
+    )
+  }
+
+  private fun registerMatrixMultiplyInterception() {
+    val matrixClass = Class.forName("android.opengl.Matrix")
+    InterceptorRegistrar.addMethodInterceptors(
+      matrixClass,
+      setOf(
+        "multiplyMM" to MatrixMatrixMultiplicationInterceptor::class.java,
+        "multiplyMV" to MatrixVectorMultiplicationInterceptor::class.java
+      )
     )
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/MatrixMatrixMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/MatrixMatrixMultiplicationInterceptor.kt
@@ -1,0 +1,43 @@
+package app.cash.paparazzi.internal
+
+// Sampled from https://cs.android.com/android/platform/superproject/+/master:external/robolectric-shadows/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java;l=10-67
+object MatrixMatrixMultiplicationInterceptor {
+  @Suppress("unused")
+  @JvmStatic
+  fun intercept(
+    result: FloatArray,
+    resultOffset: Int,
+    lhs: FloatArray,
+    lhsOffset: Int,
+    rhs: FloatArray,
+    rhsOffset: Int
+  ) {
+    require(resultOffset + 16 <= result.size) { "resultOffset + 16 > result.length" }
+    require(lhsOffset + 16 <= lhs.size) { "lhsOffset + 16 > lhs.length" }
+    require(rhsOffset + 16 <= rhs.size) { "rhsOffset + 16 > rhs.length" }
+    for (i in 0..3) {
+      val rhs_i0 = rhs[I(i, 0, rhsOffset)]
+      var ri0 = lhs[I(0, 0, lhsOffset)] * rhs_i0
+      var ri1 = lhs[I(0, 1, lhsOffset)] * rhs_i0
+      var ri2 = lhs[I(0, 2, lhsOffset)] * rhs_i0
+      var ri3 = lhs[I(0, 3, lhsOffset)] * rhs_i0
+      for (j in 1..3) {
+        val rhs_ij = rhs[I(i, j, rhsOffset)]
+        ri0 += lhs[I(j, 0, lhsOffset)] * rhs_ij
+        ri1 += lhs[I(j, 1, lhsOffset)] * rhs_ij
+        ri2 += lhs[I(j, 2, lhsOffset)] * rhs_ij
+        ri3 += lhs[I(j, 3, lhsOffset)] * rhs_ij
+      }
+      result[I(i, 0, resultOffset)] = ri0
+      result[I(i, 1, resultOffset)] = ri1
+      result[I(i, 2, resultOffset)] = ri2
+      result[I(i, 3, resultOffset)] = ri3
+    }
+  }
+
+  @Suppress("FunctionName")
+  private fun I(i: Int, j: Int, offset: Int): Int {
+    // #define I(_i, _j) ((_j)+ 4*(_i))
+    return offset + j + 4 * i
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/MatrixVectorMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/MatrixVectorMultiplicationInterceptor.kt
@@ -1,0 +1,37 @@
+package app.cash.paparazzi.internal
+
+// Sampled from https://cs.android.com/android/platform/superproject/+/master:external/robolectric-shadows/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java;l=69-121
+object MatrixVectorMultiplicationInterceptor {
+  @Suppress("unused")
+  @JvmStatic
+  fun intercept(
+    resultVec: FloatArray,
+    resultVecOffset: Int,
+    lhsMat: FloatArray,
+    lhsMatOffset: Int,
+    rhsVec: FloatArray,
+    rhsVecOffset: Int
+  ) {
+    require(resultVecOffset + 4 <= resultVec.size) { "resultOffset + 4 > result.length" }
+    require(lhsMatOffset + 16 <= lhsMat.size) { "lhsOffset + 16 > lhs.length" }
+    require(rhsVecOffset + 4 <= rhsVec.size) { "rhsOffset + 4 > rhs.length" }
+    val x = rhsVec[rhsVecOffset + 0]
+    val y = rhsVec[rhsVecOffset + 1]
+    val z = rhsVec[rhsVecOffset + 2]
+    val w = rhsVec[rhsVecOffset + 3]
+    resultVec[resultVecOffset + 0] =
+      lhsMat[I(0, 0, lhsMatOffset)] * x + lhsMat[I(1, 0, lhsMatOffset)] * y + lhsMat[I(2, 0, lhsMatOffset)] * z + lhsMat[I(3, 0, lhsMatOffset)] * w
+    resultVec[resultVecOffset + 1] =
+      lhsMat[I(0, 1, lhsMatOffset)] * x + lhsMat[I(1, 1, lhsMatOffset)] * y + lhsMat[I(2, 1, lhsMatOffset)] * z + lhsMat[I(3, 1, lhsMatOffset)] * w
+    resultVec[resultVecOffset + 2] =
+      lhsMat[I(0, 2, lhsMatOffset)] * x + lhsMat[I(1, 2, lhsMatOffset)] * y + lhsMat[I(2, 2, lhsMatOffset)] * z + lhsMat[I(3, 2, lhsMatOffset)] * w
+    resultVec[resultVecOffset + 3] =
+      lhsMat[I(0, 3, lhsMatOffset)] * x + lhsMat[I(1, 3, lhsMatOffset)] * y + lhsMat[I(2, 3, lhsMatOffset)] * z + lhsMat[I(3, 3, lhsMatOffset)] * w
+  }
+
+  @Suppress("FunctionName")
+  private fun I(i: Int, j: Int, offset: Int): Int {
+    // #define I(_i, _j) ((_j)+ 4*(_i))
+    return offset + j + 4 * i
+  }
+}


### PR DESCRIPTION
Trying the native layoutlib in internal CashApp paparazzi tests highlighted that some matrix operations are still not handled by the native Android runtime, so this PR implements them using method interceptors.

Before/After
<img width="391" alt="Screen Shot 2021-09-05 at 9 16 58 PM" src="https://user-images.githubusercontent.com/1868149/132168646-6fbfc24c-e5d3-4b0b-9bba-a4a5dba03c07.png"><img width="405" alt="Screen Shot 2021-09-05 at 9 17 05 PM" src="https://user-images.githubusercontent.com/1868149/132168648-fff21ae9-fbba-477b-8f75-0105476b77be.png">
