### PR TITLE
Invert logic for selecting SnapshotHandler

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -571,14 +571,14 @@ class Paparazzi @JvmOverloads constructor(
     /** The choreographer doesn't like 0 as a frame time, so start an hour later. */
     internal val TIME_OFFSET_NANOS = TimeUnit.HOURS.toNanos(1L)
 
-    private val isVerifying: Boolean =
-      System.getProperty("paparazzi.test.verify")?.toBoolean() == true
+    private val isRecording: Boolean =
+      System.getProperty("paparazzi.test.record")?.toBoolean() == true
 
     private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
-      if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference)
-      } else {
+      if (isRecording) {
         HtmlReportWriter()
+      } else {
+        SnapshotVerifier(maxPercentDifference)
       }
   }
 }


### PR DESCRIPTION
Currently the private `determineHandler()` selects the `SnapshotHandler` based on the `paparazzi.test.verify` system property, which the Gradle tasks set. Unfortunately this forces users to use the `verifyPaparazzi` task to perform snapshot verification. Using `testDebug` (or `check`, etc) will actually perform a recording instead which feels counter intuitive.

This PR flips that logic around so that it checks for the `paparazzi.test.record` property instead. This results in `test` tasks performing a verification, and users needing to use the `recordPaparazzi` task to perform the record. The `verifyPaparazzi` task could probably be removed after this PR but I'll leave that for now.