### PR TITLE
Update linux action to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,7 @@ jobs:
         os: [
           macOS-latest,
           windows-latest,
-          # Copied from SqlDelight: https://github.com/cashapp/sqldelight/blame/master/.github/workflows/PR.yml#L13-L18
-          # TL;DR looks like libraries installed on ubuntu-latest conflicts, resulting in failed builds
-          # Also, see: https://github.com/touchlab/SQLiter/pull/38#issuecomment-867171789
-          ubuntu-18.04
+          ubuntu-latest
         ]
         java-version: [11, 12, 16, 18]
 


### PR DESCRIPTION
Looks like ubuntu-18.04 is deprecated and will not be available after April 1, 2023 https://github.com/actions/runner-images/issues/6002. Removed the comment since we didn't run into any issues with the update.