### PR TITLE
Don't require Android plugin to be declared before Paparazzi plugin

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -43,10 +43,16 @@ import java.util.Locale
 class PaparazziPlugin : Plugin<Project> {
   @OptIn(ExperimentalStdlibApi::class)
   override fun apply(project: Project) {
-    require(project.plugins.hasPlugin("com.android.library")) {
-      "The Android Gradle library plugin must be applied before the Paparazzi plugin."
+    project.afterEvaluate {
+      require(project.plugins.hasPlugin("com.android.library")) {
+        "The Android Gradle library plugin must be applied for Paparazzi to be configured."
+      }
     }
 
+    project.plugins.withId("com.android.library") { setupPaparazzi(project) }
+  }
+
+  private fun setupPaparazzi(project: Project) {
     val unzipConfiguration = project.setupPlatformDataTransform()
 
     // Create anchor tasks for all variants.

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -31,8 +31,19 @@ class PaparazziPluginTest {
 
     assertThat(result.task(":preparePaparazziDebugResources")).isNull()
     assertThat(result.output).contains(
-        "The Android Gradle library plugin must be applied before the Paparazzi plugin."
+        "The Android Gradle library plugin must be applied for Paparazzi to be configured."
     )
+  }
+
+  @Test
+  fun declareAndroidPluginAfter() {
+    val fixtureRoot = File("src/test/projects/declare-android-plugin-after")
+
+    val result = gradleRunner
+        .withArguments("preparePaparazziDebugResources", "--stacktrace")
+        .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'app.cash.paparazzi'
+  id 'com.android.library' // intentionally declared after paparazzi plugin
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}
+
+android {
+  compileSdkVersion 30
+  defaultConfig {
+    minSdkVersion 25
+  }
+}


### PR DESCRIPTION
Fixes #297.  Closes #301.