### PR TITLE
Prepend paths with file:// in error output for ergonomics

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -201,7 +201,7 @@ internal object ImageUtils {
         assertTrue(deleted)
       }
       ImageIO.write(deltaImage, "PNG", output)
-      error += " - see details in " + output.path + "\n"
+      error += " - see details in file://" + output.path + "\n"
       error = saveImageAndAppendMessage(image, error, relativePath)
       println(error)
       fail(error)
@@ -336,7 +336,7 @@ internal object ImageUtils {
       assertTrue(deleted)
     }
     ImageIO.write(image, "PNG", output)
-    initialMessage += "Thumbnail for current rendering stored at " + output.path
+    initialMessage += "Thumbnail for current rendering stored at file://" + output.path
     //        initialMessage += "\nRun the following command to accept the changes:\n";
     //        initialMessage += String.format("mv %1$s %2$s", output.getPath(),
     //                ImageUtils.class.getResource(relativePath).getPath());


### PR DESCRIPTION
This allows clicking on the path URLs in Android Studio:

Before

![image](https://user-images.githubusercontent.com/1186186/156602122-5c0ad88e-b275-4fb4-a565-ac6b563bd533.png)

After:

<img width="1475" alt="Screen Shot 2022-03-03 at 10 51 36 AM" src="https://user-images.githubusercontent.com/1186186/156602161-295108a1-415c-4d38-888e-84c24cfb32eb.png">

Unfortunately, as you can see, AS trips up on URLs that contain "[]", but that feels like an AS bug that I can report. This should work fine for simple paths.
