### PR TITLE
Update sample tests to use View Binding

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,6 +9,7 @@ android {
   }
   buildFeatures {
     compose true
+    viewBinding true
   }
   composeOptions {
     kotlinCompilerExtensionVersion '1.1.1'

--- a/sample/src/test/java/app/cash/paparazzi/sample/KeypadViewTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/KeypadViewTest.kt
@@ -17,9 +17,8 @@ package app.cash.paparazzi.sample
 
 import android.animation.ObjectAnimator
 import android.view.View
-import android.widget.LinearLayout
-import android.widget.TextView
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.sample.databinding.KeypadBinding
 import org.junit.Rule
 import org.junit.Test
 
@@ -29,43 +28,40 @@ class KeypadViewTest {
 
   @Test
   fun testViews() {
-    val keypad = paparazzi.inflate<LinearLayout>(R.layout.keypad)
-    val amount = keypad.findViewById<TextView>(R.id.amount)
-    val amount123 = keypad.findViewById<TextView>(R.id.amount123)
-    val amount456 = keypad.findViewById<TextView>(R.id.amount456)
-    val amount789 = keypad.findViewById<TextView>(R.id.amount789)
-    val amount0 = keypad.findViewById<TextView>(R.id.amount0)
+    val binding = KeypadBinding.inflate(paparazzi.layoutInflater)
 
-    amount.text = "$0"
-    paparazzi.snapshot(keypad, "zero dollars")
+    with(binding) {
+      amount.text = "$0"
+      paparazzi.snapshot(root, "zero dollars")
 
-    amount.text = "$5.00"
-    paparazzi.snapshot(keypad, "five bucks")
+      amount.text = "$5.00"
+      paparazzi.snapshot(root, "five bucks")
 
-    keypad.setBackgroundResource(R.color.keypadDarkGrey)
-    val darkGrey = paparazzi.context.getColor(R.color.keypadDarkGrey)
-    keypad.setBackgroundColor(darkGrey)
-    amount.text = "$1.00"
-    paparazzi.snapshot(keypad, "grey")
+      root.setBackgroundResource(R.color.keypadDarkGrey)
+      val darkGrey = paparazzi.context.getColor(R.color.keypadDarkGrey)
+      root.setBackgroundColor(darkGrey)
+      amount.text = "$1.00"
+      paparazzi.snapshot(root, "grey")
 
-    keypad.setBackgroundResource(R.color.keypadDarkGrey)
-    keypad.setBackgroundColor(paparazzi.context.getColor(R.color.bolt))
-    amount.setTextColor(darkGrey)
-    amount123.setTextColor(darkGrey)
-    amount456.setTextColor(darkGrey)
-    amount789.setTextColor(darkGrey)
-    amount0.setTextColor(darkGrey)
-    amount.text = ".01 BTC"
+      root.setBackgroundResource(R.color.keypadDarkGrey)
+      root.setBackgroundColor(paparazzi.context.getColor(R.color.bolt))
+      amount.setTextColor(darkGrey)
+      amount123.setTextColor(darkGrey)
+      amount456.setTextColor(darkGrey)
+      amount789.setTextColor(darkGrey)
+      amount0.setTextColor(darkGrey)
+      amount.text = ".01 BTC"
 
-    paparazzi.snapshot(keypad, "bolt")
+      paparazzi.snapshot(root, "bolt")
 
-    val rotation = ObjectAnimator.ofFloat(amount, View.ROTATION, 0.0f, 360.0f).apply {
-      duration = 500
-      startDelay = 500
+      val rotation = ObjectAnimator.ofFloat(amount, View.ROTATION, 0.0f, 360.0f).apply {
+        duration = 500
+        startDelay = 500
+      }
+      rotation.start()
+
+      // Uncomment once snapshot verification supports videos
+      // paparazzi.gif(root, "spin", start = 500, end = 1500, fps = 30)
     }
-    rotation.start()
-
-    // Uncomment once snapshot verification supports videos
-    // paparazzi.gif(keypad, "spin", start = 500, end = 1500, fps = 30)
   }
 }

--- a/sample/src/test/java/app/cash/paparazzi/sample/TestParameterInjectorTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/TestParameterInjectorTest.kt
@@ -1,9 +1,9 @@
 package app.cash.paparazzi.sample
 
 import android.widget.LinearLayout
-import android.widget.TextView
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.sample.databinding.KeypadBinding
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Rule
@@ -49,9 +49,8 @@ class TestParameterInjectorTest(
 
   @Test
   fun amountProviderTest(@TestParameter(valuesProvider = AmountProvider::class) amount: String) {
-    val keypad = paparazzi.inflate<LinearLayout>(R.layout.keypad)
-    val amountView = keypad.findViewById<TextView>(R.id.amount)
-    amountView.text = amount
-    paparazzi.snapshot(keypad)
+    val binding = KeypadBinding.inflate(paparazzi.layoutInflater)
+    binding.amount.text = amount
+    paparazzi.snapshot(binding.root)
   }
 }


### PR DESCRIPTION
Sample tests using `findViewById` are migrated to View Binding for easier access to the views and less boilerplate code.

I've done this migration because it wasn't obvious to me that Paparazzi worked with View Binding (see [my issue](https://github.com/cashapp/paparazzi/issues/544)). With this there's more visibility for this support.

I've decided not to migrate tests that don't access views besides the root one since those can be created quicker without View Binding. That way there are samples for inflating with the Paparazzi object _and_ inflating with Bindings.