### PR TITLE
Keep AGP and tools dependencies aligned

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-agp = "7.1.2"
+agp = "7.1.3"
+androidTools = "30.1.3" # == 23.0.0 + agp version
 bytebuddy = "1.12.10"
 composeCompiler = "1.3.0"
 javaTarget = "1.8"
@@ -49,10 +50,10 @@ moshi-kotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", vers
 
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
-tools-common = { module = "com.android.tools:common", version = "30.1.3" }
-tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "27.2.2" }
-tools-ninepatch = { module = "com.android.tools:ninepatch", version = "30.1.3" }
-tools-sdkCommon = { module = "com.android.tools:sdk-common", version = "30.1.3" }
+tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version.ref = "androidTools" }
+tools-ninepatch = { module = "com.android.tools:ninepatch", version.ref = "androidTools" }
+tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "androidTools" }
 
 trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version = "1.0.20200330" }
 


### PR DESCRIPTION
Prevents tech debt from sdk-common, common and layoutlib-api from happening again.