### PR TITLE
Configure HtmlReportWriter to use custom project.buildDir

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -115,6 +115,26 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun customBuildDir() {
+    val fixtureRoot = File("src/test/projects/custom-build-dir")
+
+    val result = gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .forwardOutput()
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+
+    val resourcesFile = File(fixtureRoot, "custom/intermediates/paparazzi/debug/resources.txt")
+    assertThat(resourcesFile.exists()).isTrue()
+
+    val snapshotsDir = File(fixtureRoot, "custom/reports/paparazzi/images")
+    assertThat(snapshotsDir.exists()).isTrue()
+
+    fixtureRoot.resolve("custom").deleteRecursively()
+  }
+
+  @Test
   fun missingPlatformDirTest() {
     val fixtureRoot = File("src/test/projects/missing-platform-dir")
 

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+project.buildDir = 'custom'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/src/test/java/app/cash/paparazzi/plugin/test/LaunchViewTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/src/test/java/app/cash/paparazzi/plugin/test/LaunchViewTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.view.View
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class LaunchViewTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun testViews() {
+    paparazzi.snapshot(View(paparazzi.context))
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -59,7 +59,7 @@ import javax.imageio.ImageIO
  */
 class HtmlReportWriter @JvmOverloads constructor(
   private val runName: String = defaultRunName(),
-  private val rootDirectory: File = File("build/reports/paparazzi"),
+  private val rootDirectory: File = File("${System.getProperty("paparazzi.build.dir", "build")}/reports/paparazzi"),
   snapshotRootDirectory: File = File("src/test/snapshots")
 ) : SnapshotHandler {
   private val runsDirectory: File = File(rootDirectory, "runs")


### PR DESCRIPTION
Pairing on https://github.com/cashapp/paparazzi/pull/588 with @chris-horner helped me understand the problem better in  https://github.com/cashapp/paparazzi/pull/408 and I've had a change of mind: let's not plumb this through the Environment object!  This will simplify things (hopefully) for the Bazel plugin support?

Closes https://github.com/cashapp/paparazzi/pull/408.