### PR TITLE
fix NPE when unit test variant is disabled

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -74,6 +74,8 @@ class PaparazziPlugin : Plugin<Project> {
       .libraryVariants
     variants.all { variant ->
       val variantSlug = variant.name.capitalize(Locale.US)
+      val testVariantSlug = variant.unitTestVariant?.name?.capitalize(Locale.US)
+        ?: return@all
 
       val mergeResourcesOutputDir = variant.mergeResourcesProvider.flatMap { it.outputDir }
       val mergeAssetsProvider =
@@ -107,8 +109,6 @@ class PaparazziPlugin : Plugin<Project> {
         task.mergeAssetsOutput.set(mergeAssetsOutputDir)
         task.paparazziResources.set(project.layout.buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
       }
-
-      val testVariantSlug = variant.unitTestVariant.name.capitalize(Locale.US)
 
       project.plugins.withType(JavaBasePlugin::class.java) {
         project.tasks.named("compile${testVariantSlug}JavaWithJavac")

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -74,8 +74,7 @@ class PaparazziPlugin : Plugin<Project> {
       .libraryVariants
     variants.all { variant ->
       val variantSlug = variant.name.capitalize(Locale.US)
-      val testVariantSlug = variant.unitTestVariant?.name?.capitalize(Locale.US)
-        ?: return@all
+      val testVariant = variant.unitTestVariant ?: return@all
 
       val mergeResourcesOutputDir = variant.mergeResourcesProvider.flatMap { it.outputDir }
       val mergeAssetsProvider =
@@ -109,6 +108,8 @@ class PaparazziPlugin : Plugin<Project> {
         task.mergeAssetsOutput.set(mergeAssetsOutputDir)
         task.paparazziResources.set(project.layout.buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
       }
+
+      val testVariantSlug = testVariant.name.capitalize(Locale.US)
 
       project.plugins.withType(JavaBasePlugin::class.java) {
         project.tasks.named("compile${testVariantSlug}JavaWithJavac")

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1102,6 +1102,14 @@ class PaparazziPluginTest {
     assertThat(darkModeSnapshotImage).isSimilarTo(darkModeGoldenImage).withDefaultThreshold()
   }
 
+  @Test
+  fun disabledUnitTestVariant() {
+    val fixtureRoot = File("src/test/projects/disabled-unit-test-variant")
+    gradleRunner
+      .withArguments("testDebug")
+      .runFixture(fixtureRoot) { build() }
+  }
+
   private fun GradleRunner.runFixture(
     projectRoot: File,
     action: GradleRunner.() -> BuildResult

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+}
+
+androidComponents {
+  beforeVariants(selector().all()) {
+    enableUnitTest = buildType == "debug"
+  }
+}


### PR DESCRIPTION
When used in a project with configuration like the following:
```
androidComponents {
  beforeVariants(selector().all()) {
    enableUnitTest = buildType == "debug"
  }
}
```

The Paparazzi Gradle plugin will throw an NPE:

```
java.lang.NullPointerException: Cannot invoke "com.android.build.gradle.api.UnitTestVariant.getName()" because the return value of "com.android.build.gradle.api.LibraryVariant.getUnitTestVariant()" is null
	at app.cash.paparazzi.gradle.PaparazziPlugin.setupPaparazzi$lambda-29(PaparazziPlugin.kt:111)
```

This skips such variants with unit tests disabled and adds a test for it.