### PR TITLE
Require view id to generate color palette for accessibility render extension

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
@@ -31,9 +31,9 @@ import app.cash.paparazzi.accessibility.RenderSettings.DEFAULT_TEXT_SIZE
 import app.cash.paparazzi.accessibility.RenderSettings.getColor
 import app.cash.paparazzi.accessibility.RenderSettings.toColorInt
 import app.cash.paparazzi.accessibility.RenderSettings.withAlpha
+import java.util.concurrent.atomic.AtomicInteger
 
 class AccessibilityRenderExtension : RenderExtension {
-
   override fun renderView(
     contentView: View
   ): View {
@@ -80,6 +80,8 @@ class AccessibilityRenderExtension : RenderExtension {
           1f
         )
       )
+    }.also {
+      RenderSettings.resetGeneratedId()
     }
   }
 


### PR DESCRIPTION
Makes tests more deterministic by generating view ids for views to generate colors for accessibility.

Using `System.identityHashCode(view)` ended up using memory register location which is not deterministic.