### PR TITLE
Fix one more configuration cache warning

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -118,10 +118,10 @@ class PaparazziPlugin : Plugin<Project> {
       recordTaskProvider.configure { it.dependsOn(testTaskProvider) }
       verifyTaskProvider.configure { it.dependsOn(testTaskProvider) }
 
-      testTaskProvider.configure {
-        it.doLast {
+      testTaskProvider.configure { test ->
+        test.doLast {
           val uri = reportOutputDir.get().asFile.toPath().resolve("index.html").toUri()
-          project.logger.log(LIFECYCLE, "See the Paparazzi report at: $uri")
+          test.logger.log(LIFECYCLE, "See the Paparazzi report at: $uri")
         }
       }
     }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -99,6 +99,21 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun configurationCache() {
+    val fixtureRoot = File("src/test/projects/configuration-cache")
+
+    gradleRunner
+      .withArguments(
+        "testDebug",
+        "--configuration-cache",
+        "--configuration-cache-problems=warn",
+        "-Dorg.gradle.unsafe.configuration-cache.max-problems=3",
+        "--stacktrace"
+      )
+      .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
   fun interceptViewEditMode() {
     val fixtureRoot = File("src/test/projects/edit-mode-intercept")
 

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}
+
+android {
+  compileSdkVersion 29
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/src/test/java/app/cash/paparazzi/plugin/test/VerifyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/src/test/java/app/cash/paparazzi/plugin/test/VerifyTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.content.Context
+import android.widget.LinearLayout
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class VerifyTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun verify() {}
+}


### PR DESCRIPTION
Also, add a test which attempts to limit future configuration cache regressions

https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution