### PR TITLE
Support custom thumbnail scale

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -91,7 +91,8 @@ class Paparazzi @JvmOverloads constructor(
   private val renderExtensions: Set<RenderExtension> = setOf(),
   private val supportsRtl: Boolean = false,
   private val showSystemUi: Boolean = false,
-  private val validateAccessibility: Boolean = false
+  private val validateAccessibility: Boolean = false,
+  private val thumbnailScale: ThumbnailScale = ThumbnailScale.ScaleMaxSideTo(DEFAULT_THUMBNAIL_SIZE)
 ) : TestRule {
   private val logger = PaparazziLogger()
   private lateinit var renderSession: RenderSessionImpl
@@ -154,7 +155,11 @@ class Paparazzi @JvmOverloads constructor(
     testName = description.toTestName()
 
     if (!isInitialized) {
-      renderer = Renderer(environment, layoutlibCallback, logger)
+      renderer = Renderer(
+        environment = environment,
+        layoutlibCallback = layoutlibCallback,
+        logger = logger
+      )
       sessionParamsBuilder = renderer.prepare()
     }
     forcePlatformSdkVersion(environment.compileSdkVersion)
@@ -408,7 +413,7 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   private fun scaleImage(image: BufferedImage): BufferedImage {
-    val scale = ImageUtils.getThumbnailScale(image)
+    val scale = ImageUtils.getThumbnailScale(image, thumbnailScale)
     // Only scale images down so we don't waste storage space enlarging smaller layouts.
     return if (scale < 1f) ImageUtils.scale(image, scale, scale) else image
   }
@@ -617,6 +622,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   companion object {
+    internal const val DEFAULT_THUMBNAIL_SIZE = 1000
+
     /** The choreographer doesn't like 0 as a frame time, so start an hour later. */
     internal val TIME_OFFSET_NANOS = TimeUnit.HOURS.toNanos(1L)
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/ThumbnailScale.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/ThumbnailScale.kt
@@ -1,0 +1,16 @@
+package app.cash.paparazzi
+
+sealed interface ThumbnailScale {
+
+  /**
+   * Thumbnails should not be scaled
+   */
+  object NoScale : ThumbnailScale
+
+  /**
+   * Scale thumbnail to have max side less or equal to [size]
+   */
+  data class ScaleMaxSideTo(
+    val size: Int
+  ) : ThumbnailScale
+}


### PR DESCRIPTION
Currently `Paparazzi` limits thumbnail size (I suppose for saving space).
But there's some tasks where it is not a good approach:

1. `Paparazzi` can be used for screenshot generation (that's my case)
2. I suppose current behavior will drastically affect long screenshots image quality

This PR adds new API. 
You can prodvide instance of `ThumbnailScale` into `Paparazzi` constructor.

`ThumbnailScale` can be:
- `NoScale` - image would not be scaled at all
- `ScaleMaxSideTo` - current behavior. Image will be scaled for max side to be no longer than `ScaleMaxSideTo.size`.