### PR TITLE
Add support for fontScale in DeviceConfig

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
@@ -68,6 +68,7 @@ data class DeviceConfig(
   val orientation: ScreenOrientation = ScreenOrientation.PORTRAIT,
   val nightMode: NightMode = NOTNIGHT,
   val density: Density = Density.XHIGH,
+  val fontScale: Float = 1f,
   val ratio: ScreenRatio = ScreenRatio.NOTLONG,
   val size: ScreenSize = ScreenSize.NORMAL,
   val keyboard: Keyboard = Keyboard.NOKEY,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/SessionParamsBuilder.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/SessionParamsBuilder.kt
@@ -93,6 +93,7 @@ internal data class SessionParamsBuilder(
         layoutPullParser, renderingMode, projectKey /* for caching */,
         deviceConfig.hardwareConfig, resourceResolver, layoutlibCallback, minSdk, targetSdk, logger
     )
+    result.fontScale = deviceConfig.fontScale
 
     for ((key, value) in flags) {
       result.setFlag(key as Key<Any>, value)


### PR DESCRIPTION
This enables testing accessibility font sizes without having to
manually mutate the context with a test helper function.

---

Note: This was unblocked by the layoutlib bump, as the version that was being used before ignored the `fontScale` property on `SessionParams`.