### PR TITLE
Reproduce androidx.core bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
   ext.versions = [
     kotlin: '1.5.31',
-    agp: '4.2.2',
+    agp: '7.0.4',
     layoutlib: "2020.3.1-$layoutLibPrebuiltSha", // "should" be similar to versions.agp
     androidTools: '27.1.2', // agp + 23.0.0 = androidTools
     jcodec: '0.2.5',

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,5 +10,6 @@ android {
 }
 
 dependencies {
+  implementation 'androidx.core:core:1.7.0'
   testImplementation deps.testparameterinjector
 }


### PR DESCRIPTION
I have been struggling with a bug concerning `androidx.core:core.1.7.0`. See https://github.com/cashapp/paparazzi/issues/351

I have been able to reproduce in the sample project by bumping the Android gradle plugin. 

