### PR TITLE
Add mavenLocalize task to uncomment mavenLocal() in all projects for development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,3 +164,21 @@ tasks.register("clean", Delete).configure {
 tasks.named("wrapper").configure {
   distributionType = Wrapper.DistributionType.ALL
 }
+
+allprojects { project ->
+  tasks.register("mavenLocalize").configure { task ->
+    def projectRootDir = project.projectDir
+    task.doFirst {
+      projectRootDir.eachFileRecurse(groovy.io.FileType.FILES) { file ->
+        if (file.name != 'build.gradle') {
+          return
+        }
+        def text = file.text
+        file.withWriter { w ->
+          // Intentional concatenation to prevent self-replacement
+          w << text.replace("//" + "mavenLocal()", "mavenLocal()")
+        }
+      }
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,10 @@ subprojects {
   }
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete).configure {
   delete rootProject.buildDir
 }
 
-tasks.wrapper {
+tasks.named("wrapper").configure {
   distributionType = Wrapper.DistributionType.ALL
 }

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
@@ -8,6 +8,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
@@ -8,6 +8,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
@@ -8,6 +8,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -9,6 +9,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
+  //mavenLocal()
   google()
 }
 


### PR DESCRIPTION
This is handy/useful when testing new versions of dependencies, e.g., a new version of layoutlib.

Also,

- Opportunistically fix some tasks to avoid unnecessary creation and configuration
- Add commented mavenLocal to all Testkit projects to simplify implementation of mavenLocalize