### PR TITLE
Optional snapshot root directory gradle property

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -21,7 +21,6 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.tasks.MergeSourceSetFolders
 import com.android.ide.common.symbols.getPackageNameFromManifest
-import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -60,10 +59,13 @@ class PaparazziPlugin : Plugin<Project> {
       }
     }
 
-    project.plugins.withId("com.android.library") { setupPaparazzi(project) }
+    project.plugins.withId("com.android.library") {
+      val extension = project.extensions.create("paparazzi", PaparazziPluginExtension::class.java)
+      setupPaparazzi(project, extension)
+    }
   }
 
-  private fun setupPaparazzi(project: Project) {
+  private fun setupPaparazzi(project: Project, extension: PaparazziPluginExtension) {
     val unzipConfiguration = project.setupPlatformDataTransform()
 
     // Create anchor tasks for all variants.
@@ -82,7 +84,7 @@ class PaparazziPlugin : Plugin<Project> {
       val reportOutputDir = project.layout.buildDirectory.dir("reports/paparazzi")
 
       val snapshotOutputDir =
-          project.extensions.extraProperties.properties["paparazzi_snapshot_dir"] as? File
+          extension.snapshotRootDirectory.orNull
           ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
 
       val packageAwareArtifacts = project.configurations.getByName("${variant.name}RuntimeClasspath")

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -84,8 +84,8 @@ class PaparazziPlugin : Plugin<Project> {
       val reportOutputDir = project.layout.buildDirectory.dir("reports/paparazzi")
 
       val snapshotOutputDir =
-          extension.snapshotRootDirectory.orNull
-          ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
+        extension.snapshotRootDirectory.orNull
+        ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
       snapshotOutputDir.mkdirs()
 
       val packageAwareArtifacts = project.configurations.getByName("${variant.name}RuntimeClasspath")

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -21,6 +21,7 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.tasks.MergeSourceSetFolders
 import com.android.ide.common.symbols.getPackageNameFromManifest
+import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -79,7 +80,10 @@ class PaparazziPlugin : Plugin<Project> {
         project.tasks.named("merge${variantSlug}Assets") as TaskProvider<MergeSourceSetFolders>
       val mergeAssetsOutputDir = mergeAssetsProvider.flatMap { it.outputDir }
       val reportOutputDir = project.layout.buildDirectory.dir("reports/paparazzi")
-      val snapshotOutputDir = project.layout.projectDirectory.dir("src/test/snapshots")
+
+      val snapshotOutputDir =
+          project.extensions.extraProperties.properties["paparazzi_snapshot_dir"] as? File
+          ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
 
       val packageAwareArtifacts = project.configurations.getByName("${variant.name}RuntimeClasspath")
         .incoming
@@ -108,6 +112,7 @@ class PaparazziPlugin : Plugin<Project> {
         task.mergeAssetsOutput.set(mergeAssetsOutputDir)
         task.platformDataRoot.set(unzipConfiguration.singleFile)
         task.paparazziResources.set(project.layout.buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
+        task.snapshotDirectory.set(snapshotOutputDir)
       }
 
       val testVariantSlug = variant.unitTestVariant.name.capitalize(Locale.US)

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -85,7 +85,7 @@ class PaparazziPlugin : Plugin<Project> {
 
       val snapshotOutputDir =
         extension.snapshotRootDirectory.orNull
-        ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
+          ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
       snapshotOutputDir.mkdirs()
 
       val packageAwareArtifacts = project.configurations.getByName("${variant.name}RuntimeClasspath")

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -86,6 +86,7 @@ class PaparazziPlugin : Plugin<Project> {
       val snapshotOutputDir =
           extension.snapshotRootDirectory.orNull
           ?: project.layout.projectDirectory.dir("src/test/snapshots").asFile
+      snapshotOutputDir.mkdirs()
 
       val packageAwareArtifacts = project.configurations.getByName("${variant.name}RuntimeClasspath")
         .incoming

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPluginExtension.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPluginExtension.kt
@@ -1,7 +1,7 @@
 package app.cash.paparazzi.gradle
 
-import java.io.File
 import org.gradle.api.provider.Property
+import java.io.File
 
 interface PaparazziPluginExtension {
   val snapshotRootDirectory: Property<File?>

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPluginExtension.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPluginExtension.kt
@@ -1,0 +1,8 @@
+package app.cash.paparazzi.gradle
+
+import java.io.File
+import org.gradle.api.provider.Property
+
+interface PaparazziPluginExtension {
+  val snapshotRootDirectory: Property<File?>
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -21,7 +21,14 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class PrepareResourcesTask : DefaultTask() {

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -21,14 +21,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 
 @CacheableTask
 abstract class PrepareResourcesTask : DefaultTask() {
@@ -52,6 +45,10 @@ abstract class PrepareResourcesTask : DefaultTask() {
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val platformDataRoot: DirectoryProperty
+
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.ABSOLUTE)
+  abstract val snapshotDirectory: DirectoryProperty
 
   @get:Input
   abstract val nonTransitiveRClassEnabled: Property<Boolean>
@@ -100,6 +97,8 @@ abstract class PrepareResourcesTask : DefaultTask() {
         it.write(platformDataRoot.get().asFile.invariantSeparatorsPath)
         it.newLine()
         it.write(resourcePackageNames)
+        it.newLine()
+        it.write(snapshotDirectory.get().asFile.invariantSeparatorsPath)
         it.newLine()
       }
   }

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -31,7 +31,7 @@ data class Environment(
   val compileSdkVersion: Int,
   val platformDataDir: String,
   val resourcePackageNames: List<String>,
-  val snapshotDirectory: String
+  val snapshotDirectory: String?
 ) {
   init {
     val platformDirPath = Path.of(platformDir)
@@ -66,7 +66,7 @@ fun detectEnvironment(): Environment {
     compileSdkVersion = configLines[2].toInt(),
     platformDataDir = configLines[5],
     resourcePackageNames = configLines[6].split(","),
-    snapshotDirectory = configLines[7]
+    snapshotDirectory = configLines.getOrNull(7)
   )
 }
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -30,7 +30,8 @@ data class Environment(
   val packageName: String,
   val compileSdkVersion: Int,
   val platformDataDir: String,
-  val resourcePackageNames: List<String>
+  val resourcePackageNames: List<String>,
+  val snapshotDirectory: String
 ) {
   init {
     val platformDirPath = Path.of(platformDir)
@@ -64,7 +65,8 @@ fun detectEnvironment(): Environment {
     packageName = configLines[0],
     compileSdkVersion = configLines[2].toInt(),
     platformDataDir = configLines[5],
-    resourcePackageNames = configLines[6].split(",")
+    resourcePackageNames = configLines[6].split(","),
+    snapshotDirectory = configLines[7]
   )
 }
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -596,11 +596,13 @@ class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double, snapshotDirectory: String): SnapshotHandler =
-      if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference, File(snapshotDirectory))
-      } else {
-        HtmlReportWriter(snapshotRootDirectory = File(snapshotDirectory))
+    private fun determineHandler(maxPercentDifference: Double, snapshotDirectory: String?): SnapshotHandler =
+      (snapshotDirectory ?: "src/test/snapshots").let { outputDir ->
+        if (isVerifying) {
+          SnapshotVerifier(maxPercentDifference, File(outputDir))
+        } else {
+          HtmlReportWriter(snapshotRootDirectory = File(outputDir))
+        }
       }
   }
 }

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -205,8 +205,6 @@ class Paparazzi @JvmOverloads constructor(
     }
   }
 
-  fun getSnapshotPath: String = Snapshot()
-
   @JvmOverloads
   fun snapshot(view: View, name: String? = null) {
     takeSnapshots(view, name, 0, -1, 1)

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -85,7 +85,7 @@ class Paparazzi @JvmOverloads constructor(
   private val renderingMode: RenderingMode = RenderingMode.NORMAL,
   private val appCompatEnabled: Boolean = true,
   private val maxPercentDifference: Double = 0.1,
-  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
+  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference, environment.snapshotDirectory),
   private val renderExtensions: Set<RenderExtension> = setOf()
 ) : TestRule {
   private val logger = PaparazziLogger()
@@ -204,6 +204,8 @@ class Paparazzi @JvmOverloads constructor(
       forceReleaseComposeReferenceLeaks()
     }
   }
+
+  fun getSnapshotPath: String = Snapshot()
 
   @JvmOverloads
   fun snapshot(view: View, name: String? = null) {
@@ -596,11 +598,11 @@ class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    private fun determineHandler(maxPercentDifference: Double, snapshotDirectory: String): SnapshotHandler =
       if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference)
+        SnapshotVerifier(maxPercentDifference, File(snapshotDirectory))
       } else {
-        HtmlReportWriter()
+        HtmlReportWriter(snapshotRootDirectory = File(snapshotDirectory))
       }
   }
 }

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -74,6 +74,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.awt.image.BufferedImage
+import java.io.File
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.ContinuationInterceptor


### PR DESCRIPTION
Allows the consumer of the Paparazzi library to specify where they want the snapshots to be saved. This includes creating a gradle plugin extension for Paparazzi with this property in it, we can add other configurable properties to this extension in future.

This can be set as shown in the consumer's gradle file
```
paparazzi {
    snapshotRootDirectory = file("where/I/want/the/snapshots")
}
```
