### PR TITLE
Bump Guava to 31.1-jre to match 31.1-android

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
 
-guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
+guava = { module = "com.google.guava:guava", version = "31.1-jre" }
 
 jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodec-javase = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }


### PR DESCRIPTION
Paparazzi currently uses Guava `31.0.1-jre`. The latest version of the Firebase SDK bumps the GRPC version
https://github.com/firebase/firebase-android-sdk/blob/d719e10c2a33adb77c22bee3b8dadf03d881693a/build.gradle#L53
which includes Guava `31.1-android`
https://github.com/grpc/grpc-java/blob/096898a46e8f15ce5eca07ee5231fcc458487202/gradle/libs.versions.toml#L7

This unfortunately breaks Paparazzi, as Gradle will now chose `31.1-android`. 

`java.lang.NoSuchMethodError: 'java.util.stream.Collector com.google.common.collect.Sets.toImmutableEnumSet()'`

Including Guava `31.1-jre` manually fixes Paparazzi tests, but that's just a workaround when Guava isn't explicitly needed otherwise. So bumping the Guava version used by Paparazzi is probably the best fix for this issue. 