### PR TITLE
Update RELEASING steps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ Releasing
  2. Update the `CHANGELOG.md` for the impending release.
  3. Update the `README.md` with the new version.
  4. `git commit -am "Prepare version X.Y.Z."` (where X.Y.Z is the new version)
- 5. `./gradlew clean publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publish`
+ 5. `./gradlew clean publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository --no-parallel`
  6. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
  7. `git tag -a X.Y.Z -m "X.Y.Z"` (where X.Y.Z is the new version)
  8. Update the `gradle.properties` to the next SNAPSHOT version.


### PR DESCRIPTION
Now that there's an "internal" repository declared in build.gradle, we need to explicitly define to which repository we wish to publish the plugin marker.  Also, use --no-parallel to force a single deploy bundle to Maven Central.