### PR TITLE
Revert "Bump default compileSdk to API 30"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
           - 15
 
     steps:
+      - name: (Temp) Remove Platforms 30
+        run: rm -rf $ANDROID_HOME/platforms/android-30
+
       - name: Checkout
         uses: actions/checkout@v2.3.4
 

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -211,4 +211,4 @@ class PaparazziPlugin : Plugin<Project> {
   }
 }
 
-private const val DEFAULT_COMPILE_SDK_VERSION = 30
+private const val DEFAULT_COMPILE_SDK_VERSION = 29

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -507,8 +507,8 @@ class PaparazziPluginTest {
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
-    assertThat(resourceFileContents[2]).isEqualTo("30")
-    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-30/")
+    assertThat(resourceFileContents[2]).isEqualTo("29")
+    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-29/")
   }
 
   @Test
@@ -525,8 +525,8 @@ class PaparazziPluginTest {
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
-    assertThat(resourceFileContents[2]).isEqualTo("29")
-    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-30/")
+    assertThat(resourceFileContents[2]).isEqualTo("27")
+    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-29/")
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
@@ -12,9 +12,9 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
-    targetSdkVersion 29
+    targetSdkVersion 27
   }
 } 

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -76,8 +76,8 @@ def generateTestConfig = tasks.register("generateTestConfig") {
     configFile.withWriter('utf-8') { writer ->
       writer.writeLine("app.cash.paparazzi")
       writer.writeLine(".")
-      writer.writeLine("30")
-      writer.writeLine("platforms/android-30/")
+      writer.writeLine("29")
+      writer.writeLine("platforms/android-29/")
       writer.writeLine(".")
       writer.writeLine(configurations.unzip.singleFile.path)
       writer.writeLine("app.cash.paparazzi")


### PR DESCRIPTION
This reverts commit 6a2c1adb

The layoutlib-native jar on master bundles an API 29 version of Android, despite its API support for 30.  As a result, references to new fields or methods added in API 30 still fail.

Example build failure:
```
com.squareup.cash.investing.screens.stockdetails.InvestmentEntityRecyclerViewTest > stock FAILED
    java.lang.NoSuchFieldError: ACTION_PRESS_AND_HOLD
        at androidx.core.view.accessibility.AccessibilityNodeInfoCompat$AccessibilityActionCompat.<clinit>(AccessibilityNodeInfoCompat.java:576)
        at androidx.viewpager2.widget.ViewPager2$PageAwareAccessibilityProvider.updatePageAccessibilityActions(ViewPager2.java:1513)
        at androidx.viewpager2.widget.ViewPager2$PageAwareAccessibilityProvider$3.onChanged(ViewPager2.java:1362)
        at androidx.viewpager2.widget.ViewPager2$DataSetChangeObserver.onItemRangeInserted(ViewPager2.java:1594)
        at androidx.recyclerview.widget.RecyclerView$AdapterDataObservable.notifyItemRangeInserted(RecyclerView.java:12684)
        at androidx.recyclerview.widget.RecyclerView$Adapter.notifyItemRangeInserted(RecyclerView.java:7722)
        at androidx.recyclerview.widget.AdapterListUpdateCallback.onInserted(AdapterListUpdateCallback.java:42)
        at androidx.recyclerview.widget.AsyncListDiffer.submitList(AsyncListDiffer.java:283)
        at androidx.recyclerview.widget.AsyncListDiffer.submitList(AsyncListDiffer.java:231)
        at androidx.recyclerview.widget.ListAdapter.submitList(ListAdapter.java:128)
        at com.squareup.cash.investing.components.InvestingKeyStatsTileView.setModel(InvestingKeyStatsTileView.kt:105)
```