### PR TITLE
Add .gitattributes to make spotlessApply work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text eol=lf
 gradlew.bat text eol=crlf
+*.png binary
+*.jar binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,5 @@
-# Source code
-*.kt            text eol=lf
-*.java          text eol=lf
-*.xml           text eol=lf
+* text=auto eol=lf
 
-# Gradle files
-*.gradle        text eol=lf
-*.properties    text eol=lf
-*.bat           text eol=crlf
-
-# GitHub stuff
-*.md            text eol=lf
-*.yml           text eol=lf
-
-# Binaries
-*.png           binary
-*.jar           binary
+*.bat text eol=crlf
+*.jar binary
+*.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
-gradlew.bat text eol=crlf
 *.png binary
 *.jar binary
+gradlew.bat text eol=crlf
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,17 @@
-*.png binary
-*.jar binary
-gradlew.bat text eol=crlf
-* text eol=lf
+# Source code
+*.kt            text eol=lf
+*.java          text eol=lf
+*.xml           text eol=lf
+
+# Gradle files
+*.gradle        text eol=lf
+*.properties    text eol=lf
+*.bat           text eol=crlf
+
+# GitHub stuff
+*.md            text eol=lf
+*.yml           text eol=lf
+
+# Binaries
+*.png           binary
+*.jar           binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+gradlew.bat text eol=crlf

--- a/build.gradle
+++ b/build.gradle
@@ -68,3 +68,7 @@ subprojects {
 tasks.register("clean", Delete).configure {
   delete rootProject.buildDir
 }
+
+tasks.named("wrapper").configure {
+  distributionType = Wrapper.DistributionType.ALL
+}

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,3 @@ subprojects {
 tasks.register("clean", Delete).configure {
   delete rootProject.buildDir
 }
-
-tasks.named("wrapper").configure {
-  distributionType = Wrapper.DistributionType.ALL
-}


### PR DESCRIPTION
Original behavior: `gradlew spotlessApply` -> all files changed

Steps:
 * look up why -> https://github.com/diffplug/spotless/issues/39
 * add .gitattributes
 * reset working copy -> https://stackoverflow.com/q/48642692/253468

New behavior: If I run spotless again, it changes nothing, unless there's actually something wrong.

Please someone on Mac/linux check out the branch test this (on an existing and a new clone):
 * change a file in `paparazzi/paparazzi-gradle-plugin/src/main/kotlin`
 * `git status` (observe changed file)
 * run `./gradlew -p paparazzi spotlessApply`
 * `git status` (observe no changed files)