### PR TITLE
Log missing AppCompat or ResourceCompat in verbose mode

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -388,7 +388,7 @@ class Paparazzi(
 
       appCompatDelegateClass = Class.forName("androidx.appcompat.app.AppCompatDelegate")
     } catch (e: ClassNotFoundException) {
-      logger.info("AppCompat not found on classpath, exiting...")
+      logger.verbose("AppCompat not found on classpath")
       return
     }
 
@@ -464,7 +464,7 @@ class Paparazzi(
           resourcesCompatClass, "getFont", ResourcesInterceptor::class.java
       )
     } catch (e: ClassNotFoundException) {
-      logger.info("ResourceCompat not found on classpath...")
+      logger.verbose("ResourceCompat not found on classpath")
     }
   }
 


### PR DESCRIPTION
When logged as info(), the message displays in red like an error and, in general, pollutes test run output.