### PR TITLE
Introduce externally-managed RendererScope to share Renderer across test suite

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/RendererScope.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/RendererScope.kt
@@ -1,0 +1,12 @@
+package app.cash.paparazzi
+
+import app.cash.paparazzi.internal.Renderer
+import app.cash.paparazzi.internal.SessionParamsBuilder
+import org.junit.rules.ExternalResource
+
+open class RendererScope : ExternalResource() {
+  internal lateinit var renderer: Renderer
+  internal lateinit var sessionParamsBuilder: SessionParamsBuilder
+  val isInitialized get() = ::renderer.isInitialized
+  override fun after() { renderer.close() }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/ClassRendererScopeTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/ClassRendererScopeTest.kt
@@ -1,0 +1,46 @@
+package app.cash.paparazzi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Verifier
+
+class ClassRendererScopeTest {
+  companion object {
+    var beforeCallCount: Int = 0
+    var afterCallCount: Int = 0
+
+    @get:ClassRule(order = 1)
+    @JvmStatic
+    val verifier = object : Verifier() {
+      override fun verify() {
+        assertThat(beforeCallCount).isEqualTo(1)
+        assertThat(afterCallCount).isEqualTo(1)
+      }
+    }
+
+    @get:ClassRule(order = 2)
+    @JvmStatic
+    val rendererScope = object : RendererScope() {
+      override fun before() {
+        super.before()
+        beforeCallCount++
+      }
+
+      override fun after() {
+        super.after()
+        afterCallCount++
+      }
+    }
+  }
+
+  @get:Rule(order = 3)
+  val paparazzi = Paparazzi(managedRendererScope = rendererScope)
+
+  @Test fun test1() {}
+  @Test fun test2() {}
+  @Test fun test3() {}
+  @Test fun test4() {}
+  @Test fun test5() {}
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/MethodRendererScopeTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/MethodRendererScopeTest.kt
@@ -1,0 +1,45 @@
+package app.cash.paparazzi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Verifier
+
+class MethodRendererScopeTest {
+  companion object {
+    var beforeCallCount: Int = 0
+    var afterCallCount: Int = 0
+
+    @get:ClassRule(order = 1)
+    @JvmStatic
+    val verifier = object : Verifier() {
+      override fun verify() {
+        assertThat(beforeCallCount).isEqualTo(5)
+        assertThat(afterCallCount).isEqualTo(5)
+      }
+    }
+  }
+
+  @get:Rule(order = 2)
+  val rendererScope = object : RendererScope() {
+    override fun before() {
+      super.before()
+      beforeCallCount++
+    }
+
+    override fun after() {
+      super.after()
+      afterCallCount++
+    }
+  }
+
+  @get:Rule(order = 3)
+  val paparazzi = Paparazzi(managedRendererScope = rendererScope)
+
+  @Test fun test1() {}
+  @Test fun test2() {}
+  @Test fun test3() {}
+  @Test fun test4() {}
+  @Test fun test5() {}
+}


### PR DESCRIPTION
Closes #369, #247 

An alternative to #247 which allows for a user-provided scope to manage the Renderer lifecycle across test methods.  Creating and preparing the Renderer (which loads Android framework resources) is expensive and seems to be constant anyway.

While I'm a bit wary of making Paparazzi into a @ClassRule, I'm also not 100% sold on this implementation.  Feedback requested.