### PR TITLE
Flush errors on unsafe update config

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -240,6 +240,7 @@ class Paparazzi @JvmOverloads constructor(
       "Calling unsafeUpdateConfig requires at least one non-null argument."
     }
 
+    logger.flushErrors()
     renderSession.release()
     bridgeRenderSession.dispose()
     cleanupThread()

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziLogger.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziLogger.kt
@@ -116,6 +116,10 @@ internal class PaparazziLogger : ILayoutLog, ILogger {
     }
   }
 
+  fun flushErrors() {
+    errors.clear()
+  }
+
   internal class MultipleFailuresException(private val causes: List<Throwable>) : Exception() {
     init {
       require(causes.isNotEmpty()) { "List of Throwables must not be empty" }

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/PaparazziLoggerTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/PaparazziLoggerTest.kt
@@ -47,4 +47,12 @@ class PaparazziLoggerTest {
       assertThat(ignored.message).contains("java.lang.IllegalStateException: error2")
     }
   }
+
+  @Test
+  fun testFlushErrors() {
+    val logger = PaparazziLogger()
+    logger.error(FileNotFoundException("error1"), null)
+    logger.flushErrors()
+    logger.assertNoErrors()
+  }
 }


### PR DESCRIPTION
If there were errors that happened in a previous snapshot run, the errors were not cleared on `unsafeUpdateConfig` so new snapshots could be taken separately.