### PR TITLE
Download mac arm artifact if on M1 machines

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -186,7 +186,10 @@ class PaparazziPlugin : Plugin<Project> {
 
     val operatingSystem = OperatingSystem.current()
     val nativeLibraryArtifactId = when {
-      operatingSystem.isMacOsX -> "macosx"
+      operatingSystem.isMacOsX -> {
+        val osArch = System.getProperty("os.arch").lowercase(Locale.US)
+        if (osArch.startsWith("x86")) "macosx" else "macarm"
+      }
       operatingSystem.isWindows -> "win"
       else -> "linux"
     }


### PR DESCRIPTION
Missed in this PR: https://github.com/cashapp/paparazzi/commit/35c94d6cc3be2b1c45580e68151c3b6bbcb69f3b
The details here: https://github.com/cashapp/paparazzi/commit/1875021258af61ba9d1fc03d92854d5dd4e9ee19#diff-eff572a5ae25fee15c83b5dc2b0ed26a5970f0bd44b392511546959bd4b1cfeb
are only to ensure tests pass in the Paparazzi module.

Oops!