### PR TITLE
Add windows default android sdk path to environment class

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -17,6 +17,7 @@ package app.cash.paparazzi
 
 import java.io.File
 import java.nio.file.Paths
+import java.util.Locale
 
 data class Environment(
   val platformDir: String,
@@ -31,7 +32,18 @@ data class Environment(
 @Suppress("unused")
 fun androidHome() = System.getenv("ANDROID_SDK_ROOT")
     ?: System.getenv("ANDROID_HOME")
-    ?: "${System.getProperty("user.home")}/Library/Android/sdk"
+    ?: androidSdkPath()
+
+private fun androidSdkPath(): String {
+    val homeDir = System.getProperty("user.home")
+    val osName = System.getProperty("os.name").lowercase(Locale.US)
+    val sdkPathDir = if (osName.startsWith("windows")) {
+        "\\AppData\\Local\\Android\\Sdk"
+    } else {
+        "/Library/Android/sdk"
+    }
+    return homeDir + sdkPathDir
+}
 
 fun detectEnvironment(): Environment {
   checkInstalledJvm()


### PR DESCRIPTION
I encountered an issue on Windows when running the sample tests:
`java.io.FileNotFoundException: C:\Users\rc\Library\Android\sdk\platforms\android-29\build.prop (The system cannot find the path specified)`

The android SDK path set in the Environment class only works for mac os, so I added a logic to use the default android SDK path on windows to make it work, in case no env. variables are present.