### PR TITLE
Use BuildList for resourcePackageNames to remove hard coded separator

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -66,15 +66,19 @@ abstract class PrepareResourcesTask : DefaultTask() {
   private val projectDirectory = project.layout.projectDirectory
 
   @TaskAction
+  @OptIn(ExperimentalStdlibApi::class)
   fun writeResourcesFile() {
     val out = paparazziResources.get().asFile
     out.delete()
 
     val mainPackage = packageName.get()
     val resourcePackageNames = if (nonTransitiveRClassEnabled.get()) {
-      "$mainPackage," + artifactFiles.files.joinToString(",") { file ->
-        file.useLines { lines -> lines.first() }
-      }
+      buildList {
+        add(mainPackage)
+        addAll(artifactFiles.files.map { file ->
+          file.useLines { lines -> lines.first() }
+        })
+      }.joinToString(",")
     } else {
       mainPackage
     }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -75,9 +75,9 @@ abstract class PrepareResourcesTask : DefaultTask() {
     val resourcePackageNames = if (nonTransitiveRClassEnabled.get()) {
       buildList {
         add(mainPackage)
-        addAll(artifactFiles.files.map { file ->
-          file.useLines { lines -> lines.first() }
-        })
+        artifactFiles.files.map { file ->
+          add(file.useLines { lines -> lines.first() })
+        }
       }.joinToString(",")
     } else {
       mainPackage

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -791,6 +791,17 @@ class PaparazziPluginTest {
     assertThat(snapshotImage).isSimilarTo(goldenImage).withDefaultThreshold()
   }
 
+  @Test
+  fun nonTransitiveResourcesNoDeps() {
+    val fixtureRoot = File("src/test/projects/non-transitive-resources-no-deps")
+
+    val result = gradleRunner
+      .withArguments("testDebug")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.output).doesNotContain("java.lang.ClassNotFoundException")
+  }
+
   private fun GradleRunner.runFixture(
     projectRoot: File,
     moduleRoot: File = projectRoot,

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 30
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/main/res/drawable/arrow_up.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/main/res/drawable/arrow_up.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="16dp"
+    android:tint="#000000"
+    android:viewportHeight="16"
+    android:viewportWidth="16"
+    android:width="16dp">
+
+  <path
+      android:fillColor="#333333"
+      android:pathData="M2.11612 6.61612C1.62796 7.10427 1.62796 7.89573 2.11612 8.38388C2.60427 8.87204 3.39573 8.87204 3.88388 8.38388L2.11612 6.61612ZM8 2.5L8.88388 1.61612C8.39573 1.12796 7.60427 1.12796 7.11612 1.61612L8 2.5ZM12.1161 8.38388C12.6043 8.87204 13.3957 8.87204 13.8839 8.38388C14.372 7.89573 14.372 7.10427 13.8839 6.61612L12.1161 8.38388ZM3.88388 8.38388L8.88388 3.38388L7.11612 1.61612L2.11612 6.61612L3.88388 8.38388ZM7.11612 3.38388L12.1161 8.38388L13.8839 6.61612L8.88388 1.61612L7.11612 3.38388Z" />
+
+  <path
+      android:pathData="M8 2.5V13.5"
+      android:strokeColor="#333333"
+      android:strokeLineCap="round"
+      android:strokeWidth="2.5" />
+</vector>

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/main/res/layout/launch.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/main/res/layout/launch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/launchBackground"
+    android:gravity="center"
+    android:orientation="vertical"
+    >
+
+  <ImageView
+      android:layout_width="200dp"
+      android:layout_height="200dp"
+      app:srcCompat="@drawable/arrow_up"
+      />
+
+</LinearLayout>

--- a/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/test/java/app/cash/paparazzi/plugin/test/LaunchViewTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/src/test/java/app/cash/paparazzi/plugin/test/LaunchViewTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.widget.LinearLayout
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class LaunchViewTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun testViews() {
+    val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
+    paparazzi.snapshot(launch, "launch")
+  }
+}


### PR DESCRIPTION
Resolves #346 