### PR TITLE
Remove setting LayoutParams on ComposeView

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
@@ -18,8 +18,15 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  buildFeatures {
+    compose true
+  }
+  composeOptions {
+    kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+  }
 }
 
 dependencies {
+  testImplementation libs.composeUi.material
   testImplementation libs.testParameterInjector
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/src/test/java/app/cash/paparazzi/plugin/test/RenderingModeTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/src/test/java/app/cash/paparazzi/plugin/test/RenderingModeTest.kt
@@ -10,6 +10,8 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.viewinterop.AndroidView
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode
@@ -33,7 +35,13 @@ class RenderingModeTest(
   )
 
   @Test fun default() {
-    paparazzi.snapshot(buildView(paparazzi.context))
+    paparazzi.snapshot {
+      Box {
+        AndroidView(
+          factory = { buildView(paparazzi.context) }
+        )
+      }
+    }
   }
 
   enum class Mode(

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -28,7 +28,6 @@ import android.view.Choreographer
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
 import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import androidx.compose.runtime.Composable
@@ -200,11 +199,7 @@ class Paparazzi @JvmOverloads constructor(
     // CompositionContext, which requires first finding the "content view", then using that to
     // find a root view with a ViewTreeLifecycleOwner
     val parent = FrameLayout(context).apply { id = android.R.id.content }
-    parent.addView(
-      hostView,
-      if (renderingMode.horizAction == RenderingMode.SizeAction.SHRINK) LayoutParams.WRAP_CONTENT else LayoutParams.MATCH_PARENT,
-      if (renderingMode.vertAction == RenderingMode.SizeAction.SHRINK) LayoutParams.WRAP_CONTENT else LayoutParams.MATCH_PARENT
-    )
+    parent.addView(hostView)
     PaparazziComposeOwner.register(parent)
     hostView.setContent(composable)
 


### PR DESCRIPTION
We don't need to apply extra LayoutParams to ComposeView since it is a child of our `contentRoot` which already sets the expected LayoutParams for the RenderingMode.