### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Paparazzi
 ========
 
-An Android library to render your application screens without a physical device or emulator.
+An Android library to render your application screens without a physical device or emulator. *Paparazzi ONLY works with library modules, and NOT app modules at this time.*
 
 ```kotlin
 class LaunchViewTest {


### PR DESCRIPTION
Based on my own experience, being able to use this library with the main app module would be expected without much fuss. I tried and finally realized what the error message was telling me, and along with this issue: [https://github.com/cashapp/paparazzi/issues/105](https://github.com/cashapp/paparazzi/issues/105) I was able to determine that Paparazzi does not support app modules. It should be made clear right up front so that no one else wastes their time.