### PR TITLE
Fix signing key issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ subprojects {
         }
       }
     }
+
+    mavenPublish {
+      releaseSigningEnabled = hasProperty('signingKey')
+    }
   }
 
   tasks.register('emptySourcesJar', Jar) {


### PR DESCRIPTION
* Don't sign when deploying to local maven folder for plugin integration tests
* Point to CI secret for signing key; required for release deploys