### PR TITLE
Implement basic Kotlin Multiplatform support

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -38,7 +38,10 @@ import org.gradle.api.tasks.options.Option
 import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import java.util.Locale
 
 @Suppress("unused")
@@ -111,6 +114,15 @@ class PaparazziPlugin : Plugin<Project> {
 
       project.plugins.withType(JavaBasePlugin::class.java) {
         project.tasks.named("compile${testVariantSlug}JavaWithJavac")
+          .configure { it.dependsOn(writeResourcesTask) }
+      }
+
+      project.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {
+        val multiplatformExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        check(multiplatformExtension.targets.any { target -> target is KotlinAndroidTarget }) {
+          "There must be an Android target configured when using Paparazzi with the Kotlin Multiplatform Plugin"
+        }
+        project.tasks.named("compile${testVariantSlug}KotlinAndroid")
           .configure { it.dependsOn(writeResourcesTask) }
       }
 

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -62,6 +62,31 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun kotlinMultiplatformPluginWithAndroidTarget() {
+    val fixtureRoot = File("src/test/projects/multiplatform-plugin-with-android")
+
+    val result = gradleRunner
+      .withArguments("preparePaparazziDebugResources", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+  }
+
+  @Test
+  fun kotlinMultiplatformPluginWithoutAndroidTarget() {
+    val fixtureRoot = File("src/test/projects/multiplatform-plugin-without-android")
+
+    val result = gradleRunner
+      .withArguments("preparePaparazziDebugResources", "--stacktrace")
+      .runFixture(fixtureRoot) { buildAndFail() }
+
+    assertThat(result.task(":preparePaparazziDebugResources")).isNull()
+    assertThat(result.output).contains(
+      "There must be an Android target configured when using Paparazzi with the Kotlin Multiplatform Plugin"
+    )
+  }
+
+  @Test
   fun excludeAndroidTestSourceSets() {
     val fixtureRoot = File("src/test/projects/exclude-androidtest")
 

--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.android.library'
+  id 'app.cash.paparazzi'
+}
+
+kotlin {
+  android()
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    minSdkVersion 25
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.android.library'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    minSdkVersion 25
+  }
+}


### PR DESCRIPTION
Adds preliminary support for Kotlin Multiplatform libraries with an Android target. This makes Gradle sync pass but I have not yet verified it with an actual Paparazzi test, hence the draft status.
