### PR TITLE
Allow for custom appCompatViewInflater #274

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -696,7 +696,6 @@ class PaparazziPluginTest {
     assertThat(snapshotImage).isSimilarTo(goldenImage).withDefaultThreshold()
   }
 
-  @Test
   @Ignore
   fun withMaterialComponents() {
     val fixtureRoot = File("src/test/projects/material-components-present")

--- a/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-  implementation 'com.google.android.material:material:1.5.0-alpha03'
+  implementation 'com.google.android.material:material:1.6.1'
 }

--- a/paparazzi-gradle-plugin/src/test/projects/material-components-present/src/test/java/app/cash/paparazzi/plugin/test/ButtonViewTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/material-components-present/src/test/java/app/cash/paparazzi/plugin/test/ButtonViewTest.kt
@@ -22,7 +22,10 @@ import org.junit.Test
 
 class ButtonViewTest {
   @get:Rule
-  val paparazzi = Paparazzi(theme = "Theme.MaterialComponents")
+  val paparazzi = Paparazzi(
+    theme = "Theme.MaterialComponents",
+    appCompatViewInflaterClassName = "com.google.android.material.theme.MaterialComponentsViewInflater",
+  )
 
   @Test
   fun testViews() {


### PR DESCRIPTION
and thus support for MaterialComponents or other custom UI library

It would be great to resolve the viewInfalter from the theme but we don't have a context before constructing Paparazzi. We could resolve it in the test function but it would add a lot of boilerplate. And we can't resolve it from within Parazzi as we need to obtain theme attribute as done in [AppCompatDelegateImpl](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDelegateImpl.java;l=1526?q=AppCompatDelegateImpl) 

we could maybe remove the `appCompatEnabled` and have a sealed class for the `appCompatViewInflaterClassName` but I didn't want to change the Paparazzi API