### PR TITLE
[For discussion] Add ready flag to compose snapshot

### DIFF
--- a/sample/src/test/java/app/cash/paparazzi/sample/ComposeDelayedTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ComposeDelayedTest.kt
@@ -1,0 +1,43 @@
+package app.cash.paparazzi.sample
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class ComposeDelayedTest {
+  @get:Rule
+  val paparazzi = Paparazzi(
+    deviceConfig = DeviceConfig.PIXEL,
+  )
+
+  @Test
+  fun Delay() {
+    var state by mutableStateOf(0)
+
+    paparazzi.snapshot(ready = {
+      state > 25
+    }) {
+      Box {
+          Text("$state")
+      }
+      SideEffect {
+        println("Side Effect $state")
+      }
+      LaunchedEffect(Unit) {
+        launch(Dispatchers.Default) {
+          while (state < 50) {
+            delay(10)
+            state++
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Digging into https://github.com/cashapp/paparazzi/issues/513, this is for discussion only.

I tried to add a ready param to wait to take a snapshot.

```


  @Test
  fun Delay() {
    var state by mutableStateOf(0)

    paparazzi.snapshot(ready = {
      state > 25
    }) {
      Box {
          Text("$state")
      }
      SideEffect {
        println("Side Effect $state")
      }
      LaunchedEffect(Unit) {
        launch(Dispatchers.Default) {
          while (state < 50) {
            delay(10)
            state++
          }
        }
      }
    }
  }
```

But it doesn't work for a couple of reasons.

1) It seems that the snapshot thread is on a tight loop on the main thread, so LaunchedEffect with `delay` never gets a chance to run.
2) Snapshots don't see to be applied, so updating state on a different thread, isn't every seen on the main thread.  It remains unapplied.