### PR TITLE
Make sure no tasks are created by paparazzi-gradle-plugin

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -145,8 +145,8 @@ class PaparazziPlugin : Plugin<Project> {
       val isVerifyRun = project.objects.property(Boolean::class.java)
 
       project.gradle.taskGraph.whenReady { graph ->
-        isRecordRun.set(graph.hasTask(recordTaskProvider.get()))
-        isVerifyRun.set(graph.hasTask(verifyTaskProvider.get()))
+        isRecordRun.set(recordTaskProvider.map { graph.hasTask(it) })
+        isVerifyRun.set(verifyTaskProvider.map { graph.hasTask(it) })
       }
 
       val testTaskProvider = project.tasks.named("test$testVariantSlug", Test::class.java) { test ->


### PR DESCRIPTION
This affects anyone who applies the plugin and does anything other than execute Paparazzi (pretty common case).

---

I'm doing some Gradle lazy performance optimizations on my projects and noticed that Paparazzi always creates 4 tasks for each module.

With this simple flip of `.get()` to `.map { }` I was able to get rid of that.

Test: manual `gradlew --scan` in paparazzi-root, not sure how to automate this yet.

Before: https://scans.gradle.com/s/gmiicgqgn3k7u/performance/configuration/by-project?details=project-:sample!app.cash.paparazzi&openProjects=WyJwcm9qZWN0LTpzYW1wbGUiXQ

After: https://scans.gradle.com/s/djtaml2nwfc6m/performance/configuration/by-project?details=project-:sample!app.cash.paparazzi&openProjects=WyJwcm9qZWN0LTpzYW1wbGUiXQ

Note: there's no point in using the configureEach/register/etc APIs if something doesn't play ball in the system.