### PR TITLE
Fix incompatibility when used with compileSdk 33 projects

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "by
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
-composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+composeUi-material = { module = "androidx.compose.material:material", version = "1.3.0-rc01" }
 
 guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -144,7 +144,12 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   fun prepare(description: Description) {
-    forcePlatformSdkVersion(environment.compileSdkVersion)
+    if (environment.compileSdkVersion > 32) {
+      // The version of layout we're using only works up to SDK level 32, so we need to coerce
+      // the compileSdkVersion down to 32
+      forceBuildVersionProp("SDK_INT", 32)
+      forceBuildVersionProp("CODENAME", "Sv2")
+    }
 
     val layoutlibCallback =
       PaparazziCallback(logger, environment.packageName, environment.resourcePackageNames)
@@ -396,7 +401,7 @@ class Paparazzi @JvmOverloads constructor(
     return TestName(packageName, className, methodName)
   }
 
-  private fun forcePlatformSdkVersion(compileSdkVersion: Int) {
+  private fun forceBuildVersionProp(name: String, value: Any) {
     val buildVersionClass = try {
       Paparazzi::class.java.classLoader.loadClass("android.os.Build\$VERSION")
     } catch (e: ClassNotFoundException) {
@@ -404,8 +409,8 @@ class Paparazzi @JvmOverloads constructor(
       return
     }
     buildVersionClass
-      .getFieldReflectively("SDK_INT")
-      .setStaticValue(compileSdkVersion)
+      .getFieldReflectively(name)
+      .setStaticValue(value)
   }
 
   private fun initializeAppCompatIfPresent() {

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -149,6 +149,9 @@ class Paparazzi @JvmOverloads constructor(
       // the compileSdkVersion down to 32
       forceBuildVersionProp("SDK_INT", 32)
       forceBuildVersionProp("CODENAME", "Sv2")
+    } else {
+      // Otherwise we just pass through the compile sdk
+      forceBuildVersionProp("SDK_INT", environment.compileSdkVersion)
     }
 
     val layoutlibCallback =

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,7 +3,9 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'app.cash.paparazzi'
 
 android {
-  compileSdk libs.versions.compileSdk.get() as int
+  // We test against compile Sdk 33, to verify that the pinning behavior
+  // works
+  compileSdk 33
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }


### PR DESCRIPTION
The layoutlib version which Paparazzi is currently using, only supports up to SDK level 32. When a project using `compileSdkVersion` 33+ tries to use Paparazzi, lots of things break.

This is caused by Paparazzi Gradle plugin passing through the `compileSdkVersion` directly through to layoutlib. This PR changes that behavior, by coercing the SDK_INT (and CODENAME) values to be API 32 at most (to match layoutlib's support).

This means that projects using `compileSdkVersion` 33 will work as normal, just running on an API 32 host.