### PR TITLE
Skip configuration for variants with disabled unit test variant

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -73,6 +73,7 @@ class PaparazziPlugin : Plugin<Project> {
     val variants = project.extensions.getByType(LibraryExtension::class.java)
       .libraryVariants
     variants.all { variant ->
+      if (variant.unitTestVariant == null) return@all
       val variantSlug = variant.name.capitalize(Locale.US)
 
       val mergeResourcesOutputDir = variant.mergeResourcesProvider.flatMap { it.outputDir }


### PR DESCRIPTION
If `unitTestVariant` is disabled for the `variant` during project configuration:
```groovy
android {
  androidComponents {
    beforeVariants(selector().withBuildType('release')) { variant ->
      variant.enableUnitTest = false
    }
  }
}
```
, `PaparazziPlugin` will cause `NullPointerException` to be thrown as it queries `unitTestVariant`.

This PR adds a simple check for every variant if it has  a `unitTestVariant` before hooking into variant tasks.

Resolves #711