### PR TITLE
Update default SDK path on Linux

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -59,8 +59,10 @@ private fun androidSdkPath(): String {
   val osName = System.getProperty("os.name").lowercase(Locale.US)
   val sdkPathDir = if (osName.startsWith("windows")) {
     "\\AppData\\Local\\Android\\Sdk"
-  } else {
+  } else if (osName.startsWith("mac")) {
     "/Library/Android/sdk"
+  } else {
+    "/Android/Sdk"
   }
   val homeDir = System.getProperty("user.home")
   return homeDir + sdkPathDir


### PR DESCRIPTION
Updates the default path logic to use `/Android/Sdk` on Linux, mirroring the logic here: https://github.com/cashapp/paparazzi/blob/2543296badfd9297ccf805ea072e5c97d7751651/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt#L109-L114

This fixes #394 