### PR TITLE
Register a LifecycleOwner only when ViewTreeLifecycleOwner is present in classpath

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -625,7 +625,7 @@ class Paparazzi @JvmOverloads constructor(
       "androidx.compose.ui.platform.AndroidUiDispatcher"
     )
     private val hasLifecycleOwnerRuntime = isPresentInClasspath(
-      "androidx.lifecycle.LifecycleOwner"
+      "androidx.lifecycle.ViewTreeLifecycleOwner"
     )
     private val hasSavedStateRegistryOwnerRuntime = isPresentInClasspath(
       "androidx.savedstate.SavedStateRegistryOwner"


### PR DESCRIPTION
`LifecycleOwner` and `ViewTreeLifecycleOwner` classes were introduced in different versions of `androidx.lifecycle`. Because `hasLifecycleOwnerRuntime` only checks for the former, projects that depend on `androidx.lifecycle.*:2.2.0` or older will run into a `ClassNotFoundException`. 

This is currently the case with our `verify-recyclerview` test project that brings in `androidx.lifecycle.*:2.0.0` as a transitive dependency through `androidx.recyclerview:recyclerview:1.2.1`.

I'm not sure why the test did not fail earlier in https://github.com/cashapp/paparazzi/pull/668.