### PR TITLE
Move to using Gradle version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ buildscript {
   }
 
   dependencies {
-    classpath(libs.kotlinGradlePlugin)
-    classpath(libs.androidGradlePlugin)
-    classpath(libs.versionsGradlePlugin)
-    classpath(libs.spotlessGradlePlugin)
+    classpath(libs.plugin.kotlin)
+    classpath(libs.plugin.android)
+    classpath(libs.plugin.versions)
+    classpath(libs.plugin.spotless)
 
     // Normally you would declare a version here, but we use dependency substitution in
     // settings.gradle to use the version built from inside the repo.

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
-  apply from: 'gradle/dependencies.gradle'
-
   repositories {
     mavenCentral()
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ buildscript {
   }
 
   dependencies {
-    classpath deps.plugins.kotlin
-    classpath deps.plugins.android
-    classpath deps.plugins.versions
-    classpath deps.plugins.spotless
+    classpath(libs.kotlinGradlePlugin)
+    classpath(libs.androidGradlePlugin)
+    classpath(libs.versionsGradlePlugin)
+    classpath(libs.spotlessGradlePlugin)
 
     // Normally you would declare a version here, but we use dependency substitution in
     // settings.gradle to use the version built from inside the repo.

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ buildscript {
   }
 
   dependencies {
-    classpath(libs.plugin.kotlin)
-    classpath(libs.plugin.android)
-    classpath(libs.plugin.versions)
-    classpath(libs.plugin.spotless)
+    classpath libs.plugin.kotlin
+    classpath libs.plugin.android
+    classpath libs.plugin.versions
+    classpath libs.plugin.spotless
 
     // Normally you would declare a version here, but we use dependency substitution in
     // settings.gradle to use the version built from inside the repo.

--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,13 @@ subprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = libs.versions.java.target.get()
+    targetCompatibility = libs.versions.java.target.get()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
     kotlinOptions {
-      jvmTarget = "1.8"
+      jvmTarget = libs.versions.java.target.get()
     }
   }
 
@@ -53,7 +53,7 @@ subprojects {
     kotlin {
       target("src/**/*.kt")
       // ktlint doesn't honour .editorconfig yet: https://github.com/diffplug/spotless/issues/142
-      ktlint('0.46.1').editorConfigOverride([
+      ktlint(libs.versions.ktlint.get()).editorConfigOverride([
         'insert_final_newline': 'true',
         'end_of_line': 'lf',
         'charset': 'utf-8',

--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,13 @@ subprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = libs.versions.java.target.get()
-    targetCompatibility = libs.versions.java.target.get()
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
     kotlinOptions {
-      jvmTarget = libs.versions.java.target.get()
+      jvmTarget = libs.versions.javaTarget.get()
     }
   }
 
@@ -72,4 +72,3 @@ tasks.register("clean", Delete).configure {
 tasks.named("wrapper").configure {
   distributionType = Wrapper.DistributionType.ALL
 }
-

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,48 +6,10 @@ buildscript {
   ext.layoutLibPrebuiltSha = 'fa3aa65'
 
   ext.versions = [
-    kotlin: '1.7.10',
-    agp: '7.1.2',
     layoutlib: "2021.2.1-patch1-$layoutLibPrebuiltSha",
-    composeMaterial: '1.2.1',
-    composeCompiler:'1.3.0',
-    jcodec: '0.2.5',
-    moshi: '1.13.0',
-    bytebuddy: '1.12.10',
   ]
 
   ext.deps = [
-    plugins: [
-      android: "com.android.tools.build:gradle:${versions.agp}",
-      kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-      versions: 'com.github.ben-manes:gradle-versions-plugin:0.42.0',
-      spotless: 'com.diffplug.spotless:spotless-plugin-gradle:6.8.0'
-    ],
-    compose: [
-      compiler: "androidx.compose.compiler:compiler:${versions.composeCompiler}"
-    ],
-    composeUI: [
-      material: "androidx.compose.material:material:${versions.composeMaterial}"
-    ],
-    kotlin: [
-      bom: "org.jetbrains.kotlin:kotlin-bom:${versions.kotlin}",
-    ],
-    kotlinx: [
-      coroutines: [
-        core: 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4',
-      ],
-    ],
-    tools: [
-      common: 'com.android.tools:common:27.1.2',
-      layoutlib: 'com.android.tools.layoutlib:layoutlib-api:27.2.2',
-      sdkcommon: 'com.android.tools:sdk-common:26.6.4',
-      ninepatch: 'com.android.tools:ninepatch:30.1.2',
-    ],
-    kxml2: 'kxml2:kxml2:2.3.0',
-    androidx: [
-      annotations: 'androidx.annotation:annotation:1.3.0',
-      lifecycleCommon: 'androidx.lifecycle:lifecycle-common:2.4.0',
-    ],
     layoutlib: [
       native: [
         jdk11: "app.cash.paparazzi:layoutlib-native-jdk11:${versions.layoutlib}",
@@ -57,24 +19,5 @@ buildscript {
         linux: "app.cash.paparazzi:layoutlib-native-linux:${versions.layoutlib}",
       ]
     ],
-    okio: 'com.squareup.okio:okio:3.1.0',
-    moshi: [
-      core: "com.squareup.moshi:moshi:${versions.moshi}",
-      adapters: "com.squareup.moshi:moshi-adapters:${versions.moshi}",
-      kotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
-    ],
-    jcodec: [
-      core: "org.jcodec:jcodec:${versions.jcodec}",
-      javase: "org.jcodec:jcodec-javase:${versions.jcodec}"
-    ],
-    bytebuddy: [
-      core: "net.bytebuddy:byte-buddy:${versions.bytebuddy}",
-      agent: "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}",
-    ],
-    guava: 'com.google.guava:guava:31.0.1-jre',
-    junit: 'junit:junit:4.13.2',
-    truth: 'com.google.truth:truth:1.1.3',
-    assertj: 'org.assertj:assertj-core:3.23.1',
-    testparameterinjector: 'com.google.testparameterinjector:test-parameter-injector:1.8',
   ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,23 +1,3 @@
 buildscript {
   ext.repoDir = new File("$rootProject.buildDir/prebuilts/studio/layoutlib")
-
-  // maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
-  // which runs on JDK 11
-  ext.layoutLibPrebuiltSha = 'fa3aa65'
-
-  ext.versions = [
-    layoutlib: "2021.2.1-patch1-$layoutLibPrebuiltSha",
-  ]
-
-  ext.deps = [
-    layoutlib: [
-      native: [
-        jdk11: "app.cash.paparazzi:layoutlib-native-jdk11:${versions.layoutlib}",
-        macArm: "app.cash.paparazzi:layoutlib-native-macarm:${versions.layoutlib}",
-        macOsX: "app.cash.paparazzi:layoutlib-native-macosx:${versions.layoutlib}",
-        windows: "app.cash.paparazzi:layoutlib-native-win:${versions.layoutlib}",
-        linux: "app.cash.paparazzi:layoutlib-native-linux:${versions.layoutlib}",
-      ]
-    ],
-  ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,3 +1,0 @@
-buildscript {
-  ext.repoDir = new File("$rootProject.buildDir/prebuilts/studio/layoutlib")
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,43 +1,21 @@
 [versions]
 kotlin = "1.7.10"
-kotlin-coroutines = "1.6.4"
 java-target = "1.8"
 
 # Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
 # because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
+
 androidx-compose-compiler = "1.3.0"
-androidx-compose-ui-material = "1.2.1"
-androidx-lifecycle = "2.4.0"
-androidx-annotations = "1.3.0"
 
-agp = "7.1.2"
-mavenPublish = "0.21.0"
-gradle-versions = "0.42.0"
-grgit = "5.0.0"
-spotless = "6.8.0"
 ktlint = "0.46.1"
-
-tools-common = "27.1.2"
-tools-sdkCommon = "26.6.4"
-tools-layoutlib = "27.2.2"
-tools-ninepatch = "30.1.2"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
 layoutLibPrebuiltSha = 'fa3aa65'
 layoutlib = "2021.2.1-patch1-fa3aa65"
 
-
-guava = "31.0.1-jre"
-kxml2 = "2.3.0"
-okio = "3.1.0"
 moshi = "1.13.0"
 jcodec = "0.2.5"
 bytebuddy = "1.12.10"
-
-junit = "4.13.2"
-testParameterInjector = "1.8"
-truth = "1.1.3"
-assertj = "3.23.1"
 
 [libraries]
 layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
@@ -46,22 +24,22 @@ layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx
 layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win", version.ref = "layoutlib" }
 layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }
 
-tools-common = { module = "com.android.tools:common", version.ref = "tools-common" }
-tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version.ref = "tools-layoutlib" }
-tools-ninepatch = { module = "com.android.tools:ninepatch", version.ref = "tools-ninepatch" }
-tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "tools-sdkCommon" }
+tools-common = { module = "com.android.tools:common", version = "27.1.2" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
+tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
+tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
 
-androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
+androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
-androidx-compose-ui-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-ui-material" }
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
+androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
 
-guava = { module = "com.google.guava:guava", version.ref = "guava" }
-kxml2 = { module = "kxml2:kxml2", version.ref = "kxml2" }
-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
+kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
+okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
@@ -72,15 +50,15 @@ jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
 bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
-junit = { module = "junit:junit", version.ref = "junit" }
-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }
-truth = { module = "com.google.truth:truth", version.ref = "truth" }
-assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+junit = { module = "junit:junit", version = "4.13.2" }
+testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
+truth = { module = "com.google.truth:truth", version = "1.1.3" }
+assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 
-plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+plugin-android = { module = "com.android.tools.build:gradle", version = "7.1.2" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
-plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version.ref = "grgit" }
+plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.0.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
-plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradle-versions" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
+plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
+plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ java-target = "1.8"
 # Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
 # because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
 
-androidx-compose-compiler = "1.3.0"
+compose-compiler = "1.3.0"
 
 ktlint = "0.46.1"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
@@ -30,9 +30,9 @@ tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
 tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
 
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
-androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
+composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+androidx-lifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,21 @@
 [versions]
 kotlin = "1.7.10"
 kotlin-coroutines = "1.6.4"
+java-target = "1.8"
+
+# Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
+# because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
 androidx-compose-compiler = "1.3.0"
 androidx-compose-ui-material = "1.2.1"
+androidx-lifecycle = "2.4.0"
+androidx-annotations = "1.3.0"
 
 agp = "7.1.2"
 mavenPublish = "0.21.0"
 gradle-versions = "0.42.0"
 grgit = "5.0.0"
 spotless = "6.8.0"
+ktlint = "0.46.1"
 
 tools-common = "27.1.2"
 tools-sdkCommon = "26.6.4"
@@ -19,8 +26,6 @@ tools-ninepatch = "30.1.2"
 layoutLibPrebuiltSha = 'fa3aa65'
 layoutlib = "2021.2.1-patch1-fa3aa65"
 
-androidx-annotations = "1.3.0"
-androidx-lifecycle = "2.4.0"
 
 guava = "31.0.1-jre"
 kxml2 = "2.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,11 +50,13 @@ jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
 bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
+# Test libraries
 junit = { module = "junit:junit", version = "4.13.2" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 
+# Plugins
 plugin-android = { module = "com.android.tools.build:gradle", version = "7.1.2" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
 plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,11 @@ jcodec = "0.2.5"
 kotlin = "1.7.10"
 moshi = "1.13.0"
 
+# Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
+# which runs on JDK 11.
+layoutLibPrebuiltSha = 'fa3aa65'
+layoutlib = "2021.2.1-patch1-fa3aa65"
+
 [libraries]
 # Gradle plugins
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -40,3 +45,9 @@ tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", versio
 tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
 tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
+
+layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
+layoutlib-native-macArm = { module = "app.cash.paparazzi:layoutlib-native-macarm", version.ref = "layoutlib" }
+layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx", version.ref = "layoutlib" }
+layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win", version.ref = "layoutlib" }
+layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
-agp = "7.1.2"
-bytebuddy = "1.12.10"
-jcodec = "0.2.5"
 kotlin = "1.7.10"
+agp = "7.1.2"
+
+jcodec = "0.2.5"
 moshi = "1.13.0"
+bytebuddy = "1.12.10"
 
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
@@ -11,43 +12,47 @@ layoutLibPrebuiltSha = 'fa3aa65'
 layoutlib = "2021.2.1-patch1-fa3aa65"
 
 [libraries]
-# Gradle plugins
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
+plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
 plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version= "5.0.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
 
-# Regular dependencies
-androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
-androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
-assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
-bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
-guava =  { module = "com.google.guava:guava", version = "31.0.1-jre" }
-jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
-jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
-junit = { module = "junit:junit", version = "4.13.2" }
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
-kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
-moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
-moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
-truth = { module = "com.google.truth:truth", version = "1.1.3" }
-tools-common = { module = "com.android.tools:common", version = "27.1.2" }
-tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
-tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
-tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
-okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
-
 layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
 layoutlib-native-macArm = { module = "app.cash.paparazzi:layoutlib-native-macarm", version.ref = "layoutlib" }
 layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx", version.ref = "layoutlib" }
 layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win", version.ref = "layoutlib" }
 layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }
+
+tools-common = { module = "com.android.tools:common", version = "27.1.2" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
+tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
+tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
+
+androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
+androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+
+guava =  { module = "com.google.guava:guava", version = "31.0.1-jre" }
+kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
+okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
+
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+
+jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
+jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
+bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+
+junit = { module = "junit:junit", version = "4.13.2" }
+testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
+truth = { module = "com.google.truth:truth", version = "1.1.3" }
+assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,3 @@ plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradle-versions" }
-
-[plugins]
-# No plugins, because ?, see plugin-* under [libraries].

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,42 @@
+[versions]
+agp = "7.1.2"
+bytebuddy = "1.12.10"
+jcodec = "0.2.5"
+kotlin = "1.7.10"
+moshi = "1.13.0"
+
+[libraries]
+# Gradle plugins
+androidGradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
+grgitGradlePlugin = { module = "org.ajoberstar.grgit:grgit-gradle", version= "5.0.0" }
+kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
+spotlessGradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
+versionsGradlePlugin = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
+
+# Regular dependencies
+androidxAnnotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
+androidxComposeCompiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
+androidxComposeMaterial = { module = "androidx.compose.material:material", version = "1.2.1" }
+androidxLifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
+bytebuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
+bytebuddyCore = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+guava =  { module = "com.google.guava:guava", version = "31.0.1-jre" }
+jcodecCore = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
+jcodecJavase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+junit = { module = "junit:junit", version = "4.13.2" }
+kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
+moshiAdapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshiCore = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshiKotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
+truth = { module = "com.google.truth:truth", version = "1.1.3" }
+toolsCommon = { module = "com.android.tools:common", version = "27.1.2" }
+toolsLayoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
+toolsNinepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
+toolsSdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
+okio = { module = "com.squareup.okio:okio", version = "3.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,60 +1,62 @@
 [versions]
-kotlin = "1.7.10"
-java-target = "1.8"
-
-# Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
-# because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
-
+bytebuddy = "1.12.10"
 compose-compiler = "1.3.0"
-
+java-target = "1.8"
+jcodec = "0.2.5"
+kotlin = "1.7.10"
 ktlint = "0.46.1"
+moshi = "1.13.0"
+
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
 layoutlib = "2021.2.1-patch1-fa3aa65"
 layoutlib-prebuiltSha = 'fa3aa65'
 
-moshi = "1.13.0"
-jcodec = "0.2.5"
-bytebuddy = "1.12.10"
+# Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
+# because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
 
 [libraries]
+androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
+androidx-lifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+
+bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
+bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
+composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+
+guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
+
+jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
+jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+
+kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
+
 layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
+layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }
 layoutlib-native-macArm = { module = "app.cash.paparazzi:layoutlib-native-macarm", version.ref = "layoutlib" }
 layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx", version.ref = "layoutlib" }
 layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win", version.ref = "layoutlib" }
-layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }
+
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+
+okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
 tools-common = { module = "com.android.tools:common", version = "27.1.2" }
 tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
 tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
 tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
 
-androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
-androidx-lifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
-
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
-
-guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
-kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
-okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
-
-moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
-moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
-
-jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
-jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
-bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
-
 # Test libraries
+assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 junit = { module = "junit:junit", version = "4.13.2" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
-assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 
 # Plugins
 plugin-android = { module = "com.android.tools.build:gradle", version = "7.1.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,36 +7,36 @@ moshi = "1.13.0"
 
 [libraries]
 # Gradle plugins
-androidGradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
-grgitGradlePlugin = { module = "org.ajoberstar.grgit:grgit-gradle", version= "5.0.0" }
-kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
-spotlessGradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
-versionsGradlePlugin = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
+plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
+plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version= "5.0.0" }
+plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
+plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
+plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
 
 # Regular dependencies
-androidxAnnotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
-androidxComposeCompiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
-androidxComposeMaterial = { module = "androidx.compose.material:material", version = "1.2.1" }
-androidxLifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
+androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
 assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
-bytebuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
-bytebuddyCore = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
+bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 guava =  { module = "com.google.guava:guava", version = "31.0.1-jre" }
-jcodecCore = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
-jcodecJavase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
+jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
 junit = { module = "junit:junit", version = "4.13.2" }
-kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
 kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
-moshiAdapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
-moshiCore = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshiKotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
-toolsCommon = { module = "com.android.tools:common", version = "27.1.2" }
-toolsLayoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
-toolsNinepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
-toolsSdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
+tools-common = { module = "com.android.tools:common", version = "27.1.2" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
+tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
+tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
+agp = "7.1.2"
 bytebuddy = "1.12.10"
-compose-compiler = "1.3.0"
-java-target = "1.8"
+composeCompiler = "1.3.0"
+javaTarget = "1.8"
 jcodec = "0.2.5"
 kotlin = "1.7.10"
 ktlint = "0.46.1"
@@ -10,10 +11,7 @@ moshi = "1.13.0"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
 layoutlib = "2021.2.1-patch1-fa3aa65"
-layoutlibPrebuiltSha = 'fa3aa65'
-
-# Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
-# because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.
+layoutlibPrebuiltSha = "fa3aa65"
 
 [libraries]
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
@@ -22,7 +20,7 @@ androidx-lifecycleCommon = { module = "androidx.lifecycle:lifecycle-common", ver
 bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
 
 guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
@@ -43,7 +41,7 @@ layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win",
 
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+moshi-kotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
@@ -59,7 +57,7 @@ testParameterInjector = { module = "com.google.testparameterinjector:test-parame
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 
 # Plugins
-plugin-android = { module = "com.android.tools.build:gradle", version = "7.1.2" }
+plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
 plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.0.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ moshi = "1.13.0"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
 layoutlib = "2021.2.1-patch1-fa3aa65"
-layoutlib-prebuiltSha = 'fa3aa65'
+layoutlibPrebuiltSha = 'fa3aa65'
 
 # Note: there are some compose/androidx versions left hardcoded in `paparazzi/paparazzi/build.gradle`,
 # because they refer to JAR files names in the `paparazzi/paparazzi/libs` folder.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,47 @@
 [versions]
 kotlin = "1.7.10"
+kotlin-coroutines = "1.6.4"
+androidx-compose-compiler = "1.3.0"
+androidx-compose-ui-material = "1.2.1"
+
 agp = "7.1.2"
+mavenPublish = "0.21.0"
+gradle-versions = "0.42.0"
+grgit = "5.0.0"
+spotless = "6.8.0"
 
-jcodec = "0.2.5"
-moshi = "1.13.0"
-bytebuddy = "1.12.10"
-
+tools-common = "27.1.2"
+tools-sdkCommon = "26.6.4"
+tools-layoutlib = "27.2.2"
+tools-ninepatch = "30.1.2"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
 layoutLibPrebuiltSha = 'fa3aa65'
 layoutlib = "2021.2.1-patch1-fa3aa65"
 
+androidx-annotations = "1.3.0"
+androidx-lifecycle = "2.4.0"
+
+guava = "31.0.1-jre"
+kxml2 = "2.3.0"
+okio = "3.1.0"
+moshi = "1.13.0"
+jcodec = "0.2.5"
+bytebuddy = "1.12.10"
+
+junit = "4.13.2"
+testParameterInjector = "1.8"
+truth = "1.1.3"
+assertj = "3.23.1"
+
 [libraries]
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
-plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version= "5.0.0" }
+plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version.ref = "grgit" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
-plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
-plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
+plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradle-versions" }
 
 layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
 layoutlib-native-macArm = { module = "app.cash.paparazzi:layoutlib-native-macarm", version.ref = "layoutlib" }
@@ -26,22 +49,22 @@ layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx
 layoutlib-native-windows = { module = "app.cash.paparazzi:layoutlib-native-win", version.ref = "layoutlib" }
 layoutlib-native-linux = { module = "app.cash.paparazzi:layoutlib-native-linux", version.ref = "layoutlib" }
 
-tools-common = { module = "com.android.tools:common", version = "27.1.2" }
-tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
-tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.2" }
-tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "26.6.4" }
+tools-common = { module = "com.android.tools:common", version.ref = "tools-common" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version.ref = "tools-layoutlib" }
+tools-ninepatch = { module = "com.android.tools:ninepatch", version.ref = "tools-ninepatch" }
+tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "tools-sdkCommon" }
 
-androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "1.3.0" }
-androidx-compose-ui-material = { module = "androidx.compose.material:material", version = "1.2.1" }
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version = "2.4.0" }
+androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
+androidx-compose-ui-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-ui-material" }
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 
-guava =  { module = "com.google.guava:guava", version = "31.0.1-jre" }
-kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
-okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+kxml2 = { module = "kxml2:kxml2", version.ref = "kxml2" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
@@ -52,7 +75,7 @@ jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
 bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
-junit = { module = "junit:junit", version = "4.13.2" }
-testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.8" }
-truth = { module = "com.google.truth:truth", version = "1.1.3" }
-assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
+junit = { module = "junit:junit", version.ref = "junit" }
+testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,14 +35,6 @@ truth = "1.1.3"
 assertj = "3.23.1"
 
 [libraries]
-plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
-plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version.ref = "grgit" }
-plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
-plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradle-versions" }
-
 layoutlib-native-jdk11 = { module = "app.cash.paparazzi:layoutlib-native-jdk11", version.ref = "layoutlib" }
 layoutlib-native-macArm = { module = "app.cash.paparazzi:layoutlib-native-macarm", version.ref = "layoutlib" }
 layoutlib-native-macOsX = { module = "app.cash.paparazzi:layoutlib-native-macosx", version.ref = "layoutlib" }
@@ -79,3 +71,14 @@ junit = { module = "junit:junit", version.ref = "junit" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
+plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version.ref = "grgit" }
+plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
+plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradle-versions" }
+
+[plugins]
+# No plugins, because ?, see plugin-* under [libraries].

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ compose-compiler = "1.3.0"
 ktlint = "0.46.1"
 # Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/fa3aa65
 # which runs on JDK 11.
-layoutLibPrebuiltSha = 'fa3aa65'
 layoutlib = "2021.2.1-patch1-fa3aa65"
+layoutlib-prebuiltSha = 'fa3aa65'
 
 moshi = "1.13.0"
 jcodec = "0.2.5"

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -11,13 +11,13 @@ buildscript {
   }
 
   dependencies {
-    classpath(libs.plugin.kotlin)
-    classpath(libs.plugin.android)
-    classpath(libs.plugin.mavenPublish)
-    classpath(libs.plugin.grgit)
-    classpath(libs.plugin.dokka)
-    classpath(libs.plugin.versions)
-    classpath(libs.plugin.spotless)
+    classpath libs.plugin.kotlin
+    classpath libs.plugin.android
+    classpath libs.plugin.mavenPublish
+    classpath libs.plugin.grgit
+    classpath libs.plugin.dokka
+    classpath libs.plugin.versions
+    classpath libs.plugin.spotless
   }
 }
 

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -11,13 +11,13 @@ buildscript {
   }
 
   dependencies {
-    classpath(libs.kotlinGradlePlugin)
-    classpath(libs.androidGradlePlugin)
-    classpath(libs.mavenPublishGradlePlugin)
-    classpath(libs.grgitGradlePlugin)
-    classpath(libs.dokkaGradlePlugin)
-    classpath(libs.versionsGradlePlugin)
-    classpath(libs.spotlessGradlePlugin)
+    classpath(libs.plugin.kotlin)
+    classpath(libs.plugin.android)
+    classpath(libs.plugin.mavenPublish)
+    classpath(libs.plugin.grgit)
+    classpath(libs.plugin.dokka)
+    classpath(libs.plugin.versions)
+    classpath(libs.plugin.spotless)
   }
 }
 

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
-  apply from: '../gradle/dependencies.gradle'
-
   repositories {
     mavenCentral()
     google()

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -37,13 +37,13 @@ subprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = libs.versions.java.target.get()
+    targetCompatibility = libs.versions.java.target.get()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
     kotlinOptions {
-      jvmTarget = "1.8"
+      jvmTarget = libs.versions.java.target.get()
     }
   }
 
@@ -85,7 +85,7 @@ subprojects {
     kotlin {
       target("src/**/*.kt")
       // ktlint doesn't honour .editorconfig yet: https://github.com/diffplug/spotless/issues/142
-      ktlint('0.46.1').editorConfigOverride([
+      ktlint(libs.versions.ktlint.get()).editorConfigOverride([
         'insert_final_newline': 'true',
         'end_of_line': 'lf',
         'charset': 'utf-8',

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -11,13 +11,13 @@ buildscript {
   }
 
   dependencies {
-    classpath deps.plugins.kotlin
-    classpath deps.plugins.android
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.21.0'
-    classpath 'org.ajoberstar.grgit:grgit-gradle:5.0.0'
-    classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.10'
-    classpath deps.plugins.versions
-    classpath deps.plugins.spotless
+    classpath(libs.kotlinGradlePlugin)
+    classpath(libs.androidGradlePlugin)
+    classpath(libs.mavenPublishGradlePlugin)
+    classpath(libs.grgitGradlePlugin)
+    classpath(libs.dokkaGradlePlugin)
+    classpath(libs.versionsGradlePlugin)
+    classpath(libs.spotlessGradlePlugin)
   }
 }
 

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -37,13 +37,13 @@ subprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = libs.versions.java.target.get()
-    targetCompatibility = libs.versions.java.target.get()
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
     kotlinOptions {
-      jvmTarget = libs.versions.java.target.get()
+      jvmTarget = libs.versions.javaTarget.get()
     }
   }
 

--- a/paparazzi/libs/build.gradle
+++ b/paparazzi/libs/build.gradle
@@ -1,0 +1,1 @@
+ext.repoDir = new File("$rootProject.buildDir/prebuilts/studio/layoutlib")

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -10,7 +10,7 @@ version = libs.versions.layoutlib.get()
  */
 tasks.register('cloneLayoutlib') {
   it.outputs.dir(repoDir)
-  it.inputs.property('sha', libs.versions.layoutlib.prebuiltSha)
+  it.inputs.property('sha', libs.versions.layoutlibPrebuiltSha)
 
   doFirst {
     // Gradle aggressively creates outputs directories, which interferes with the git clone check
@@ -30,9 +30,9 @@ tasks.register('cloneLayoutlib') {
       dir = repoDir
     }
 
-    logger.warn("Checking out SHA ${libs.versions.layoutlib.prebuiltSha.get()}")
+    logger.warn("Checking out SHA ${libs.versions.layoutlibPrebuiltSha.get()}")
     repo.checkout {
-      branch = libs.versions.layoutlib.prebuiltSha.get()
+      branch = libs.versions.layoutlibPrebuiltSha.get()
     }
   }
 }

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = libs.versions.layoutlib
+version = libs.versions.layoutlib.get()
 
 /**
  * Clone AOSP's prebuilts repo to get a prebuilt layoutlib jar. This big repo that takes a long time to clone!
@@ -30,9 +30,9 @@ tasks.register('cloneLayoutlib') {
       dir = repoDir
     }
 
-    logger.warn("Checking out SHA ${libs.versions.layoutLibPrebuiltSha}")
+    logger.warn("Checking out SHA ${libs.versions.layoutLibPrebuiltSha.get()}")
     repo.checkout {
-      branch = libs.versions.layoutLibPrebuiltSha
+      branch = libs.versions.layoutLibPrebuiltSha.get()
     }
   }
 }

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -10,7 +10,7 @@ version = libs.versions.layoutlib.get()
  */
 tasks.register('cloneLayoutlib') {
   it.outputs.dir(repoDir)
-  it.inputs.property('sha', libs.versions.layoutLibPrebuiltSha)
+  it.inputs.property('sha', libs.versions.layoutlib.prebuiltSha)
 
   doFirst {
     // Gradle aggressively creates outputs directories, which interferes with the git clone check
@@ -30,9 +30,9 @@ tasks.register('cloneLayoutlib') {
       dir = repoDir
     }
 
-    logger.warn("Checking out SHA ${libs.versions.layoutLibPrebuiltSha.get()}")
+    logger.warn("Checking out SHA ${libs.versions.layoutlib.prebuiltSha.get()}")
     repo.checkout {
-      branch = libs.versions.layoutLibPrebuiltSha.get()
+      branch = libs.versions.layoutlib.prebuiltSha.get()
     }
   }
 }

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+version = libs.versions.layoutlib
 
 /**
  * Clone AOSP's prebuilts repo to get a prebuilt layoutlib jar. This big repo that takes a long time to clone!
@@ -10,7 +10,7 @@ version = versions.layoutlib
  */
 tasks.register('cloneLayoutlib') {
   it.outputs.dir(repoDir)
-  it.inputs.property('sha', layoutLibPrebuiltSha)
+  it.inputs.property('sha', libs.versions.layoutLibPrebuiltSha)
 
   doFirst {
     // Gradle aggressively creates outputs directories, which interferes with the git clone check
@@ -30,9 +30,9 @@ tasks.register('cloneLayoutlib') {
       dir = repoDir
     }
 
-    logger.warn("Checking out SHA $layoutLibPrebuiltSha")
+    logger.warn("Checking out SHA ${libs.versions.layoutLibPrebuiltSha}")
     repo.checkout {
-      branch = layoutLibPrebuiltSha
+      branch = libs.versions.layoutLibPrebuiltSha
     }
   }
 }

--- a/paparazzi/libs/native-linux/build.gradle
+++ b/paparazzi/libs/native-linux/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = libs.versions.layoutlib
+version = libs.versions.layoutlib.get()
 
 tasks.register('linuxJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-linux/build.gradle
+++ b/paparazzi/libs/native-linux/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+version = libs.versions.layoutlib
 
 tasks.register('linuxJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-macarm/build.gradle
+++ b/paparazzi/libs/native-macarm/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = libs.versions.layoutlib
+version = libs.versions.layoutlib.get()
 
 tasks.register('macArmJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-macarm/build.gradle
+++ b/paparazzi/libs/native-macarm/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+version = libs.versions.layoutlib
 
 tasks.register('macArmJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-macosx/build.gradle
+++ b/paparazzi/libs/native-macosx/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = libs.versions.layoutlib
+version = libs.versions.layoutlib.get()
 
 tasks.register('macJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-macosx/build.gradle
+++ b/paparazzi/libs/native-macosx/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+version = libs.versions.layoutlib
 
 tasks.register('macJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-win/build.gradle
+++ b/paparazzi/libs/native-win/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = libs.versions.layoutlib
+version = libs.versions.layoutlib.get()
 
 tasks.register('winJar', Jar) {
   from(repoDir) {

--- a/paparazzi/libs/native-win/build.gradle
+++ b/paparazzi/libs/native-win/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
-version = versions.layoutlib
+version = libs.versions.layoutlib
 
 tasks.register('winJar', Jar) {
   from(repoDir) {

--- a/paparazzi/paparazzi-agent/build.gradle
+++ b/paparazzi/paparazzi-agent/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
-  implementation deps.bytebuddy.core
-  implementation deps.bytebuddy.agent
-  api deps.junit
+  implementation(libs.bytebuddyCore)
+  implementation(libs.bytebuddyAgent)
+  api(libs.junit)
 
-  testImplementation deps.assertj
+  testImplementation(libs.assertj)
 }

--- a/paparazzi/paparazzi-agent/build.gradle
+++ b/paparazzi/paparazzi-agent/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
-  implementation(libs.bytebuddyCore)
-  implementation(libs.bytebuddyAgent)
+  implementation(libs.bytebuddy.core)
+  implementation(libs.bytebuddy.agent)
   api(libs.junit)
 
   testImplementation(libs.assertj)

--- a/paparazzi/paparazzi-agent/build.gradle
+++ b/paparazzi/paparazzi-agent/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
-  implementation(libs.bytebuddy.core)
-  implementation(libs.bytebuddy.agent)
-  api(libs.junit)
+  implementation libs.bytebuddy.core
+  implementation libs.bytebuddy.agent
+  api libs.junit
 
-  testImplementation(libs.assertj)
+  testImplementation libs.assertj
 }

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -41,7 +41,7 @@ def generateVersion = tasks.register("pluginVersion") {
     versionFile.text = """// Generated file. Do not edit!
 package app.cash.paparazzi
 const val VERSION = "${project.version}"
-const val NATIVE_LIB_VERSION = "${libs.versions.layoutlib}"
+const val NATIVE_LIB_VERSION = "${libs.versions.layoutlib.get()}"
 """
   }
 }

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -32,7 +32,7 @@ def generateVersion = tasks.register("pluginVersion") {
   def outputDir = file('src/generated/kotlin')
 
   inputs.property 'version', version
-  inputs.property 'nativeLibVersion', versions.layoutlib
+  inputs.property 'nativeLibVersion', libs.versions.layoutlib
   outputs.dir outputDir
 
   doLast {
@@ -41,7 +41,7 @@ def generateVersion = tasks.register("pluginVersion") {
     versionFile.text = """// Generated file. Do not edit!
 package app.cash.paparazzi
 const val VERSION = "${project.version}"
-const val NATIVE_LIB_VERSION = "${project.versions.layoutlib}"
+const val NATIVE_LIB_VERSION = "${libs.versions.layoutlib}"
 """
   }
 }

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -12,16 +12,16 @@ gradlePlugin {
 }
 
 dependencies {
-  compileOnly gradleApi()
-  implementation platform(deps.kotlin.bom)
-  implementation deps.plugins.kotlin
-  implementation deps.plugins.android
-  implementation(deps.tools.sdkcommon) {
+  compileOnly(gradleApi())
+  implementation(platform(libs.kotlinBom))
+  implementation(libs.kotlinGradlePlugin)
+  implementation(libs.androidGradlePlugin)
+  implementation(libs.toolsSdkCommon) {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }
 
 sourceSets {

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -13,10 +13,10 @@ gradlePlugin {
 
 dependencies {
   compileOnly(gradleApi())
-  implementation(platform(libs.kotlinBom))
-  implementation(libs.kotlinGradlePlugin)
-  implementation(libs.androidGradlePlugin)
-  implementation(libs.toolsSdkCommon) {
+  implementation(platform(libs.kotlin.bom))
+  implementation(libs.plugin.kotlin)
+  implementation(libs.plugin.android)
+  implementation(libs.tools.sdkCommon) {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -12,16 +12,16 @@ gradlePlugin {
 }
 
 dependencies {
-  compileOnly(gradleApi())
-  implementation(platform(libs.kotlin.bom))
-  implementation(libs.plugin.kotlin)
-  implementation(libs.plugin.android)
+  compileOnly gradleApi()
+  implementation platform(libs.kotlin.bom)
+  implementation libs.plugin.kotlin
+  implementation libs.plugin.android
   implementation(libs.tools.sdkCommon) {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 
-  testImplementation(libs.junit)
-  testImplementation(libs.truth)
+  testImplementation libs.junit
+  testImplementation libs.truth
 }
 
 sourceSets {

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -28,46 +28,46 @@ dependencies {
   // TODO: Use Gradle transforms to extract/rename classes.jar's from AARs
   api files('libs/compose-runtime-1.2.1.jar')
   compileOnly files('libs/compose-ui-1.2.1.jar')
-  compileOnly deps.androidx.lifecycleCommon
+  compileOnly(libs.androidxLifecycleCommon)
   compileOnly files('libs/lifecycle-runtime-2.5.0.jar')
   compileOnly files('libs/savedstate-1.2.0.jar')
 
-  api deps.layoutlib.native.jdk11
-  api deps.tools.common
-  api deps.tools.layoutlib
-  api deps.tools.ninepatch
-  api deps.tools.sdkcommon
-  api deps.kxml2
-  api deps.junit
-  api deps.androidx.annotations
-  api deps.guava
-  api deps.kotlinx.coroutines.core
-  api deps.okio
-  api platform(deps.kotlin.bom)
-  implementation deps.moshi.core
-  implementation deps.moshi.adapters
-  kapt deps.moshi.kotlinCodegen
-  implementation deps.jcodec.core
-  implementation deps.jcodec.javase
-  implementation projects.paparazziAgent
+  api(deps.layoutlib.native.jdk11)
+  api(libs.toolsCommon)
+  api(libs.toolsLayoutlib)
+  api(libs.toolsNinepatch)
+  api(libs.toolsSdkCommon)
+  api(libs.kxml2)
+  api(libs.junit)
+  api(libs.androidxAnnotations)
+  api(libs.guava)
+  api(libs.kotlinxCoroutinesCore)
+  api(libs.okio)
+  api(platform(libs.kotlinBom))
+  implementation(libs.moshiCore)
+  implementation(libs.moshiAdapters)
+  kapt(libs.moshiKotlinCodegen)
+  implementation(libs.jcodecCore)
+  implementation(libs.jcodecJavase)
+  implementation(projects.paparazziAgent)
 
   def osName = System.getProperty("os.name").toLowerCase(Locale.US)
   if (osName.startsWith("mac")) {
     def osArch = System.getProperty("os.arch").toLowerCase(Locale.US)
     if (osArch.startsWith("x86")) {
-      unzip deps.layoutlib.native.macOsX
+      unzip(deps.layoutlib.native.macOsX)
     } else {
-      unzip deps.layoutlib.native.macArm
+      unzip(deps.layoutlib.native.macArm)
     }
   } else if (osName.startsWith("windows")) {
-    unzip deps.layoutlib.native.windows
+    unzip(deps.layoutlib.native.windows)
   } else {
-    unzip deps.layoutlib.native.linux
+    unzip(deps.layoutlib.native.linux)
   }
 
-  testImplementation deps.assertj
+  testImplementation(libs.assertj)
 
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, deps.compose.compiler)
+  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME,(libs.androidxComposeCompiler))
 }
 
 tasks.named("dokkaGfm").configure {

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish'
 
-sourceCompatibility = libs.versions.java.target.get()
-targetCompatibility = libs.versions.java.target.get()
+sourceCompatibility = libs.versions.javaTarget.get()
+targetCompatibility = libs.versions.javaTarget.get()
 
 def artifactType = Attribute.of('artifactType', String)
 
@@ -46,7 +46,7 @@ dependencies {
   api platform(libs.kotlin.bom)
   implementation libs.moshi.core
   implementation libs.moshi.adapters
-  kapt libs.moshi.kotlin
+  kapt libs.moshi.kotlinCodegen
   implementation libs.jcodec.core
   implementation libs.jcodec.javase
   implementation projects.paparazziAgent

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = libs.versions.java.target.get()
+targetCompatibility = libs.versions.java.target.get()
 
 def artifactType = Attribute.of('artifactType', String)
 

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compileOnly files('libs/lifecycle-runtime-2.5.0.jar')
   compileOnly files('libs/savedstate-1.2.0.jar')
 
-  api deps.layoutlib.native.jdk11
+  api libs.layoutlib.native.jdk11
   api libs.tools.common
   api libs.tools.layoutlib
   api libs.tools.ninepatch
@@ -55,14 +55,14 @@ dependencies {
   if (osName.startsWith("mac")) {
     def osArch = System.getProperty("os.arch").toLowerCase(Locale.US)
     if (osArch.startsWith("x86")) {
-      unzip deps.layoutlib.native.macOsX
+      unzip libs.layoutlib.native.macOsX
     } else {
-      unzip deps.layoutlib.native.macArm
+      unzip libs.layoutlib.native.macArm
     }
   } else if (osName.startsWith("windows")) {
-    unzip deps.layoutlib.native.windows
+    unzip libs.layoutlib.native.windows
   } else {
-    unzip deps.layoutlib.native.linux
+    unzip libs.layoutlib.native.linux
   }
 
   testImplementation libs.assertj

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   // TODO: Use Gradle transforms to extract/rename classes.jar's from AARs
   api files('libs/compose-runtime-1.2.1.jar')
   compileOnly files('libs/compose-ui-1.2.1.jar')
-  compileOnly libs.androidx.lifecycle.common
+  compileOnly libs.androidx.lifecycleCommon
   compileOnly files('libs/lifecycle-runtime-2.5.0.jar')
   compileOnly files('libs/savedstate-1.2.0.jar')
 
@@ -67,7 +67,7 @@ dependencies {
 
   testImplementation libs.assertj
 
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.androidx.compose.compiler)
+  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.compose.compiler)
 }
 
 tasks.named("dokkaGfm").configure {

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -28,46 +28,46 @@ dependencies {
   // TODO: Use Gradle transforms to extract/rename classes.jar's from AARs
   api files('libs/compose-runtime-1.2.1.jar')
   compileOnly files('libs/compose-ui-1.2.1.jar')
-  compileOnly(libs.androidx.lifecycle.common)
+  compileOnly libs.androidx.lifecycle.common
   compileOnly files('libs/lifecycle-runtime-2.5.0.jar')
   compileOnly files('libs/savedstate-1.2.0.jar')
 
-  api(deps.layoutlib.native.jdk11)
-  api(libs.tools.common)
-  api(libs.tools.layoutlib)
-  api(libs.tools.ninepatch)
-  api(libs.tools.sdkCommon)
-  api(libs.kxml2)
-  api(libs.junit)
-  api(libs.androidx.annotations)
-  api(libs.guava)
-  api(libs.kotlinx.coroutines.core)
-  api(libs.okio)
-  api(platform(libs.kotlin.bom))
-  implementation(libs.moshi.core)
-  implementation(libs.moshi.adapters)
-  kapt(libs.moshi.kotlin)
-  implementation(libs.jcodec.core)
-  implementation(libs.jcodec.javase)
-  implementation(projects.paparazziAgent)
+  api deps.layoutlib.native.jdk11
+  api libs.tools.common
+  api libs.tools.layoutlib
+  api libs.tools.ninepatch
+  api libs.tools.sdkCommon
+  api libs.kxml2
+  api libs.junit
+  api libs.androidx.annotations
+  api libs.guava
+  api libs.kotlinx.coroutines.core
+  api libs.okio
+  api platform(libs.kotlin.bom)
+  implementation libs.moshi.core
+  implementation libs.moshi.adapters
+  kapt libs.moshi.kotlin
+  implementation libs.jcodec.core
+  implementation libs.jcodec.javase
+  implementation projects.paparazziAgent
 
   def osName = System.getProperty("os.name").toLowerCase(Locale.US)
   if (osName.startsWith("mac")) {
     def osArch = System.getProperty("os.arch").toLowerCase(Locale.US)
     if (osArch.startsWith("x86")) {
-      unzip(deps.layoutlib.native.macOsX)
+      unzip deps.layoutlib.native.macOsX
     } else {
-      unzip(deps.layoutlib.native.macArm)
+      unzip deps.layoutlib.native.macArm
     }
   } else if (osName.startsWith("windows")) {
-    unzip(deps.layoutlib.native.windows)
+    unzip deps.layoutlib.native.windows
   } else {
-    unzip(deps.layoutlib.native.linux)
+    unzip deps.layoutlib.native.linux
   }
 
-  testImplementation(libs.assertj)
+  testImplementation libs.assertj
 
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME,(libs.androidx.compose.compiler))
+  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.androidx.compose.compiler)
 }
 
 tasks.named("dokkaGfm").configure {

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -28,27 +28,27 @@ dependencies {
   // TODO: Use Gradle transforms to extract/rename classes.jar's from AARs
   api files('libs/compose-runtime-1.2.1.jar')
   compileOnly files('libs/compose-ui-1.2.1.jar')
-  compileOnly(libs.androidxLifecycleCommon)
+  compileOnly(libs.androidx.lifecycle.common)
   compileOnly files('libs/lifecycle-runtime-2.5.0.jar')
   compileOnly files('libs/savedstate-1.2.0.jar')
 
   api(deps.layoutlib.native.jdk11)
-  api(libs.toolsCommon)
-  api(libs.toolsLayoutlib)
-  api(libs.toolsNinepatch)
-  api(libs.toolsSdkCommon)
+  api(libs.tools.common)
+  api(libs.tools.layoutlib)
+  api(libs.tools.ninepatch)
+  api(libs.tools.sdkCommon)
   api(libs.kxml2)
   api(libs.junit)
-  api(libs.androidxAnnotations)
+  api(libs.androidx.annotations)
   api(libs.guava)
-  api(libs.kotlinxCoroutinesCore)
+  api(libs.kotlinx.coroutines.core)
   api(libs.okio)
-  api(platform(libs.kotlinBom))
-  implementation(libs.moshiCore)
-  implementation(libs.moshiAdapters)
-  kapt(libs.moshiKotlinCodegen)
-  implementation(libs.jcodecCore)
-  implementation(libs.jcodecJavase)
+  api(platform(libs.kotlin.bom))
+  implementation(libs.moshi.core)
+  implementation(libs.moshi.adapters)
+  kapt(libs.moshi.kotlin)
+  implementation(libs.jcodec.core)
+  implementation(libs.jcodec.javase)
   implementation(projects.paparazziAgent)
 
   def osName = System.getProperty("os.name").toLowerCase(Locale.US)
@@ -67,7 +67,7 @@ dependencies {
 
   testImplementation(libs.assertj)
 
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME,(libs.androidxComposeCompiler))
+  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME,(libs.androidx.compose.compiler))
 }
 
 tasks.named("dokkaGfm").configure {

--- a/paparazzi/settings.gradle
+++ b/paparazzi/settings.gradle
@@ -10,3 +10,11 @@ include ':libs:native-win'
 include ':libs:native-linux'
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+        	from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/paparazzi/settings.gradle
+++ b/paparazzi/settings.gradle
@@ -12,9 +12,9 @@ include ':libs:native-linux'
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 
 dependencyResolutionManagement {
-    versionCatalogs {
-        libs {
-        	from(files("../gradle/libs.versions.toml"))
-        }
+  versionCatalogs {
+    libs {
+      from(files("../gradle/libs.versions.toml"))
     }
+  }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,7 +12,7 @@ android {
     viewBinding true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion '1.3.0'
+    kotlinCompilerExtensionVersion libs.versions.androidx.compose.compiler.get()
   }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,5 +19,5 @@ android {
 dependencies {
   implementation deps.composeUI.material
 
-  testImplementation deps.testparameterinjector
+  testImplementation(libs.testParameterInjector)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,12 +12,12 @@ android {
     viewBinding true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion libs.versions.androidx.compose.compiler.get()
+    kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
   }
 }
 
 dependencies {
-  implementation libs.androidx.compose.ui.material
+  implementation libs.composeUi.material
 
   testImplementation libs.testParameterInjector
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-  implementation deps.composeUI.material
+  implementation libs.androidx.compose.ui.material
 
   testImplementation(libs.testParameterInjector)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,5 +19,5 @@ android {
 dependencies {
   implementation libs.androidx.compose.ui.material
 
-  testImplementation(libs.testParameterInjector)
+  testImplementation libs.testParameterInjector
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,7 +12,7 @@ android {
     viewBinding true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
+    kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
   }
 }
 


### PR DESCRIPTION
Migrating the project to use Gradle version datalog instead of gradle/dependencies.gradle script.

Based on @liutikas's #522, including recent Kotlin/Compose upgrade + review feedback and some more work.

Feel free to squash to master.