### PR TITLE
Fix OOM error when a large number of compose snapshots are failing when verifying

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -189,17 +189,19 @@ class Paparazzi @JvmOverloads constructor(
   fun <V : View> inflate(@LayoutRes layoutId: Int): V = layoutInflater.inflate(layoutId, null) as V
 
   fun snapshot(name: String? = null, composable: @Composable () -> Unit) {
-    val hostView = ComposeView(context)
-    // During onAttachedToWindow, AbstractComposeView will attempt to resolve its parent's
-    // CompositionContext, which requires first finding the "content view", then using that to
-    // find a root view with a ViewTreeLifecycleOwner
-    val parent = FrameLayout(context).apply { id = android.R.id.content }
-    parent.addView(hostView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-    PaparazziComposeOwner.register(parent)
-    hostView.setContent(composable)
-    snapshot(parent, name)
-
-    forceReleaseComposeReferenceLeaks()
+    try {
+      val hostView = ComposeView(context)
+      // During onAttachedToWindow, AbstractComposeView will attempt to resolve its parent's
+      // CompositionContext, which requires first finding the "content view", then using that to
+      // find a root view with a ViewTreeLifecycleOwner
+      val parent = FrameLayout(context).apply { id = android.R.id.content }
+      parent.addView(hostView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+      PaparazziComposeOwner.register(parent)
+      hostView.setContent(composable)
+      snapshot(parent, name)
+    } finally {
+      forceReleaseComposeReferenceLeaks()
+    }
   }
 
   @JvmOverloads

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -189,15 +189,16 @@ class Paparazzi @JvmOverloads constructor(
   fun <V : View> inflate(@LayoutRes layoutId: Int): V = layoutInflater.inflate(layoutId, null) as V
 
   fun snapshot(name: String? = null, composable: @Composable () -> Unit) {
+    val hostView = ComposeView(context)
+    // During onAttachedToWindow, AbstractComposeView will attempt to resolve its parent's
+    // CompositionContext, which requires first finding the "content view", then using that to
+    // find a root view with a ViewTreeLifecycleOwner
+    val parent = FrameLayout(context).apply { id = android.R.id.content }
+    parent.addView(hostView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+    PaparazziComposeOwner.register(parent)
+    hostView.setContent(composable)
+
     try {
-      val hostView = ComposeView(context)
-      // During onAttachedToWindow, AbstractComposeView will attempt to resolve its parent's
-      // CompositionContext, which requires first finding the "content view", then using that to
-      // find a root view with a ViewTreeLifecycleOwner
-      val parent = FrameLayout(context).apply { id = android.R.id.content }
-      parent.addView(hostView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-      PaparazziComposeOwner.register(parent)
-      hostView.setContent(composable)
       snapshot(parent, name)
     } finally {
       forceReleaseComposeReferenceLeaks()


### PR DESCRIPTION
I've noticed that if you have a large number of compose snapshot tests failing when running the `verifyPaparazziDebug` task, it will eventually lead to an `OutOfMemoryError: Java heap space`

[The following gist contains a test class that will simulate 2000 failing tests being run and leading to OOM errors (depending on heap size)](https://gist.github.com/rojanthomas/a200a1375b699525378d7d0410706575). (I didn't record a baseline so they would all fail).

This fix will ensure that the correct error is presented in the JUnit report & any failure diffs continue to be generated.

This may be related to #468 