### PR TITLE
Add plugin test results to be included in GHA artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           name: test-failures
           path: |
-            **/build/reports/tests/test/
+            **/build/reports/tests/*/
             **/out/failures/
             paparazzi/paparazzi-gradle-plugin/src/test/projects/**/build/reports/paparazzi/images/
 


### PR DESCRIPTION
JVM module test reports are in **/build/reports/tests/test/
But, plugin test reports are in **/build/reports/tests/testDebugUnitTest/