### PR TITLE
Revert "Update layoutlib versions to include SNAPSHOT suffix"

### DIFF
--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -1,11 +1,7 @@
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'com.vanniktech.maven.publish'
 
-if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
-  version = "${versions.layoutlib}-SNAPSHOT"
-} else {
-  version = versions.layoutlib
-}
+version = versions.layoutlib
 
 /**
  * Clone AOSP's prebuilts repo to get a prebuilt layoutlib jar. This big repo that takes a long time to clone!

--- a/libs/native-linux/build.gradle
+++ b/libs/native-linux/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
-  version = "${versions.layoutlib}-SNAPSHOT"
-} else {
-  version = versions.layoutlib
-}
+version = versions.layoutlib
 
 tasks.register('linuxJar', Jar) {
   from(repoDir) {

--- a/libs/native-macarm/build.gradle
+++ b/libs/native-macarm/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
-  version = "${versions.layoutlib}-SNAPSHOT"
-} else {
-  version = versions.layoutlib
-}
+version = versions.layoutlib
 
 tasks.register('macArmJar', Jar) {
   from(repoDir) {

--- a/libs/native-macosx/build.gradle
+++ b/libs/native-macosx/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
-  version = "${versions.layoutlib}-SNAPSHOT"
-} else {
-  version = versions.layoutlib
-}
+version = versions.layoutlib
 
 tasks.register('macJar', Jar) {
   from(repoDir) {

--- a/libs/native-win/build.gradle
+++ b/libs/native-win/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-if (properties['VERSION_NAME'].endsWith("SNAPSHOT")) {
-  version = "${versions.layoutlib}-SNAPSHOT"
-} else {
-  version = versions.layoutlib
-}
+version = versions.layoutlib
 
 tasks.register('winJar', Jar) {
   from(repoDir) {


### PR DESCRIPTION
This reverts commit 6743ca28d40fcf6590ba8f4579d05b4fa3ac7fd4.

Since we push relocated/shadowed versions of Layoutlib from AOSP, they're never SNAPSHOTs.  This has bitten us a few times when locally testing, so let's nuke it.