### PR TITLE
Only apply wear circle shape to full device screenshots.

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -373,7 +373,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   private fun frameImage(image: BufferedImage): BufferedImage {
-    if (deviceConfig.screenRound == ScreenRound.ROUND) {
+    // On device sized screenshot, we should apply any device specific shapes.
+    if (renderingMode == RenderingMode.NORMAL && deviceConfig.screenRound == ScreenRound.ROUND) {
       val newImage = BufferedImage(image.width, image.height, image.type)
       val g = newImage.createGraphics()
       g.clip = Ellipse2D.Float(0f, 0f, image.height.toFloat(), image.width.toFloat())


### PR DESCRIPTION
Only apply wear circle shape to full device screenshots.

#fixes https://github.com/cashapp/paparazzi/issues/609

