### PR TITLE
InstantAnimationsRule

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/InstantAnimationsRule.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/InstantAnimationsRule.kt
@@ -31,11 +31,12 @@ import org.junit.runners.model.Statement
  */
 class InstantAnimationsRule : TestRule {
   private val getDurationScale = ValueAnimator::class.java.getDeclaredMethod(
-    "getDurationScale",
+    "getDurationScale"
   )
 
   private val setDurationScale = ValueAnimator::class.java.getDeclaredMethod(
-    "setDurationScale", Float::class.javaPrimitiveType
+    "setDurationScale",
+    Float::class.javaPrimitiveType
   )
 
   private var durationScale: Float

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/InstantAnimationsRule.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/InstantAnimationsRule.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import android.animation.Animator.AnimatorListener
+import android.animation.ValueAnimator
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Sets animation duration scale to 0 so all animations run instantly. Use this with Paparazzi to
+ * skip animations and snapshot their terminal state.
+ *
+ * Note that animation side effects are still performed, including calls like
+ * [AnimatorListener.onAnimationEnd]. This way views from fade-ins and moves are rendered as they
+ * do when the animations complete.
+ */
+class InstantAnimationsRule : TestRule {
+  private val getDurationScale = ValueAnimator::class.java.getDeclaredMethod(
+    "getDurationScale",
+  )
+
+  private val setDurationScale = ValueAnimator::class.java.getDeclaredMethod(
+    "setDurationScale", Float::class.javaPrimitiveType
+  )
+
+  private var durationScale: Float
+    get() {
+      return getDurationScale.invoke(null) as Float
+    }
+    set(value) {
+      setDurationScale.invoke(null, value)
+    }
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        val scaleBefore = durationScale
+        durationScale = 0.0f
+        try {
+          base.evaluate()
+        } finally {
+          durationScale = scaleBefore
+        }
+      }
+    }
+  }
+}

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/InstantAnimationsRuleTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/InstantAnimationsRuleTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.graphics.Canvas
+import android.view.animation.LinearInterpolator
+import android.widget.TextView
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class InstantAnimationsRuleTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @get:Rule
+  val instantAnimationsRule = InstantAnimationsRule()
+
+  /**
+   * Confirm that animations and their event listeners are all executed immediately, even though
+   * they have both a start delay and a non-zero duration.
+   */
+  @Test
+  fun happyPath() {
+    val log = mutableListOf<String>()
+
+    val view = object : TextView(paparazzi.context) {
+      override fun onDraw(canvas: Canvas) {
+        log += "onDraw text=$text"
+      }
+    }
+
+    val animator = ValueAnimator.ofInt(200, 300)
+    animator.addUpdateListener {
+      view.text = it.animatedFraction.toString()
+    }
+    animator.addListener(object : AnimatorListenerAdapter() {
+      override fun onAnimationStart(animation: Animator?, isReverse: Boolean) {
+        log += "onAnimationStart"
+      }
+
+      override fun onAnimationEnd(animation: Animator?) {
+        log += "onAnimationEnd"
+      }
+    })
+
+    animator.startDelay = 20_000L
+    animator.duration = 10_000L
+    animator.interpolator = LinearInterpolator()
+    animator.start()
+
+    paparazzi.snapshot(view)
+    assertThat(log).containsExactly(
+      "onAnimationStart",
+      "onAnimationEnd",
+      "onDraw text=1.0"
+    )
+    log.clear()
+  }
+}


### PR DESCRIPTION
This is a utility that complements Paparazzi to prevent snapshots from capturing the first frame of an animation. Instead they capture the last frame.