### PR TITLE
Fixes issue causing `HtmlReportWriter` to ignore configured project.buildDir.

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -145,6 +145,7 @@ class PaparazziPlugin : Plugin<Project> {
           override fun execute(t: Task) {
             test.systemProperties["paparazzi.test.record"] = isRecordRun.get()
             test.systemProperties["paparazzi.test.verify"] = isVerifyRun.get()
+            test.systemProperties["paparazzi.test.reportDir"] = reportOutputDir.get()
             test.systemProperties.putAll(paparazziProperties)
           }
         })

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -96,6 +96,7 @@ class PaparazziPlugin : Plugin<Project> {
         task.compileSdkVersion.set(android.compileSdkVersion())
         task.mergeAssetsOutput.set(mergeAssetsOutputDir)
         task.platformDataRoot.set(unzipConfiguration.singleFile)
+        task.reportOutputPath.set(reportOutputDir.map { it.asFile.absolutePath })
         task.paparazziResources.set(project.layout.buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
       }
 
@@ -145,7 +146,6 @@ class PaparazziPlugin : Plugin<Project> {
           override fun execute(t: Task) {
             test.systemProperties["paparazzi.test.record"] = isRecordRun.get()
             test.systemProperties["paparazzi.test.verify"] = isVerifyRun.get()
-            test.systemProperties["paparazzi.test.reportDir"] = reportOutputDir.get()
             test.systemProperties.putAll(paparazziProperties)
           }
         })

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -60,6 +60,9 @@ abstract class PrepareResourcesTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val artifactFiles: ConfigurableFileCollection
 
+  @get:Input
+  abstract val reportOutputPath: Property<String>
+
   @get:OutputFile
   abstract val paparazziResources: RegularFileProperty
 
@@ -100,6 +103,8 @@ abstract class PrepareResourcesTask : DefaultTask() {
         it.write(platformDataRoot.get().asFile.invariantSeparatorsPath)
         it.newLine()
         it.write(resourcePackageNames)
+        it.newLine()
+        it.write(reportOutputPath.get())
         it.newLine()
       }
   }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-custom-buildDir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-custom-buildDir/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+project.buildDir = project.property("paparazzi.test.customBuildDir")
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -21,6 +21,7 @@ import java.util.Locale
 
 data class Environment(
   val platformDir: String,
+  val reportOutputDir: String,
   val appTestDir: String,
   val resDir: String,
   val assetsDir: String,
@@ -45,6 +46,7 @@ fun detectEnvironment(): Environment {
   val androidHome = Paths.get(androidHome())
   return Environment(
       platformDir = androidHome.resolve(configLines[3]).toString(),
+      reportOutputDir = configLines[7],
       appTestDir = appTestDir.toString(),
       resDir = appTestDir.resolve(configLines[1]).toString(),
       assetsDir = appTestDir.resolve(configLines[4]).toString(),

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -59,12 +59,12 @@ import javax.imageio.ImageIO
  */
 class HtmlReportWriter @JvmOverloads constructor(
   private val runName: String = defaultRunName(),
-  private val rootDirectory: File = File(System.getProperty("paparazzi.test.reportDir", "build/reports/paparazzi")),
+  private val reportOutputDirectory: File = File("build/reports/paparazzi"),
   snapshotRootDirectory: File = File("src/test/snapshots")
 ) : SnapshotHandler {
-  private val runsDirectory: File = File(rootDirectory, "runs")
-  private val imagesDirectory: File = File(rootDirectory, "images")
-  private val videosDirectory: File = File(rootDirectory, "videos")
+  private val runsDirectory: File = File(reportOutputDirectory, "runs")
+  private val imagesDirectory: File = File(reportOutputDirectory, "images")
+  private val videosDirectory: File = File(reportOutputDirectory, "videos")
 
   private val goldenImagesDirectory = File(snapshotRootDirectory, "images")
   private val goldenVideosDirectory = File(snapshotRootDirectory, "videos")
@@ -211,7 +211,7 @@ class HtmlReportWriter @JvmOverloads constructor(
       }
     }
 
-    File(rootDirectory, "index.js").writeAtomically {
+    File(reportOutputDirectory, "index.js").writeAtomically {
       writeUtf8("window.all_runs = ")
       PaparazziJson.listOfStringsAdapter.toJson(this, runNames)
       writeUtf8(";")
@@ -251,7 +251,7 @@ class HtmlReportWriter @JvmOverloads constructor(
 
   private fun writeStaticFiles() {
     for (staticFile in listOf("index.html", "paparazzi.js")) {
-      File(rootDirectory, staticFile).writeAtomically {
+      File(reportOutputDirectory, staticFile).writeAtomically {
         writeAll(HtmlReportWriter::class.java.classLoader.getResourceAsStream(staticFile).source())
       }
     }
@@ -275,7 +275,7 @@ class HtmlReportWriter @JvmOverloads constructor(
     tmpFile.renameTo(this)
   }
 
-  private fun File.toJsonPath(): String = relativeTo(rootDirectory).invariantSeparatorsPath
+  private fun File.toJsonPath(): String = relativeTo(reportOutputDirectory).invariantSeparatorsPath
 }
 
 internal fun defaultRunName(): String {

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -59,7 +59,7 @@ import javax.imageio.ImageIO
  */
 class HtmlReportWriter @JvmOverloads constructor(
   private val runName: String = defaultRunName(),
-  private val rootDirectory: File = File("build/reports/paparazzi"),
+  private val rootDirectory: File = File(System.getProperty("paparazzi.test.reportDir", "build/reports/paparazzi")),
   snapshotRootDirectory: File = File("src/test/snapshots")
 ) : SnapshotHandler {
   private val runsDirectory: File = File(rootDirectory, "runs")

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -70,6 +70,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.awt.image.BufferedImage
+import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util.Date
@@ -82,7 +83,7 @@ class Paparazzi @JvmOverloads constructor(
   private val renderingMode: RenderingMode = RenderingMode.NORMAL,
   private val appCompatEnabled: Boolean = true,
   private val maxPercentDifference: Double = 0.1,
-  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
+  private val snapshotHandler: SnapshotHandler = determineHandler(environment, maxPercentDifference),
   private val renderExtensions: Set<RenderExtension> = setOf()
 ) : TestRule {
   private val THUMBNAIL_SIZE = 1000
@@ -556,11 +557,14 @@ class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    private fun determineHandler(
+        environment: Environment,
+        maxPercentDifference: Double
+    ): SnapshotHandler =
       if (isVerifying) {
         SnapshotVerifier(maxPercentDifference)
       } else {
-        HtmlReportWriter()
+        HtmlReportWriter(reportOutputDirectory = File(environment.reportOutputDir))
       }
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/EnvironmentTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/EnvironmentTest.kt
@@ -1,0 +1,66 @@
+package app.cash.paparazzi
+
+import java.io.File
+import java.nio.file.Paths
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class EnvironmentTest {
+  @get:Rule
+  val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private lateinit var resourceFile: File
+  private val androidSdkRoot = androidHome() // Not sure how to fake System.env
+  private val currentDir = "/tmp/testDir"
+  private val relativePlatformPath = "platforms/android-32/"
+  private val relativeResDir = "./build/intermediates/merged_res"
+  private val relativeAssetsDir = "./build/intermediates/merged_assets"
+  private val platformDataDir = "./build/intermediates/paparazzi/platform-32"
+  private val customBuildDir = "/tmp/custom-build-dir/"
+  private val expected = Environment(
+    platformDir = Paths.get(androidSdkRoot).resolve(relativePlatformPath).toString(),
+    reportOutputDir = customBuildDir,
+    appTestDir = currentDir,
+    resDir = "$currentDir/$relativeResDir",
+    assetsDir = "$currentDir/$relativeAssetsDir",
+    packageName = "com.example",
+    compileSdkVersion = 29,
+    platformDataDir = platformDataDir,
+    resourcePackageNames = listOf("com.example", "com.example.feature1", "com.example.feature2"),
+  )
+
+  @Before
+  fun setup() {
+    resourceFile = tempFolder.newFile()
+    resourceFile.bufferedWriter().use {
+      it.write(expected.packageName)
+      it.newLine()
+      it.write(Paths.get(expected.appTestDir).resolve(relativeResDir).toString())
+      it.newLine()
+      it.write(expected.compileSdkVersion.toString())
+      it.newLine()
+      it.write(relativePlatformPath)
+      it.newLine()
+      it.write(Paths.get(expected.appTestDir).resolve(relativeAssetsDir).toString())
+      it.newLine()
+      it.write(platformDataDir)
+      it.newLine()
+      it.write(expected.resourcePackageNames.joinToString(","))
+      it.newLine()
+      it.write(customBuildDir)
+      it.newLine()
+    }
+
+    System.setProperty("paparazzi.test.resources", resourceFile.absolutePath)
+    System.setProperty("user.dir", expected.appTestDir)
+  }
+
+  @Test
+  fun happyPath() {
+    val actual = detectEnvironment()
+    assertThat(actual).isEqualTo(expected)
+  }
+}


### PR DESCRIPTION
We use a customized `project.buildDir` in our project, and while the plugin reads it appropriately to be able to print a string to the console, it didn't pass it to the HtmlReportWriter.