### PR TITLE
Reset AndroidUiDispatcher between compose snapshots

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -904,6 +904,18 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun composeDispatcher() {
+    val fixtureRoot = File("src/test/projects/compose-dispatcher")
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    val snapshotsDir = File(fixtureRoot, "build/reports/paparazzi/images")
+    val snapshots = snapshotsDir.listFiles()
+    assertThat(snapshots!!).hasLength(1)
+  }
+
+  @Test
   fun immSoftInputInteraction() {
     val fixtureRoot = File("src/test/projects/imm-soft-input")
     gradleRunner

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    minSdkVersion 25
+  }
+  buildFeatures {
+    compose true
+  }
+  composeOptions {
+    kotlinCompilerExtensionVersion '1.3.0'
+  }
+}
+
+dependencies {
+  implementation 'androidx.compose.material:material:1.2.1'
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/src/test/java/app/cash/paparazzi/plugin/test/AndroidUiDispatcherTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/src/test/java/app/cash/paparazzi/plugin/test/AndroidUiDispatcherTest.kt
@@ -1,0 +1,27 @@
+package app.cash.paparazzi.plugin.test
+
+import androidx.compose.runtime.LaunchedEffect
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class AndroidUiDispatcherTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun androidUiDispatcherResets1() = assertSynchronousLaunchedEffect()
+
+  @Test
+  fun androidUiDispatcherResets2() = assertSynchronousLaunchedEffect()
+
+  private fun assertSynchronousLaunchedEffect() {
+    var launchedEffect = false
+    paparazzi.snapshot {
+      LaunchedEffect(Unit) {
+        launchedEffect = true
+      }
+    }
+    assert(launchedEffect)
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -564,6 +564,16 @@ class Paparazzi @JvmOverloads constructor(
       .apply { isAccessible = true }
       .get(dispatcher) as ArrayDeque<*>
     toRunTrampolined.clear()
+    // Upon reference leaks being fixed, verify we don't need to reset these values for
+    // AndroidUiDispatcher to continue dispatching between tests.
+    dispatcher.javaClass
+      .getDeclaredField("scheduledTrampolineDispatch")
+      .apply { isAccessible = true }
+      .set(dispatcher, false)
+    dispatcher.javaClass
+      .getDeclaredField("scheduledFrameDispatch")
+      .apply { isAccessible = true }
+      .set(dispatcher, false)
   }
 
   private class PaparazziComposeOwner private constructor() : LifecycleOwner, SavedStateRegistryOwner {


### PR DESCRIPTION
AndroidUiDispatcher schedules a callback for both a Handler and Choreographer using [scheduledTrampolineDispatch and scheduledFrameDispatch](https://android.googlesource.com/platform//frameworks/support/+/c354fa29007af485641665604612df30199a644a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/AndroidUiDispatcher.android.kt#52) to prevent queuing more than once. forceReleaseComposeReferenceLeaks() clears out any pending operations but we need to also reset these two fields else AndroidUiDispatcher won't dispatch any jobs after the first test.

I believe this will resolve https://github.com/cashapp/paparazzi/issues/553 and fixes an issue with infiniteAnimation not running after the first test.