### PR TITLE
Update layoutlib versions to include SNAPSHOT suffix

### DIFF
--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -1,7 +1,11 @@
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
+  version = "${versions.layoutlib}-SNAPSHOT"
+} else {
+  version = versions.layoutlib
+}
 
 /**
  * Clone AOSP's prebuilts repo to get a prebuilt layoutlib jar. This big repo that takes a long time to clone!

--- a/libs/native-linux/build.gradle
+++ b/libs/native-linux/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
+  version = "${versions.layoutlib}-SNAPSHOT"
+} else {
+  version = versions.layoutlib
+}
 
 tasks.register('linuxJar', Jar) {
   from(repoDir) {

--- a/libs/native-macarm/build.gradle
+++ b/libs/native-macarm/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
+  version = "${versions.layoutlib}-SNAPSHOT"
+} else {
+  version = versions.layoutlib
+}
 
 tasks.register('macArmJar', Jar) {
   from(repoDir) {

--- a/libs/native-macosx/build.gradle
+++ b/libs/native-macosx/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
+  version = "${versions.layoutlib}-SNAPSHOT"
+} else {
+  version = versions.layoutlib
+}
 
 tasks.register('macJar', Jar) {
   from(repoDir) {

--- a/libs/native-win/build.gradle
+++ b/libs/native-win/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
+  version = "${versions.layoutlib}-SNAPSHOT"
+} else {
+  version = versions.layoutlib
+}
 
 tasks.register('winJar', Jar) {
   from(repoDir) {


### PR DESCRIPTION
Our internal Maven repo enforces that the snapshot repo only contains artifacts with SNAPSHOT versions. It's a bit overly correct, but correct none the same.

This PR tweaks the layoutlib versions to add a `SNAPSHOT` suffix if the main library also has a snapshot suffix.