### PR TITLE
Expose an API for frame time

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -208,8 +208,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   @JvmOverloads
-  fun snapshot(view: View, name: String? = null, timeMillis: Long = 0L) {
-    takeSnapshots(view, name, TimeUnit.MILLISECONDS.toNanos(timeMillis), -1, 1)
+  fun snapshot(view: View, name: String? = null, offsetMillis: Long = 0L) {
+    takeSnapshots(view, name, TimeUnit.MILLISECONDS.toNanos(offsetMillis), -1, 1)
   }
 
   @JvmOverloads

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -208,8 +208,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   @JvmOverloads
-  fun snapshot(view: View, name: String? = null) {
-    takeSnapshots(view, name, 0, -1, 1)
+  fun snapshot(view: View, name: String? = null, timeNanos: Long = 0L) {
+    takeSnapshots(view, name, timeNanos, -1, 1)
   }
 
   @JvmOverloads

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -208,8 +208,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   @JvmOverloads
-  fun snapshot(view: View, name: String? = null, timeNanos: Long = 0L) {
-    takeSnapshots(view, name, timeNanos, -1, 1)
+  fun snapshot(view: View, name: String? = null, timeMillis: Long = 0L) {
+    takeSnapshots(view, name, TimeUnit.MILLISECONDS.toNanos(timeMillis), -1, 1)
   }
 
   @JvmOverloads

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -147,26 +147,26 @@ class PaparazziTest {
     animator.start()
     assertThat(AnimationHandler.getAnimationCount()).isEqualTo(1)
 
-    paparazzi.snapshot(view, timeMillis = 0L)
+    paparazzi.snapshot(view, offsetMillis = 0L)
     assertThat(log).containsExactly(
       "onDraw text="
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeMillis = 2_000L)
+    paparazzi.snapshot(view, offsetMillis = 2_000L)
     assertThat(log).containsExactly(
       "onAnimationStart uptimeMillis=2000",
       "onDraw text=0.0"
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeMillis = 2_500L)
+    paparazzi.snapshot(view, offsetMillis = 2_500L)
     assertThat(log).containsExactly(
       "onDraw text=0.5"
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeMillis = 3_000L)
+    paparazzi.snapshot(view, offsetMillis = 3_000L)
     assertThat(log).containsExactly(
       "onAnimationEnd uptimeMillis=3000",
       "onDraw text=1.0"

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -147,26 +147,26 @@ class PaparazziTest {
     animator.start()
     assertThat(AnimationHandler.getAnimationCount()).isEqualTo(1)
 
-    paparazzi.snapshot(view, timeNanos = 0L)
+    paparazzi.snapshot(view, timeMillis = 0L)
     assertThat(log).containsExactly(
       "onDraw text="
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeNanos = 2_000_000_000L)
+    paparazzi.snapshot(view, timeMillis = 2_000L)
     assertThat(log).containsExactly(
       "onAnimationStart uptimeMillis=2000",
       "onDraw text=0.0"
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeNanos = 2_500_000_000L)
+    paparazzi.snapshot(view, timeMillis = 2_500L)
     assertThat(log).containsExactly(
       "onDraw text=0.5"
     )
     log.clear()
 
-    paparazzi.snapshot(view, timeNanos = 3_000_000_000L)
+    paparazzi.snapshot(view, timeMillis = 3_000L)
     assertThat(log).containsExactly(
       "onAnimationEnd uptimeMillis=3000",
       "onDraw text=1.0"

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -149,27 +149,27 @@ class PaparazziTest {
 
     paparazzi.snapshot(view, timeNanos = 0L)
     assertThat(log).containsExactly(
-      "onDraw text=",
+      "onDraw text="
     )
     log.clear()
 
     paparazzi.snapshot(view, timeNanos = 2_000_000_000L)
     assertThat(log).containsExactly(
       "onAnimationStart uptimeMillis=2000",
-      "onDraw text=0.0",
+      "onDraw text=0.0"
     )
     log.clear()
 
     paparazzi.snapshot(view, timeNanos = 2_500_000_000L)
     assertThat(log).containsExactly(
-      "onDraw text=0.5",
+      "onDraw text=0.5"
     )
     log.clear()
 
     paparazzi.snapshot(view, timeNanos = 3_000_000_000L)
     assertThat(log).containsExactly(
       "onAnimationEnd uptimeMillis=3000",
-      "onDraw text=1.0",
+      "onDraw text=1.0"
     )
     assertThat(AnimationHandler.getAnimationCount()).isEqualTo(0)
     log.clear()

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -26,6 +26,7 @@ import android.view.Choreographer.CALLBACK_ANIMATION
 import android.view.View
 import android.view.animation.LinearInterpolator
 import android.widget.Button
+import android.widget.TextView
 import com.android.internal.lang.System_Delegate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Ignore
@@ -113,6 +114,65 @@ class PaparazziTest {
       "onAnimationEnd time=3000 animationElapsed=1.0",
       "onDraw time=3000 animationElapsed=1.0"
     )
+  }
+
+  @Test
+  fun animationCallbacksForStaticSnapshots() {
+    val log = mutableListOf<String>()
+
+    val view = object : TextView(paparazzi.context) {
+      override fun onDraw(canvas: Canvas) {
+        log += "onDraw text=$text"
+      }
+    }
+
+    val animator = ValueAnimator.ofInt(200, 300)
+    animator.addUpdateListener {
+      view.text = it.animatedFraction.toString()
+    }
+    animator.addListener(object : AnimatorListenerAdapter() {
+      override fun onAnimationStart(animation: Animator?, isReverse: Boolean) {
+        log += "onAnimationStart uptimeMillis=$time"
+      }
+
+      override fun onAnimationEnd(animator: Animator) {
+        log += "onAnimationEnd uptimeMillis=$time"
+      }
+    })
+
+    animator.startDelay = 2_000L
+    animator.duration = 1_000L
+    animator.interpolator = LinearInterpolator()
+    assertThat(AnimationHandler.getAnimationCount()).isEqualTo(0)
+    animator.start()
+    assertThat(AnimationHandler.getAnimationCount()).isEqualTo(1)
+
+    paparazzi.snapshot(view, timeNanos = 0L)
+    assertThat(log).containsExactly(
+      "onDraw text=",
+    )
+    log.clear()
+
+    paparazzi.snapshot(view, timeNanos = 2_000_000_000L)
+    assertThat(log).containsExactly(
+      "onAnimationStart uptimeMillis=2000",
+      "onDraw text=0.0",
+    )
+    log.clear()
+
+    paparazzi.snapshot(view, timeNanos = 2_500_000_000L)
+    assertThat(log).containsExactly(
+      "onDraw text=0.5",
+    )
+    log.clear()
+
+    paparazzi.snapshot(view, timeNanos = 3_000_000_000L)
+    assertThat(log).containsExactly(
+      "onAnimationEnd uptimeMillis=3000",
+      "onDraw text=1.0",
+    )
+    assertThat(AnimationHandler.getAnimationCount()).isEqualTo(0)
+    log.clear()
   }
 
   @Test


### PR DESCRIPTION
Allow capturing snapshots at arbitrary points in an animation. This is building on the same mechanism as our gif support, but without the complexity of choosing a video encoding format.