### PR TITLE
Paparazzi.js fixes

### DIFF
--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -12,7 +12,7 @@ class Shot {
   constructor(name, test) {
     this.name = name;
     this.test = test;
-    
+
     [, this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
 
     this.runs = [];

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -13,7 +13,7 @@ class Shot {
     this.name = name;
     this.test = test;
     
-    [this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
+    [, this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
 
     this.runs = [];
   }

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -181,7 +181,7 @@ class PaparazziRenderer {
         continue;
       }
       // The js loading is async so the rendering can happen in the next refresh
-      this.loadRunScript(`${runId}/run.js`);
+      this.loadRunScript(`runs/${runId}.js`);
 
       this.render(new Run(runId, window.runs[runId]));
 

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -19,7 +19,7 @@ class Shot {
   }
 
   static get TestMethodRegex() {
-    return /^(.*)\.(.*)#(.*)\[/;
+    return /^(.*)\.(.*)#([^\[]*)\[?.*$/;
   }
 
   addRun(runId, file, timestamp) {

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -19,7 +19,7 @@ class Shot {
   }
 
   static get TestMethodRegex() {
-    return /^(.*)\.(.*)#([^\[]*)\[?.*$/;
+    return /^(.*)\.(.*)#(.*)$/;
   }
 
   addRun(runId, file, timestamp) {

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -12,14 +12,14 @@ class Shot {
   constructor(name, test) {
     this.name = name;
     this.test = test;
-
-    [, this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
+    
+    [this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
 
     this.runs = [];
   }
 
   static get TestMethodRegex() {
-    return /^(.*)\.([^.]*)#([^.]*)$/;
+    return /^(.*)\.(.*)#(.*)\[/;
   }
 
   addRun(runId, file, timestamp) {

--- a/sample/src/test/java/app/cash/paparazzi/sample/TestParameterInjectorTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/TestParameterInjectorTest.kt
@@ -1,6 +1,7 @@
 package app.cash.paparazzi.sample
 
 import android.widget.LinearLayout
+import android.widget.TextView
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -26,6 +27,10 @@ class TestParameterInjectorTest(
     LIGHT_NO_ACTION_BAR("android:Theme.Material.Light.NoActionBar")
   }
 
+  object AmountProvider : TestParameter.TestParameterValuesProvider {
+    override fun provideValues(): List<String> = listOf("\$1.00", "\$2.00", "\$5.00", "\$10.00")
+  }
+
   @get:Rule
   val paparazzi = Paparazzi(deviceConfig = config.deviceConfig)
 
@@ -40,5 +45,13 @@ class TestParameterInjectorTest(
     paparazzi.unsafeUpdateConfig(theme = theme.themeName)
     val launch = paparazzi.inflate<LinearLayout>(R.layout.launch)
     paparazzi.snapshot(launch)
+  }
+
+  @Test
+  fun amountProviderTest(@TestParameter(valuesProvider = AmountProvider::class) amount: String) {
+    val keypad = paparazzi.inflate<LinearLayout>(R.layout.keypad)
+    val amountView = keypad.findViewById<TextView>(R.id.amount)
+    amountView.text = amount
+    paparazzi.snapshot(keypad)
   }
 }


### PR DESCRIPTION
While using Paparazzi I ran into a few issues regarding paparazzi.js when running . These are fixed in this MR:
- Syntax error on line 16
- `Shot.TestMethodRegex` was failing to parse `this.package`, `this.clazz`, `this.method` from `test` properly.
- The path to the scripts was incorrect, pointing to `${runId}/run.js` instead of `runs/${runId}.js`
![image](https://user-images.githubusercontent.com/8784017/180872026-e24349d7-f15d-4350-b146-6a97a8dcaecd.png)


This fixes paparazzi.js and ensures the HTML report can be opened without errors.