### PR TITLE
Publish Kotlin version with api to stabilize dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ buildscript {
       android: "com.android.tools.build:gradle:${versions.agp}",
       kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
     ],
+    kotlin: [
+      bom: "org.jetbrains.kotlin:kotlin-bom:${versions.kotlin}",
+    ],
     kotlinx: [
       coroutines: [
         core: 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2',

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -13,6 +13,7 @@ gradlePlugin {
 
 dependencies {
   compileOnly gradleApi()
+  implementation platform(deps.kotlin.bom)
   implementation deps.plugins.kotlin
   implementation deps.plugins.android
 

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   api deps.guava
   api deps.kotlinx.coroutines.core
   api deps.okio
+  api platform(deps.kotlin.bom)
   implementation deps.moshi.core
   implementation deps.moshi.adapters
   kapt deps.moshi.kotlinCodegen

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
@@ -77,7 +77,7 @@ class AccessibilityRenderExtensionTest {
             relativePath = expected.path,
             image = image,
             goldenImage = ImageIO.read(expected),
-            maxPercentDifferent = 0.1, // Default percent used in Paparazzi constructor.
+            maxPercentDifferent = 0.2,
           )
         }
 


### PR DESCRIPTION
Why? Because `api deps.kotlinx.coroutines.core` and `api deps.tools.layoutlib` and `api deps.okio` has conflicting Kotlin versions.

Symptom: every user of Paparazzi will observe this message:
```
> Task :...
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.30/5fd47535cc85f9e24996f939c2de6583991481b0/kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.71/fca74670d8e6906a3241b3cf3732409ca77b2508/kotlin-reflect-1.3.71.jar (version 1.3)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.30/525f5a7fa6d7790a571c07dd24214ed2dda352fe/kotlin-stdlib-jdk7-1.5.30.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.30/d68efdea04955974ac1020f8f66ef8176bfbce1f/kotlin-stdlib-1.5.30.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.30/649ffab7767038323fec0cc41e2d7b0a8f65a378/kotlin-stdlib-common-1.5.30.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
```

The relevant parts from `:dependencies`:
```
+--- app.cash.paparazzi:paparazzi:0.8.0
|    +--- com.android.tools:sdk-common:26.6.4
|    |    +--- com.android.tools:sdklib:26.6.4
|    |    |    +--- com.android.tools:repository:26.6.4
|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71 -> 1.5.30
|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.30
|    |    |    |         |    +--- org.jetbrains:annotations:13.0
|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.30
|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.30
|    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.30 (*)
|    |    +--- com.android.tools.analytics-library:shared:26.6.4
|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71 -> 1.5.30 (*)
|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71 -> 1.5.30 (*)
|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.3.71 <--------------------------------- offender
|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.30 (*)
|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2
|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.2
|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.30 (*) <--------------------------------- offender
|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.30
|    +--- com.squareup.okio:okio:3.0.0-alpha.10
|    |    \--- com.squareup.okio:okio-jvm:3.0.0-alpha.10
|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.30 (*) <--------------------------------- offender
|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.30
```

Even Paparazzi's own build has this problem:
```
> Task :paparazzi:kaptGenerateStubsKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/ff5d99aecd328872494e8921b72bf6e3af97af3e/kotlin-stdlib-jdk8-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.71/fca74670d8e6906a3241b3cf3732409ca77b2508/kotlin-reflect-1.3.71.jar (version 1.3)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/77e0f2568912e45d26c31fd417a332458508acdf/kotlin-stdlib-jdk7-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.31/6628d61d0f5603568e72d2d5915d2c034b4f1c55/kotlin-stdlib-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.31/43331609c7de811fed085e0dfd150874b157c32/kotlin-stdlib-common-1.5.31.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath

> Task :paparazzi-gradle-plugin:compileKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    P:/caches/gradle/wrapper/dists/gradle-7.2-all/260hg96vuh6ex27h9vo47iv4d/gradle-7.2/lib/kotlin-stdlib-1.5.21.jar (version 1.5)
    P:/caches/gradle/wrapper/dists/gradle-7.2-all/260hg96vuh6ex27h9vo47iv4d/gradle-7.2/lib/kotlin-stdlib-common-1.5.21.jar (version 1.5)
    P:/caches/gradle/wrapper/dists/gradle-7.2-all/260hg96vuh6ex27h9vo47iv4d/gradle-7.2/lib/kotlin-stdlib-jdk7-1.5.21.jar (version 1.5)
    P:/caches/gradle/wrapper/dists/gradle-7.2-all/260hg96vuh6ex27h9vo47iv4d/gradle-7.2/lib/kotlin-stdlib-jdk8-1.5.21.jar (version 1.5)
    P:/caches/gradle/wrapper/dists/gradle-7.2-all/260hg96vuh6ex27h9vo47iv4d/gradle-7.2/lib/kotlin-reflect-1.5.21.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/ff5d99aecd328872494e8921b72bf6e3af97af3e/kotlin-stdlib-jdk8-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/77e0f2568912e45d26c31fd417a332458508acdf/kotlin-stdlib-jdk7-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.31/63db9d66c3d20f7b8f66196e7ba86969daae8b8a/kotlin-reflect-1.4.31.jar (version 1.4)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.31/6628d61d0f5603568e72d2d5915d2c034b4f1c55/kotlin-stdlib-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.31/43331609c7de811fed085e0dfd150874b157c32/kotlin-stdlib-common-1.5.31.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath

> Task :paparazzi:compileKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/ff5d99aecd328872494e8921b72bf6e3af97af3e/kotlin-stdlib-jdk8-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.71/fca74670d8e6906a3241b3cf3732409ca77b2508/kotlin-reflect-1.3.71.jar (version 1.3)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/77e0f2568912e45d26c31fd417a332458508acdf/kotlin-stdlib-jdk7-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.31/6628d61d0f5603568e72d2d5915d2c034b4f1c55/kotlin-stdlib-1.5.31.jar (version 1.5)
    P:/caches/gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.31/43331609c7de811fed085e0dfd150874b157c32/kotlin-stdlib-common-1.5.31.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
```
[after.txt](https://github.com/cashapp/paparazzi/files/7492086/after.txt)
[before.txt](https://github.com/cashapp/paparazzi/files/7492087/before.txt)

