### PR TITLE
Start using gradle-build-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Run Paparazzi Tests
         run: ./gradlew -p paparazzi check
 


### PR DESCRIPTION
Enables the use of Github Action cache to restore relevant Gradle caches to speed up builds.

Details:
https://github.com/marketplace/actions/gradle-build-action