### PR TITLE
Ensure LifecycleOwner is available for ComposeView

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1001,6 +1001,18 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun composeViewTreeLifecycle() {
+    val fixtureRoot = File("src/test/projects/compose-lifecycle-owner")
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    val snapshotsDir = File(fixtureRoot, "build/reports/paparazzi/images")
+    val snapshots = snapshotsDir.listFiles()
+    assertThat(snapshots!!).hasLength(1)
+  }
+
+  @Test
   fun composeWear() {
     val fixtureRoot = File("src/test/projects/compose-wear")
     gradleRunner

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  buildFeatures {
+    compose true
+  }
+  composeOptions {
+    kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+  }
+}
+
+dependencies {
+  implementation libs.composeUi.material
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/src/main/java/app/cash/paparazzi/plugin/test/HelloPaparazzi.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/src/main/java/app/cash/paparazzi/plugin/test/HelloPaparazzi.kt
@@ -1,0 +1,48 @@
+package app.cash.paparazzi.plugin.test
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+
+@Composable
+fun HelloPaparazzi() {
+  val text = "Hello, Paparazzi"
+  Column(
+    Modifier
+      .background(Color.White)
+      .fillMaxSize()
+      .wrapContentSize()
+  ) {
+    Text(text)
+    Text(text, style = TextStyle(fontFamily = FontFamily.Cursive))
+    Text(
+      text = text,
+      style = TextStyle(textDecoration = TextDecoration.LineThrough)
+    )
+    Text(
+      text = text,
+      style = TextStyle(textDecoration = TextDecoration.Underline)
+    )
+    Text(
+      text = text,
+      style = TextStyle(
+        textDecoration = TextDecoration.combine(
+          listOf(
+            TextDecoration.Underline,
+            TextDecoration.LineThrough
+          )
+        ),
+        fontWeight = FontWeight.Bold
+      )
+    )
+  }
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/src/test/java/app/cash/paparazzi/plugin/test/ComposeLifecycleOwnerTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/src/test/java/app/cash/paparazzi/plugin/test/ComposeLifecycleOwnerTest.kt
@@ -1,0 +1,20 @@
+package app.cash.paparazzi.plugin.test
+
+import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
+import org.junit.Rule
+import org.junit.Test
+
+class ComposeLifecycleOwnerTest {
+  @get:Rule
+  val paparazzi = Paparazzi(
+    renderExtensions = setOf(AccessibilityRenderExtension())
+  )
+
+  @Test
+  fun lifecycleOwnerAvailableWithRendererExtension() {
+    paparazzi.snapshot {
+      HelloPaparazzi()
+    }
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -291,13 +291,13 @@ class Paparazzi @JvmOverloads constructor(
 
         if (hasLifecycleOwnerRuntime) {
           val lifecycleOwner = PaparazziLifecycleOwner()
-          ViewTreeLifecycleOwner.set(view, lifecycleOwner)
+          ViewTreeLifecycleOwner.set(modifiedView, lifecycleOwner)
 
           if (hasSavedStateRegistryOwnerRuntime) {
-            view.setViewTreeSavedStateRegistryOwner(PaparazziSavedStateRegistryOwner(lifecycleOwner))
+            modifiedView.setViewTreeSavedStateRegistryOwner(PaparazziSavedStateRegistryOwner(lifecycleOwner))
           }
           if (hasAndroidxActivityRuntime) {
-            view.setViewTreeOnBackPressedDispatcherOwner(PaparazziOnBackPressedDispatcherOwner(lifecycleOwner))
+            modifiedView.setViewTreeOnBackPressedDispatcherOwner(PaparazziOnBackPressedDispatcherOwner(lifecycleOwner))
           }
           // Must be changed after the SavedStateRegistryOwner above has finished restoring its state.
           lifecycleOwner.registry.currentState = Lifecycle.State.CREATED


### PR DESCRIPTION
Compose installs its WindowRecomposer on the contentChild

`
The content child is the view that is either a direct child of the view with id android.R.id.content (and was therefore set as a content view into an activity or dialog window) or the root view of the window.
`

When using renderer extensions `view` becomes a child of `modifiedView` which prevents compose from finding the LifecycleOwner.