### PR TITLE
Check for AndroidUiDispatcher too

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -634,7 +634,7 @@ class Paparazzi @JvmOverloads constructor(
     private val hasComposeRuntime: Boolean =
       try {
         Class.forName("androidx.compose.runtime.snapshots.SnapshotKt")
-        Class.forName("androidx.lifecycle.LifecycleOwner")
+        Class.forName("androidx.compose.ui.platform.AndroidUiDispatcher")
         true
       } catch (e: ClassNotFoundException) {
         false


### PR DESCRIPTION
If a module doesn't enable the Compose build feature, but depends on other modules with Composables, then we crash with:

```
    java.lang.NoClassDefFoundError: androidx/compose/ui/platform/AndroidUiDispatcher
        at app.cash.paparazzi.Paparazzi.forceReleaseComposeReferenceLeaks(Paparazzi.kt:586)
        at app.cash.paparazzi.Paparazzi.takeSnapshots(Paparazzi.kt:311)
        at app.cash.paparazzi.Paparazzi.snapshot(Paparazzi.kt:204)
        at app.cash.paparazzi.Paparazzi.snapshot$default(Paparazzi.kt:203)
        at com.squareup.cash.recurring.RecurringTransferFrequencyViewTest.amountTest(RecurringTransferFrequencyViewTest.kt:99)

        Caused by:
        java.lang.ClassNotFoundException: androidx.compose.ui.platform.AndroidUiDispatcher
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
            at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
            ... 5 more
```

in `forceReleaseComposeReferenceLeaks`.  So let's add another classpath check.

Side note: an alternative might be to read `android.buildFeatures.compose` setting from the AGP extension, and pipe it via the Paparazzi Gradle Plugin, but that exposes more Gradle plugin surface area.  Something to keep in mind though, if this turns into a case of whack-a-mole.