### PR TITLE
Set default renderingMode to NORMAL

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -132,7 +132,7 @@ class Paparazzi(
         .copy(
             layoutPullParser = LayoutPullParser.createFromString(contentRoot),
             deviceConfig = deviceConfig,
-            renderingMode = SessionParams.RenderingMode.V_SCROLL
+            renderingMode = SessionParams.RenderingMode.NORMAL
         )
         .withTheme(theme)
 


### PR DESCRIPTION
This is how pre-layoutlib-4.2 works, 4.2 sets this properly.
A follow-up will make this configurable.