### PR TITLE
Add warning about limits of LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ android.jetifier.ignorelist=android-base-common,common
 
 Git LFS
 --------
-It is recommended you use [Git LFS][lfs] to store your snapshots.  Here's a template to get started.
+It is recommended you use [Git LFS][lfs] to store your snapshots. Here's a template to get started.
+_Beware that on GitHub there are [limitations on size and bandwidth][lfs-limit] and using LFS may incur [additional cost][lfs-cost]._
 
 #### **`.gitattributes`**
 ```bash
@@ -212,3 +213,5 @@ limitations under the License.
  [sample]: https://github.com/cashapp/paparazzi/tree/master/sample
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/app/cash/paparazzi/
  [lfs]: https://git-lfs.github.com/
+ [lfs-limit]: https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
+ [lfs-cost]: https://docs.github.com/en/billing/managing-billing-for-git-large-file-storage/about-billing-for-git-large-file-storage

--- a/README.md
+++ b/README.md
@@ -15,74 +15,6 @@ exclude bundled Android dependencies.
 android.jetifier.ignorelist=android-base-common,common
 ```
 
-Git LFS
---------
-It is recommended you use [Git LFS][lfs] to store your snapshots. Here's a template to get started.
-_Beware that on GitHub there are [limitations on size and bandwidth][lfs-limit] and using LFS may incur [additional cost][lfs-cost]._
-
-#### **`.gitattributes`**
-```bash
-**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text
-```
-
-#### **`.hooks/pre-receive`**
-```bash
-# compares files that match .gitattributes filter to those actually tracked by git-lfs
-diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
-
-ret=$?
-if [[ $ret -ne 0 ]]; then
-  echo >&2 "This remote has detected files committed without using Git LFS. Run 'brew install git-lfs && git lfs install' to install it and re-commit your files.";
-  exit 1;
-fi
-```
-
-#### **`.hooks/post-checkout`**
-```bash
-# Call the git-lfs filter (except in CI)
-if [[ not CI ]]; then
-  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
-  git lfs post-checkout "$@"
-fi
-```
-
-#### **`.hooks/post-commit`**
-```bash
-# Call the git-lfs filter (except in CI)
-if [[ not CI ]]; then
-  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
-  git lfs post-commit "$@"
-fi
-```
-
-#### **`.hooks/post-merge`**
-```bash
-# Call the git-lfs filter (except in CI)
-if [[ not CI ]]; then
-  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
-  git lfs post-merge "$@"
-fi
-```
-
-#### **`.hooks/pre-push`**
-```bash
-# Call the git-lfs filter (except in CI)
-if [[ not CI ]]; then
-  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
-  git lfs pre-push "$@"
-fi
-```
-
-#### **`your CI script`**
-```bash
-  if [[ is running snapshot tests ]]; then
-    # fail fast if files not checked in using git lfs
-    "$REPO_DIR"/.hooks/pre-receive
-    git lfs install --local
-    git lfs pull
-  fi
-```
-
 Releases
 --------
 
@@ -188,6 +120,74 @@ android {
 ```
 
 -------- 
+
+Git LFS
+--------
+It is recommended you use [Git LFS][lfs] to store your snapshots. Here's a template to get started.
+_Beware that on GitHub there are [limitations on size and bandwidth][lfs-limit] and using LFS may incur [additional cost][lfs-cost]._
+
+#### **`.gitattributes`**
+```bash
+**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text
+```
+
+#### **`.hooks/pre-receive`**
+```bash
+# compares files that match .gitattributes filter to those actually tracked by git-lfs
+diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
+
+ret=$?
+if [[ $ret -ne 0 ]]; then
+  echo >&2 "This remote has detected files committed without using Git LFS. Run 'brew install git-lfs && git lfs install' to install it and re-commit your files.";
+  exit 1;
+fi
+```
+
+#### **`.hooks/post-checkout`**
+```bash
+# Call the git-lfs filter (except in CI)
+if [[ not CI ]]; then
+  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
+  git lfs post-checkout "$@"
+fi
+```
+
+#### **`.hooks/post-commit`**
+```bash
+# Call the git-lfs filter (except in CI)
+if [[ not CI ]]; then
+  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
+  git lfs post-commit "$@"
+fi
+```
+
+#### **`.hooks/post-merge`**
+```bash
+# Call the git-lfs filter (except in CI)
+if [[ not CI ]]; then
+  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
+  git lfs post-merge "$@"
+fi
+```
+
+#### **`.hooks/pre-push`**
+```bash
+# Call the git-lfs filter (except in CI)
+if [[ not CI ]]; then
+  command -v git-lfs >/dev/null 2>&1 || { echo >&2 "This repository is configured for Git LFS but 'git-lfs' was not found on your path. Run 'brew install git-lfs && git lfs install' to install it."; exit 2; }
+  git lfs pre-push "$@"
+fi
+```
+
+#### **`your CI script`**
+```bash
+  if [[ is running snapshot tests ]]; then
+    # fail fast if files not checked in using git lfs
+    "$REPO_DIR"/.hooks/pre-receive
+    git lfs install --local
+    git lfs pull
+  fi
+```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ android {
 
 Git LFS
 --------
-It is recommended you use [Git LFS][lfs] to store your snapshots. Here's a template to get started.
-_Beware that on GitHub there are [limitations on size and bandwidth][lfs-limit] and using LFS may incur [additional cost][lfs-cost]._
+It is recommended you use a [Git LFS][lfs] server [implementation][lfs-impl] to store your snapshots. Here's a template to get started.
 
 #### **`.gitattributes`**
 ```bash
@@ -213,5 +212,5 @@ limitations under the License.
  [sample]: https://github.com/cashapp/paparazzi/tree/master/sample
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/app/cash/paparazzi/
  [lfs]: https://git-lfs.github.com/
- [lfs-limit]: https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
- [lfs-cost]: https://docs.github.com/en/billing/managing-billing-for-git-large-file-storage/about-billing-for-git-large-file-storage
+ [lfs-impl]: https://github.com/git-lfs/git-lfs/wiki/Implementations
+ 


### PR DESCRIPTION
It wasn't apparent from https://git-lfs.github.com/, only realized this after I got mail.
![image](https://user-images.githubusercontent.com/2906988/140807524-956d503a-2f90-4ad8-b3a9-896410faeedc.png)

Essentially if one has 100 MBs of screenshots, one can do only 10 GitHub action CI builds with verifyPaparazzi.