### PR TITLE
Fix incompatibility when used on compileSdk 33 projects

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -75,10 +75,21 @@ internal class Renderer(
     val icuLocation = File(platformDataDir, "icu" + File.separator + "icudt68l.dat")
     val buildProp = File(environment.platformDir, "build.prop")
     val attrs = File(platformDataResDir, "values" + File.separator + "attrs.xml")
-    val systemProperties = DeviceConfig.loadProperties(buildProp) + mapOf(
+    val systemProperties = (DeviceConfig.loadProperties(buildProp) + mapOf(
       // We want Choreographer.USE_FRAME_TIME to be false so it uses System_Delegate.nanoTime()
       "debug.choreographer.frametime" to "false"
-    )
+    )).let { props ->
+      // Workaround for https://github.com/cashapp/paparazzi/issues/486:
+      // When used in a project compiled with SDK 33, the known_codenames build prop is too long
+      // for our 'old' version of SystemProperties to handle. The SystemProperties class was
+      // updated in SDK 33 to handle this, but we need to wait until we hit a layoutlib build
+      // which matches (likely EE). For now we just omit the value if too long, which
+      // doesn't seem to cause any issues.
+      // TODO: remove this once we upgrade to a layoutlib version which contains SDK 33 changes
+      val codenames = props["ro.build.version.known_codenames"]?.takeIf { it.length <= 91 }
+      props + mapOf("ro.build.version.known_codenames" to codenames)
+    }
+
     bridge = Bridge().apply {
       check(
         init(


### PR DESCRIPTION
Caused by the SDK 33 ro.build.version.known_codenames build prop being
too long for the pre-SDK 33 SystemProperties class. The old versions of
the SystemProperties class throw exceptions for values with lengths of
92+ chars.

Since we can't update to a version of layoutlib which contains the SDK 33
changes yet (likely in Electric Eel), this PR adds a workaround which
omits the build prop when it is longer than 91 chars. This doesn't
cause any obvious issues from my testing on the Twitter for Android app.

Fixes #486