### PR TITLE
Suppress plugin task action object literal to lambda inspection

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -116,6 +116,7 @@ class PaparazziPlugin : Plugin<Project> {
 
         val paparazziProperties = project.properties.filterKeys { it.startsWith("app.cash.paparazzi") }
 
+        @Suppress("ObjectLiteralToLambda")
         // why not a lambda?  See: https://docs.gradle.org/7.2/userguide/validation_problems.html#implementation_unknown
         test.doFirst(object : Action<Task> {
           override fun execute(t: Task) {
@@ -130,6 +131,7 @@ class PaparazziPlugin : Plugin<Project> {
       verifyTaskProvider.configure { it.dependsOn(testTaskProvider) }
 
       testTaskProvider.configure { test ->
+        @Suppress("ObjectLiteralToLambda")
         // why not a lambda?  See: https://docs.gradle.org/7.2/userguide/validation_problems.html#implementation_unknown
         test.doLast(object : Action<Task> {
           override fun execute(t: Task) {


### PR DESCRIPTION
Since it's easy to ignore the comment when the IDE is adding squiggly lines