### PR TITLE
Update to AGP 7.4.0 stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "7.4.0-rc01"
-androidTools = "30.4.0-rc01" # == 23.0.0 + agp version
+agp = "7.4.0"
+androidTools = "30.4.0" # == 23.0.0 + agp version
 bytebuddy = "1.12.10"
 composeCompiler = "1.3.2"
 javaTarget = "11"


### PR DESCRIPTION
Just wanted to make sure this happens before the next release

Also noted that layoutlib did not change between beta4 and the stable tag for EE, both point to the same commit https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.1.1