### PR TITLE
Extract build dir via customizable system property

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -150,6 +150,8 @@ class PaparazziPlugin : Plugin<Project> {
       val testTaskProvider = project.tasks.named("test$testVariantSlug", Test::class.java) { test ->
         test.systemProperties["paparazzi.test.resources"] =
           writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
+        test.systemProperties["paparazzi.build.dir"] =
+          project.layout.buildDirectory.get().toString()
 
         test.inputs.dir(mergeResourcesOutputDir)
         test.inputs.dir(mergeAssetsOutputDir)

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -59,7 +59,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
   @get:OutputFile
   abstract val paparazziResources: RegularFileProperty
 
-  private val projectDirectory = project.layout.projectDirectory
+  private val buildDirectory = project.layout.buildDirectory
 
   @TaskAction
   // TODO: figure out why this can't be removed as of Kotlin 1.6+
@@ -79,6 +79,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
     } else {
       mainPackage
     }
+    val projectDirectory = buildDirectory.get()
 
     out.bufferedWriter()
       .use {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -568,8 +568,8 @@ class PaparazziPluginTest {
 
     val resourceFileContents = resourcesFile.readLines()
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
-    assertThat(resourceFileContents[1]).isEqualTo("build/intermediates/merged_res/debug")
-    assertThat(resourceFileContents[4]).isEqualTo("build/intermediates/assets/debug/mergeDebugAssets")
+    assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
+    assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug/mergeDebugAssets")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
   }
 
@@ -588,8 +588,8 @@ class PaparazziPluginTest {
 
     val resourceFileContents = resourcesFile.readLines()
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
-    assertThat(resourceFileContents[1]).isEqualTo("build/intermediates/merged_res/debug")
-    assertThat(resourceFileContents[4]).isEqualTo("build/intermediates/assets/debug/mergeDebugAssets")
+    assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
+    assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug/mergeDebugAssets")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
   }
 

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -110,6 +110,10 @@ tasks.withType(Test).configureEach {
     generateTestConfig.map { it.outputs.files.singleFile }.get().path
   )
   systemProperty(
+    "paparazzi.build.dir",
+    project.layout.buildDirectory.get().toString()
+  )
+  systemProperty(
     "paparazzi.platform.data.root",
     configurations.unzip.singleFile.absolutePath
   )

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -53,7 +53,7 @@ fun detectEnvironment(): Environment {
   val resourcesFile = File(System.getProperty("paparazzi.test.resources"))
   val configLines = resourcesFile.readLines()
 
-  val appTestDir = Paths.get(System.getProperty("user.dir"))
+  val appTestDir = Paths.get(System.getProperty("paparazzi.build.dir"))
   val androidHome = Paths.get(androidHome())
   return Environment(
     platformDir = androidHome.resolve(configLines[3]).toString(),


### PR DESCRIPTION
Gradle's build dir isn't necessarily MODULE/build, but can instead be anywhere.

Thanks for pairing @jrodbx !