### PR TITLE
Add quotation marks to the git lfs track command in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It is recommended you use [Git LFS][lfs] to store your snapshots.  Here's a quic
 $ brew install git-lfs
 $ git config core.hooksPath  # optional, confirm where your git hooks will be installed
 $ git lfs install --local
-$ git lfs track **/snapshots/**/*.png
+$ git lfs track "**/snapshots/**/*.png"
 $ git add .gitattributes
 ```
 


### PR DESCRIPTION
If you run the current command `git lfs track **/snapshots/**/*.png` in the Git LFS section, it returns this error:
```
zsh: no matches found: **/snapshots/**/*.png
``` 
Added quotation marks to the `**/snapshots/**/*.png` part so it actually adds this into the `.gitattributes`
