### PR TITLE
Add Pixel 6 & Pixel 6 Pro to DeviceConfig

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
@@ -445,6 +445,42 @@ data class DeviceConfig(
       released = "October 15, 2020"
     )
 
+    @JvmField
+    val PIXEL_6 = DeviceConfig(
+      screenHeight = 2400,
+      screenWidth = 1080,
+      xdpi = 409,
+      ydpi = 412,
+      orientation = ScreenOrientation.PORTRAIT,
+      density = Density.DPI_420,
+      ratio = ScreenRatio.LONG,
+      size = ScreenSize.NORMAL,
+      keyboard = Keyboard.NOKEY,
+      touchScreen = TouchScreen.FINGER,
+      keyboardState = KeyboardState.SOFT,
+      softButtons = true,
+      navigation = Navigation.NONAV,
+      released = "October 28, 2021"
+    )
+
+    @JvmField
+    val PIXEL_6_PRO = DeviceConfig(
+      screenHeight = 3120,
+      screenWidth = 1440,
+      xdpi = 515,
+      ydpi = 511,
+      orientation = ScreenOrientation.PORTRAIT,
+      density = Density.DPI_560,
+      ratio = ScreenRatio.LONG,
+      size = ScreenSize.NORMAL,
+      keyboard = Keyboard.NOKEY,
+      touchScreen = TouchScreen.FINGER,
+      keyboardState = KeyboardState.SOFT,
+      softButtons = true,
+      navigation = Navigation.NONAV,
+      released = "October 28, 2021"
+    )
+
     private const val TAG_ATTR = "attr"
     private const val TAG_ENUM = "enum"
     private const val TAG_FLAG = "flag"

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
@@ -467,8 +467,8 @@ data class DeviceConfig(
     val PIXEL_6_PRO = DeviceConfig(
       screenHeight = 3120,
       screenWidth = 1440,
-      xdpi = 515,
-      ydpi = 511,
+      xdpi = 512,
+      ydpi = 512,
       orientation = ScreenOrientation.PORTRAIT,
       density = Density.DPI_560,
       ratio = ScreenRatio.LONG,

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
@@ -449,8 +449,8 @@ data class DeviceConfig(
     val PIXEL_6 = DeviceConfig(
       screenHeight = 2400,
       screenWidth = 1080,
-      xdpi = 409,
-      ydpi = 412,
+      xdpi = 406,
+      ydpi = 411,
       orientation = ScreenOrientation.PORTRAIT,
       density = Density.DPI_420,
       ratio = ScreenRatio.LONG,


### PR DESCRIPTION
Source of `xdpi` & `ydpi` for physical devices:

| Device | AIDA64 report |
| - | - |
| Pixel 6 | <img src="https://user-images.githubusercontent.com/6156111/183293950-fbe6201a-6f00-4e61-abf5-3b3ccc29914f.png" width="300"/> | 
| Pixel 6 Pro | <img src="https://user-images.githubusercontent.com/6156111/183294015-2015dbc6-9e93-440e-9e1a-dae2b6986b6f.png" width="300"/>

Was also trying to find these values for Pixel 6A, but can't find them in the wild for now.
