### PR TITLE
Revert "Add support for material components (#267)"

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -615,6 +615,7 @@ class PaparazziPluginTest {
   }
 
   @Test
+  @Ignore
   fun withMaterialComponents() {
     val fixtureRoot = File("src/test/projects/material-components-present")
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -366,22 +366,15 @@ class Paparazzi(
     // See androidx.appcompat.app.AppCompatDelegateImpl#installViewFactory()
     if (layoutInflater.factory == null) {
       layoutInflater.factory2 = object : LayoutInflater.Factory2 {
-        private val appCompatViewInflaterClass =
-          Class.forName("androidx.appcompat.app.AppCompatViewInflater")
-
-        private val viewInflaterClass = try {
-          Class.forName("com.google.android.material.theme.MaterialComponentsViewInflater")
-        } catch (e: ClassNotFoundException) {
-          logger.info("MaterialComponents not found on classpath...")
-          appCompatViewInflaterClass
-        }
-
         override fun onCreateView(
           parent: View?,
           name: String,
           context: Context,
           attrs: AttributeSet
         ): View? {
+          val appCompatViewInflaterClass =
+            Class.forName("androidx.appcompat.app.AppCompatViewInflater")
+
           val createViewMethod = appCompatViewInflaterClass
               .getDeclaredMethod(
                   "createView",
@@ -401,7 +394,7 @@ class Paparazzi(
           val readAppTheme = true
           val wrapContext = true
 
-          val newAppCompatViewInflaterInstance = viewInflaterClass
+          val newAppCompatViewInflaterInstance = appCompatViewInflaterClass
               .getConstructor()
               .newInstance()
 


### PR DESCRIPTION
This partially reverts commit 9634cbf5, leaving the test ignored.

The 1st implementation is a bit aggressive; in a Gradle module depending on the Material Design library, all view tests will expect all views to apply a material theme (or descendant) due to ThemeEnforcement.

Potential future fixes:
- provide a flag in the Paparazzi rule to enforce theme (off by default)
- use method interception or resource lookup overrides for the enforceTheme flag
