### PR TITLE
update publishing library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,6 @@ plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
 plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.0.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.24.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.12.0" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.44.0" }

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -16,6 +16,7 @@ POM_DEVELOPER_URL=https://github.com/cashapp/
 
 SONATYPE_HOST=DEFAULT
 RELEASE_SIGNING_ENABLED=true
+SONATYPE_AUTOMATIC_RELEASE=true
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -31,7 +31,7 @@ sourceSets {
 def generateVersion = tasks.register("pluginVersion") {
   def outputDir = file('src/generated/kotlin')
 
-  inputs.property 'version', version
+  inputs.property 'version', project.property("VERSION_NAME")
   inputs.property 'nativeLibVersion', libs.versions.layoutlib
   outputs.dir outputDir
 
@@ -40,7 +40,7 @@ def generateVersion = tasks.register("pluginVersion") {
     versionFile.parentFile.mkdirs()
     versionFile.text = """// Generated file. Do not edit!
 package app.cash.paparazzi
-const val VERSION = "${project.version}"
+const val VERSION = "${project.property("VERSION_NAME")}"
 const val NATIVE_LIB_VERSION = "${libs.versions.layoutlib.get()}"
 """
   }


### PR DESCRIPTION
Wit this the plugin will explicitly create a staging repository before publishing and close it and the end which means that the `--no-parallel` isn't needed anymore and publishing is a lot more reliant. The `SONATYPE_AUTOMATIC_RELEASE=true` means that the repository will also be released automatically at the end of the build, so you'll have 0 interactions with the Sonatype Web UI.

I needed to adjust the code that injects the plugin version into the code because the publish plugin does not send `project.version` anymore.