### PR TITLE
Use layoutlib SNAPSHOTs part 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,15 +45,6 @@ buildscript {
       annotations: 'androidx.annotation:annotation:1.3.0',
       lifecycleCommon: 'androidx.lifecycle:lifecycle-common:2.4.0',
     ],
-    layoutlib: [
-      native: [
-        jdk11: "app.cash.paparazzi:layoutlib-native-jdk11:${versions.layoutlib}",
-        macArm: "app.cash.paparazzi:layoutlib-native-macarm:${versions.layoutlib}",
-        macOsX: "app.cash.paparazzi:layoutlib-native-macosx:${versions.layoutlib}",
-        windows: "app.cash.paparazzi:layoutlib-native-win:${versions.layoutlib}",
-        linux: "app.cash.paparazzi:layoutlib-native-linux:${versions.layoutlib}",
-      ]
-    ],
     okio: 'com.squareup.okio:okio:3.0.0',
     moshi: [
       core: "com.squareup.moshi:moshi:${versions.moshi}",

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -32,7 +32,14 @@ def generateVersion = tasks.register("pluginVersion") {
   def outputDir = file('src/generated/kotlin')
 
   inputs.property 'version', version
-  inputs.property 'nativeLibVersion', versions.layoutlib
+
+  def layoutLibVersion = versions.layoutlib
+  if (version.endsWith('SNAPSHOT')) {
+    // If we have a SNAPSHOT version, we should use a snapshot layoutlib
+    layoutLibVersion = "${layoutLibVersion}-SNAPSHOT"
+  }
+
+  inputs.property 'nativeLibVersion', layoutLibVersion
   outputs.dir outputDir
 
   doLast {
@@ -41,7 +48,7 @@ def generateVersion = tasks.register("pluginVersion") {
     versionFile.text = """// Generated file. Do not edit!
 package app.cash.paparazzi
 const val VERSION = "${project.version}"
-const val NATIVE_LIB_VERSION = "${project.versions.layoutlib}"
+const val NATIVE_LIB_VERSION = "${layoutLibVersion}"
 """
   }
 }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compileOnly files('libs/lifecycle-runtime-2.4.0.jar')
   compileOnly files('libs/savedstate-1.1.0.jar')
 
-  api deps.layoutlib.native.jdk11
+  api project(':libs:layoutlib')
   api deps.tools.common
   api deps.tools.layoutlib
   api deps.tools.sdkcommon
@@ -54,14 +54,14 @@ dependencies {
   if (osName.startsWith("mac")) {
     def osArch = System.getProperty("os.arch").toLowerCase(Locale.US)
     if (osArch.startsWith("x86")) {
-      unzip deps.layoutlib.native.macOsX
+      unzip project(':libs:native-macosx')
     } else {
-      unzip deps.layoutlib.native.macArm
+      unzip project(':libs:native-macarm')
     }
   } else if (osName.startsWith("windows")) {
-    unzip deps.layoutlib.native.windows
+    unzip project(':libs:native-win')
   } else {
-    unzip deps.layoutlib.native.linux
+    unzip project(':libs:native-linux')
   }
 
   testImplementation deps.assertj


### PR DESCRIPTION
Follow on from #377

I just realised that I didn't update the plugin or library to actually use the SNAPSHOT versions. This PR does that my tweaking the layoutlib version which is dynamically added as a dependency.

I also removed hardcoded FQN references to the layoutlib in :paparazzi. Using `project` dependencies means that it automatically uses the correct layoutlib version, and doesn't require the SNAPSHOTs to already be pre-pushed to Sonatype.