### PR TITLE
Don't reset boot time to current time on every frame

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -238,6 +238,7 @@ class Paparazzi(
     val frameHandler = snapshotHandler.newFrameHandler(snapshot, frameCount, fps)
     frameHandler.use {
       val viewGroup = bridgeRenderSession.rootViews[0].viewObject as ViewGroup
+      System_Delegate.setBootTimeNanos(0L)
       try {
         withTime(0L) {
           // Initialize the choreographer at time=0.
@@ -272,7 +273,6 @@ class Paparazzi(
     val frameNanos = TIME_OFFSET_NANOS + timeNanos
 
     // Execute the block at the requested time.
-    System_Delegate.setBootTimeNanos(frameNanos)
     System_Delegate.setNanosTime(frameNanos)
 
     try {


### PR DESCRIPTION
Not sure how this worked before, but choreographer callbacks trigged based on elapsed time