### PR TITLE
PrepareResourcesTask - Use PathSensitivity.ABSOLUTE for platformDataRoot 

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -50,7 +50,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
   abstract val mergeAssetsOutput: DirectoryProperty
 
   @get:InputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:PathSensitive(PathSensitivity.ABSOLUTE)
   abstract val platformDataRoot: DirectoryProperty
 
   @get:Input


### PR DESCRIPTION
Fix #495, since `platformDataRoot` is a path contained in gradle home it's safer to use absolute path for cache input.

Here the build input comparison after fix when using steps to repro on #495: 

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/773377/179038793-0ab47fa8-b793-4082-8d40-2dd9811a3126.png">