### PR TITLE
Remove deprecated `forUseAtConfigurationTime()`

### DIFF
--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -64,7 +64,7 @@ subprojects {
          */
         maven {
           name = "internal"
-          url = providers.gradleProperty("internalUrl").forUseAtConfigurationTime()
+          url = providers.gradleProperty("internalUrl")
           credentials(PasswordCredentials)
         }
       }


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation

> Provider#forUseAtConfigurationTime is now deprecated and scheduled for removal in Gradle 9.0. Clients should simply remove the call.