### PR TITLE
Improving README.md with compose example & where to find snapshot failure diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Paparazzi
 ========
 
-An Android library to snapshot test your views or composables without a physical device or emulator.
+An Android library to render your application screens without a physical device or emulator.
 
 ```kotlin
 class LaunchViewTest {
@@ -13,7 +13,7 @@ class LaunchViewTest {
   )
 
   @Test
-  fun simpleViewTest() {
+  fun launchView() {
     val view = paparazzi.inflate<LaunchView>(R.layout.launch)
     // or...
     // val view = LaunchView(paparazzi.context)
@@ -23,7 +23,7 @@ class LaunchViewTest {
   }
 
   @Test
-  fun simpleComposableTest() {
+  fun launchComposable() {
     paparazzi.snapshot {
       MyComposable()
     }
@@ -53,7 +53,7 @@ Saves snapshots as golden values to a predefined source-controlled location
 $ ./gradlew sample:verifyPaparazziDebug
 ```
 
-Runs tests and verifies against previously-recorded golden values. Snapshot test failure diffs can be found at `sample/out/failures`.
+Runs tests and verifies against previously-recorded golden values. Failures generate diffs at `sample/out/failures`.
 
 For more examples, check out the [sample][sample] project.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Paparazzi
 ========
 
-An Android library to render your application screens without a physical device or emulator.
+An Android library to snapshot test your views or composables without a physical device or emulator.
 
 ```kotlin
 class LaunchViewTest {
@@ -13,13 +13,20 @@ class LaunchViewTest {
   )
 
   @Test
-  fun simple() {
+  fun simpleViewTest() {
     val view = paparazzi.inflate<LaunchView>(R.layout.launch)
     // or...
     // val view = LaunchView(paparazzi.context)
 
     view.setModel(LaunchModel(title = "paparazzi"))
     paparazzi.snapshot(view)
+  }
+
+  @Test
+  fun simpleComposableTest() {
+    paparazzi.snapshot {
+      MyComposable()
+    }
   }
 }
 ```
@@ -46,8 +53,7 @@ Saves snapshots as golden values to a predefined source-controlled location
 $ ./gradlew sample:verifyPaparazziDebug
 ```
 
-Runs tests and verifies against previously-recorded golden values.
-
+Runs tests and verifies against previously-recorded golden values. Snapshot test failure diffs can be found at `sample/out/failures`.
 
 For more examples, check out the [sample][sample] project.
 


### PR DESCRIPTION
Hi, I think the README can be improved to mention the ability to snapshot test composables & where to find snapshot failure diff images.