### PR TITLE
Fix deprecation warnings in sample

### DIFF
--- a/sample/src/test/java/app/cash/paparazzi/sample/KeypadViewTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/KeypadViewTest.kt
@@ -43,13 +43,13 @@ class KeypadViewTest {
     paparazzi.snapshot(keypad, "five bucks")
 
     keypad.setBackgroundResource(R.color.keypadDarkGrey)
-    val darkGrey = paparazzi.resources.getColor(R.color.keypadDarkGrey)
+    val darkGrey = paparazzi.context.getColor(R.color.keypadDarkGrey)
     keypad.setBackgroundColor(darkGrey)
     amount.text = "$1.00"
     paparazzi.snapshot(keypad, "grey")
 
     keypad.setBackgroundResource(R.color.keypadDarkGrey)
-    keypad.setBackgroundColor(paparazzi.resources.getColor(R.color.bolt))
+    keypad.setBackgroundColor(paparazzi.context.getColor(R.color.bolt))
     amount.setTextColor(darkGrey)
     amount123.setTextColor(darkGrey)
     amount456.setTextColor(darkGrey)


### PR DESCRIPTION
```
w: P:\projects\contrib\github-paparazzi\sample\src\test\java\app\cash\paparazzi\sample\KeypadViewTest.kt: (46, 40): 'getColor(Int): Int' is deprecated. Deprecated in Java
w: P:\projects\contrib\github-paparazzi\sample\src\test\java\app\cash\paparazzi\sample\KeypadViewTest.kt: (52, 51): 'getColor(Int): Int' is deprecated. Deprecated in Java
```

Had the option of `paparazzi.resources.getColor(..., null)` or `paparazzi.context.getColor(...)`, latter looks simpler and more likely used (indirectly via `ContextCompat.getColor(context, ...)`).