### PR TITLE
Bump default compileSdk to API 30 (Take #2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
           - 15
 
     steps:
-      - name: (Temp) Remove Platforms 30
-        run: rm -rf $ANDROID_HOME/platforms/android-30
-
       - name: Checkout
         uses: actions/checkout@v2.3.4
 

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -203,4 +203,4 @@ class PaparazziPlugin : Plugin<Project> {
   }
 }
 
-private const val DEFAULT_COMPILE_SDK_VERSION = 29
+private const val DEFAULT_COMPILE_SDK_VERSION = 30

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -526,8 +526,8 @@ class PaparazziPluginTest {
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
-    assertThat(resourceFileContents[2]).isEqualTo("29")
-    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-29/")
+    assertThat(resourceFileContents[2]).isEqualTo("30")
+    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-30/")
   }
 
   @Test
@@ -544,8 +544,8 @@ class PaparazziPluginTest {
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
-    assertThat(resourceFileContents[2]).isEqualTo("27")
-    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-29/")
+    assertThat(resourceFileContents[2]).isEqualTo("29")
+    assertThat(resourceFileContents[3]).isEqualTo("platforms/android-30/")
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
@@ -12,9 +12,10 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
-    targetSdkVersion 27
+    //noinspection OldTargetApi
+    targetSdkVersion 29
   }
 } 

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     minSdkVersion 25
     vectorDrawables.useSupportLibrary = true

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -76,8 +76,8 @@ def generateTestConfig = tasks.register("generateTestConfig") {
     configFile.withWriter('utf-8') { writer ->
       writer.writeLine("app.cash.paparazzi")
       writer.writeLine(".")
-      writer.writeLine("29")
-      writer.writeLine("platforms/android-29/")
+      writer.writeLine("30")
+      writer.writeLine("platforms/android-30/")
       writer.writeLine(".")
       writer.writeLine(configurations.unzip.singleFile.path)
     }


### PR DESCRIPTION
Undoes the revert in #276. AFAICT, the layoutlib-native jar on master now bundles an API 30 version of Android.