### PR TITLE
Expose isVerifying and determineHandler

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "7.3.0"
+agp = "7.1.2"
 bytebuddy = "1.12.10"
 composeCompiler = "1.3.0"
 javaTarget = "1.8"
@@ -26,8 +26,6 @@ bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
-composeUi-iconscore = { module = "androidx.compose.material:material-icons-core", version = "1.2.1" }
-composeUi-iconsext = { module = "androidx.compose.material:material-icons-extended", version = "1.2.1" }
 
 guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "7.1.2"
+agp = "7.3.0"
 bytebuddy = "1.12.10"
 composeCompiler = "1.3.0"
 javaTarget = "1.8"
@@ -26,6 +26,8 @@ bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+composeUi-iconscore = { module = "androidx.compose.material:material-icons-core", version = "1.2.1" }
+composeUi-iconsext = { module = "androidx.compose.material:material-icons-extended", version = "1.2.1" }
 
 guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -619,10 +619,14 @@ class Paparazzi @JvmOverloads constructor(
 
     internal lateinit var sessionParamsBuilder: SessionParamsBuilder
 
-    private val isVerifying: Boolean =
+    /** Whether we are running in verify mode or report mode */
+    val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    /**
+     * Build the default handler.
+     */
+    fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
       if (isVerifying) {
         SnapshotVerifier(maxPercentDifference)
       } else {


### PR DESCRIPTION
Expose isVerifying and determineHandler. These are useful when implementing a decorating SnapshotHandler. Used for Wear and A11y reasons.

```
    snapshotHandler: SnapshotHandler = WearSnapshotHandler(
        determineHandler(maxPercentDifference),
        round = round
    ),
```

#fixes https://github.com/cashapp/paparazzi/issues/412