### PR TITLE
Change the project name when building from Intellij or Android Studio

### DIFF
--- a/paparazzi/settings.gradle
+++ b/paparazzi/settings.gradle
@@ -1,4 +1,13 @@
-rootProject.name = 'paparazzi-libs'
+/**
+ * Set the root project name to `paparazzi` when building from Intellij or Android Studio so that run executions created
+ * via context actions resolve to the task that matches the actual project directory structure. This is a workaround for
+ * https://github.com/gradle/gradle/issues/16608.
+ */
+if (System.getProperty("idea.active")) {
+  rootProject.name = 'paparazzi'
+} else {
+  rootProject.name = 'paparazzi-libs'
+}
 
 include ':paparazzi'
 include ':paparazzi-agent'


### PR DESCRIPTION
This change set updates the `paparazzi/settings.gradle` root project name to `paparrazzi` when the project is built from Intellij or Android Studio. Previously when attempting to create run configurations, the IDE would set the task to `paparazzi-libs:` in accordance with the root project name which would fail to run because the task did not match the directory structure. This change provides a workaround for the following [gradle issue](https://github.com/gradle/gradle/issues/16608) by checking a property `idea.active` which is only set when building the project from Intellij or Android Studio. This approach is documented in this [Stack Overflow post](https://stackoverflow.com/questions/63409895/configure-gradle-plugin-based-on-future-tasks/63411337#63411337).


<img width="716" alt="Screenshot 2022-12-28 at 7 53 38 AM" src="https://user-images.githubusercontent.com/1734140/209822678-7c2c43a4-cf57-499e-b697-e9cfcdca4e67.png">
