### PR TITLE
Fixes crash when using InputMethodManager to show/hide keyboard.

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -863,6 +863,14 @@ class PaparazziPluginTest {
     assertThat(snapshotImage).isSimilarTo(goldenImage).withDefaultThreshold()
   }
 
+  @Test
+  fun immSoftInputInteraction() {
+    val fixtureRoot = File("src/test/projects/imm-soft-input")
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
   private fun GradleRunner.runFixture(
     projectRoot: File,
     moduleRoot: File = projectRoot,

--- a/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/src/test/java/app/cash/paparazzi/plugin/test/IMMTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/src/test/java/app/cash/paparazzi/plugin/test/IMMTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+import android.widget.FrameLayout
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class IMMTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun test() {
+    paparazzi.snapshot(DummyLayout(paparazzi.context))
+  }
+}
+
+class DummyLayout(context: Context) : FrameLayout(context) {
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    // Fake environments such as snapshot tests may return null here, which we can safely ignore.
+    val inputMethodManager = context.getSystemService(InputMethodManager::class.java)
+    inputMethodManager.hideSoftInputFromWindow(this.windowToken, 0)
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -54,6 +54,8 @@ import app.cash.paparazzi.internal.Renderer
 import app.cash.paparazzi.internal.ResourcesInterceptor
 import app.cash.paparazzi.internal.SessionParamsBuilder
 import app.cash.paparazzi.internal.ChoreographerDelegateInterceptor
+import app.cash.paparazzi.internal.IInputMethodManagerInterceptor
+import app.cash.paparazzi.internal.ServiceManagerInterceptor
 import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.Result
 import com.android.ide.common.rendering.api.Result.Status.ERROR_UNKNOWN
@@ -129,6 +131,8 @@ class Paparazzi @JvmOverloads constructor(
     registerViewEditModeInterception()
     registerMatrixMultiplyInterception()
     registerChoreographerDelegateInterception()
+    registerServiceManagerInterception()
+    registerIInputMethodManagerInterception()
 
     val outerRule = AgentTestRule()
     return outerRule.apply(statement, description)
@@ -504,6 +508,20 @@ class Paparazzi @JvmOverloads constructor(
     } catch (e: ClassNotFoundException) {
       logger.verbose("ResourceCompat not found on classpath")
     }
+  }
+
+  private fun registerServiceManagerInterception() {
+    val serviceManager = Class.forName("android.os.ServiceManager")
+    InterceptorRegistrar.addMethodInterceptor(
+      serviceManager, "getServiceOrThrow", ServiceManagerInterceptor::class.java
+    )
+  }
+
+  private fun registerIInputMethodManagerInterception() {
+    val iimm = Class.forName("com.android.internal.view.IInputMethodManager\$Stub")
+    InterceptorRegistrar.addMethodInterceptor(
+      iimm, "asInterface", IInputMethodManagerInterceptor::class.java
+    )
   }
 
   private fun registerViewEditModeInterception() {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/IInputMethodManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/IInputMethodManagerInterceptor.kt
@@ -1,0 +1,16 @@
+package app.cash.paparazzi.internal
+
+import android.os.IBinder
+import com.android.internal.view.IInputMethodManager
+
+/**
+ * With [ServiceManagerInterceptor] returning null for the service, we must override the logic
+ * in [com.android.internal.view.IInputMethodManager.Stub.asInterface] to return the default
+ * implementation of [IInputMethodManager].
+ */
+object IInputMethodManagerInterceptor {
+  @Suppress("unused")
+  @JvmStatic
+  fun interceptAsInterface(@Suppress("UNUSED_PARAMETER") obj: IBinder?): IInputMethodManager =
+    IInputMethodManager.Default()
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ServiceManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ServiceManagerInterceptor.kt
@@ -1,0 +1,17 @@
+package app.cash.paparazzi.internal
+
+import android.os.IBinder
+
+/**
+ * The ImeTracing class attempts to initialize its [mService field in its constructor](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/util/imetracing/ImeTracing.java;l=60).
+ *
+ * Unfortunately, [layoutlib's version of ServiceManager](https://cs.android.com/android/platform/superproject/+/master:frameworks/layoutlib/bridge/src/android/os/ServiceManager.java;l=37)
+ * throws an exception immediately.
+ *
+ * This interceptor overrides ServiceManager.getServiceOrThrow to simply return null instead.
+ */
+object ServiceManagerInterceptor {
+  @Suppress("unused")
+  @JvmStatic
+  fun interceptGetServiceOrThrow(@Suppress("UNUSED_PARAMETER") name: String): IBinder? = null
+}


### PR DESCRIPTION
Fixes #407 

This fix requires two changes.

First, we prevent layoutlib's version of ServiceManager from throwing a ServiceNotFoundException when
it's asked to find the "input_method" service.

Second, we return the default implementation for IInputMethodManager in IInputMethodManager.Stub.asInterface.
This ensures that the mService field in ImeTracing is not null.