### PR TITLE
Fix github pages title (copy paste leftovers)

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -15,7 +15,7 @@ set -ex
 # Assign metadata to the file's first Markdown heading.
 # https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
 title_markdown_file() {
-  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - SQLDelight/"
+  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - Paprazzi/"
   echo "---"                                                     > "$1.fixed"
   cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
   echo "---"                                                    >> "$1.fixed"

--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -15,7 +15,7 @@ set -ex
 # Assign metadata to the file's first Markdown heading.
 # https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
 title_markdown_file() {
-  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - Paprazzi/"
+  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - Paparazzi/"
   echo "---"                                                     > "$1.fixed"
   cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
   echo "---"                                                    >> "$1.fixed"


### PR DESCRIPTION
Leftovers from SQLDelight 
<img width="820" alt="Screenshot 2022-06-30 at 16 50 16" src="https://user-images.githubusercontent.com/2768618/176722039-9d0277b9-2f04-45cf-a407-da8e35524d76.png">

