### PR TITLE
Make Renderer static to share across test suite

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -88,8 +88,6 @@ class Paparazzi @JvmOverloads constructor(
   private val THUMBNAIL_SIZE = 1000
 
   private val logger = PaparazziLogger()
-  private lateinit var sessionParamsBuilder: SessionParamsBuilder
-  private lateinit var renderer: Renderer
   private lateinit var renderSession: RenderSessionImpl
   private lateinit var bridgeRenderSession: RenderSession
   private var testName: TestName? = null
@@ -143,8 +141,10 @@ class Paparazzi @JvmOverloads constructor(
 
     testName = description.toTestName()
 
-    renderer = Renderer(environment, layoutlibCallback, logger, maxPercentDifference)
-    sessionParamsBuilder = renderer.prepare()
+    if (!isInitialized) {
+      renderer = Renderer(environment, layoutlibCallback, logger, maxPercentDifference)
+      sessionParamsBuilder = renderer.prepare()
+    }
 
     sessionParamsBuilder = sessionParamsBuilder
         .copy(
@@ -170,11 +170,12 @@ class Paparazzi @JvmOverloads constructor(
 
   fun close() {
     testName = null
-    renderer.close()
     renderSession.release()
     bridgeRenderSession.dispose()
     cleanupThread()
     snapshotHandler.close()
+
+    renderer.dumpDelegates()
   }
 
   fun <V : View> inflate(@LayoutRes layoutId: Int): V = layoutInflater.inflate(layoutId, null) as V
@@ -552,6 +553,11 @@ class Paparazzi @JvmOverloads constructor(
   companion object {
     /** The choreographer doesn't like 0 as a frame time, so start an hour later. */
     internal val TIME_OFFSET_NANOS = TimeUnit.HOURS.toNanos(1L)
+
+    internal lateinit var renderer: Renderer
+    internal val isInitialized get() = ::renderer.isInitialized
+
+    internal lateinit var sessionParamsBuilder: SessionParamsBuilder
 
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -121,6 +121,10 @@ internal class Renderer(
 
     Gc.gc()
 
+    dumpDelegates()
+  }
+
+  fun dumpDelegates() {
     if (System.getProperty(Flags.DEBUG_LINKED_OBJECTS) != null) {
       println("Objects still linked from the DelegateManager:")
       DelegateManager.dump(System.out)


### PR DESCRIPTION
Closes https://github.com/cashapp/paparazzi/issues/369, https://github.com/cashapp/paparazzi/pull/247, https://github.com/cashapp/paparazzi/pull/376

In chatting with @JakeWharton, he convinced me that since the test process should die after a run, we mind as well just make the Renderer static and simplify things.

In the process of debugging this, I noticed that DelegateManager does hold onto delegates and creates seemingly additional delegates between snapshot calls, but that's a different problem.  TODO: profile and show this change doesn't exacerbate that issue.