### PR TITLE
Reset AnimationHandler singleton after snapshot

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paparazzi
 
+import android.animation.AnimationHandler
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
@@ -261,6 +262,7 @@ class Paparazzi(
         }
       } finally {
         viewGroup.removeView(view)
+        AnimationHandler.sAnimatorHandler.set(null)
       }
     }
   }

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paparazzi
 
+import android.animation.AnimationHandler
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
@@ -24,6 +25,7 @@ import android.view.Choreographer
 import android.view.Choreographer.CALLBACK_ANIMATION
 import android.view.View
 import android.view.animation.LinearInterpolator
+import android.widget.Button
 import com.android.internal.lang.System_Delegate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Ignore
@@ -48,6 +50,17 @@ class PaparazziTest {
     paparazzi.snapshot(view)
 
     assertThat(log).containsExactly("onDraw time=0")
+  }
+
+  @Test
+  fun resetsAnimationHandler() {
+    assertThat(AnimationHandler.sAnimatorHandler.get()).isNull()
+
+    // Why Button?  Because it sets a StateListAnimator on window attach
+    // See https://github.com/cashapp/paparazzi/pull/319
+    paparazzi.snapshot(Button(paparazzi.context))
+
+    assertThat(AnimationHandler.sAnimatorHandler.get()).isNull()
   }
 
   @Test


### PR DESCRIPTION
When testing Windows CI builds, this bug mysteriously arose due to the natural platform-invocation ordering for AccessibilityRenderExtensionTest.test and PaparazziTest.animationEvents.  Both tests require and create a AnimationHandler singleton. Whichever test creates that singleton first, leaks it, and prevents animation update callbacks from being enqueued in subsequent tests.

As a result, it turns out that on Windows, AccessibilityRenderExtensionTest.test ran first, created the AnimationHandler singleton due to the inclusion of a Button in the snapshotted view hierarchy, then prevented PaparazziTest.animationEvents from receiving any animation updates after the first frame.