### PR TITLE
[Bugfix] java.lang.UnsupportedOperationException 

### DIFF
--- a/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -30,7 +30,7 @@ object InterceptorRegistrar {
           builder: DynamicType.Builder<*>,
           typeDescription: TypeDescription,
           classLoader: ClassLoader?,
-          module: JavaModule?,
+          module: JavaModule?
         ): DynamicType.Builder<*> {
           var builder = ByteBuddy().redefine(receiver)
           methodNamesToInterceptors.forEach {

--- a/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -12,6 +12,7 @@ import net.bytebuddy.utility.JavaModule
 
 object InterceptorRegistrar {
 
+  private val byteBuddy = ByteBuddy()
   private val methodInterceptors = mutableListOf<() -> Unit>()
 
   fun addMethodInterceptor(
@@ -32,7 +33,7 @@ object InterceptorRegistrar {
           classLoader: ClassLoader?,
           module: JavaModule?
         ): DynamicType.Builder<*> {
-          var builder = ByteBuddy().redefine(receiver)
+          var builder = byteBuddy.redefine(receiver)
           methodNamesToInterceptors.forEach {
             builder = builder
               .method(named(it.first))

--- a/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/paparazzi-agent/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -9,7 +9,6 @@ import net.bytebuddy.matcher.ElementMatchers.`is`
 import net.bytebuddy.matcher.ElementMatchers.named
 import net.bytebuddy.matcher.ElementMatchers.none
 import net.bytebuddy.utility.JavaModule
-import java.security.ProtectionDomain
 
 object InterceptorRegistrar {
 


### PR DESCRIPTION
Fixing a crash that appears when using Paparazzi with Java 18 and jacoco code coverage (including the stacktrace at the bottom)

**How the crash appears:**
Paparazzi agent and jacoco both manipulate the bytecode. When using `ByteBuddy.make().load()`, it doesn't pickup the changes made by Jacoco ([Similar Issue](https://github.com/raphw/byte-buddy/issues/1248)). To address this, I've used the suggestion made by `ByteBuddy` maintainer to use `AgentBuilder` instead of `make().load()`


Potentially related issues: https://github.com/cashapp/paparazzi/issues/384, https://github.com/cashapp/paparazzi/issues/364




**Stacktrace:**
```
java.lang.UnsupportedOperationException: class redefinition failed: attempted to delete a method
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:169)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at net.bytebuddy.utility.Invoker$Dispatcher.invoke(Unknown Source)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$Dispatcher$ForNonStaticMethod.invoke(JavaDispatcher.java:1028)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$ProxiedInvocationHandler.invoke(JavaDispatcher.java:1158)
	at net.bytebuddy.dynamic.loading.$Proxy33.retransformClasses(Unknown Source)
	at net.bytebuddy.dynamic.loading.ClassReloadingStrategy$Strategy$2.apply(ClassReloadingStrategy.java:399)
	at net.bytebuddy.dynamic.loading.ClassReloadingStrategy.load(ClassReloadingStrategy.java:227)
	at net.bytebuddy.dynamic.TypeResolutionStrategy$Passive.initialize(TypeResolutionStrategy.java:101)
	at net.bytebuddy.dynamic.DynamicType$Default$Unloaded.load(DynamicType.java:6166)
	at app.cash.paparazzi.agent.InterceptorRegistrar$addMethodInterceptors$1.invoke(InterceptorRegistrar.kt:34)
	at app.cash.paparazzi.agent.InterceptorRegistrar$addMethodInterceptors$1.invoke(InterceptorRegistrar.kt:22)
	at app.cash.paparazzi.agent.InterceptorRegistrar.registerMethodInterceptors(InterceptorRegistrar.kt:39)
	at app.cash.paparazzi.agent.AgentTestRule$apply$1.evaluate(AgentTestRule.kt:15)
	at com.instacart.client.rules.TimeZoneRule$apply$1.evaluate(TimeZoneRule.kt:16)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy2/jdk.proxy2.$Proxy5.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```