### PR TITLE
Rewire Grgit usage

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi-material = { module = "androidx.compose.material:material", version = "1.4.3" }
 
+grgit = { module = "org.ajoberstar.grgit:grgit-core", version = "5.2.0" }
 guava = { module = "com.google.guava:guava", version = "31.1-jre" }
 
 jcodec-core = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
@@ -67,7 +68,6 @@ truth = { module = "com.google.truth:truth", version = "1.1.3" }
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 plugin-buildConfig = { module = "com.github.gmazzo:gradle-buildconfig-plugin", version = "3.1.0" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.8.10" }
-plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.2.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version = "1.8.21-1.0.11" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -12,12 +12,12 @@ buildscript {
     classpath libs.plugin.kotlin
     classpath libs.plugin.android
     classpath libs.plugin.mavenPublish
-    classpath libs.plugin.grgit
     classpath libs.plugin.dokka
     classpath libs.plugin.versions
     classpath libs.plugin.spotless
     classpath libs.plugin.buildConfig
     classpath libs.plugin.ksp
+    classpath libs.grgit
   }
 }
 

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -33,6 +33,7 @@ tasks.register('cloneLayoutlib') {
       }
     }
     grgit.withCloseable { repo ->
+      repo.fetch()
       logger.warn("Checking out SHA ${libs.versions.layoutlibPrebuiltSha.get()}")
       repo.checkout {
         branch = libs.versions.layoutlibPrebuiltSha.get()

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -1,4 +1,5 @@
-apply plugin: 'org.ajoberstar.grgit'
+import org.ajoberstar.grgit.Grgit
+
 apply plugin: 'com.vanniktech.maven.publish'
 
 version = libs.versions.layoutlib.get()
@@ -17,22 +18,25 @@ tasks.register('cloneLayoutlib') {
     if (repoDir.exists() && !repoDir.list()) {
       repoDir.delete()
     }
+    Grgit grgit
     if (!repoDir.exists()) {
       logger.warn('Cloning prebuilt layoutlib: this make take a few minutes...')
-      grgit.clone {
+      grgit = Grgit.clone {
         dir = repoDir
         uri = "https://android.googlesource.com/platform/prebuilts/studio/layoutlib"
       }
       logger.warn('Cloned prebuilt layoutlib.')
+    } else {
+      logger.warn('Using existing prebuilt layoutlib clone.')
+      grgit = Grgit.open {
+        dir = repoDir
+      }
     }
-
-    def repo = grgit.open {
-      dir = repoDir
-    }
-
-    logger.warn("Checking out SHA ${libs.versions.layoutlibPrebuiltSha.get()}")
-    repo.checkout {
-      branch = libs.versions.layoutlibPrebuiltSha.get()
+    grgit.withCloseable { repo ->
+      logger.warn("Checking out SHA ${libs.versions.layoutlibPrebuiltSha.get()}")
+      repo.checkout {
+        branch = libs.versions.layoutlibPrebuiltSha.get()
+      }
     }
   }
 }

--- a/paparazzi/libs/layoutlib/build.gradle
+++ b/paparazzi/libs/layoutlib/build.gradle
@@ -20,7 +20,7 @@ tasks.register('cloneLayoutlib') {
     }
     Grgit grgit
     if (!repoDir.exists()) {
-      logger.warn('Cloning prebuilt layoutlib: this make take a few minutes...')
+      logger.warn('Cloning prebuilt layoutlib: this may take a few minutes...')
       grgit = Grgit.clone {
         dir = repoDir
         uri = "https://android.googlesource.com/platform/prebuilts/studio/layoutlib"


### PR DESCRIPTION
1. `apply plugin: 'org.ajoberstar.grgit'` is not necessary, because it exists for a performance improvement where it eagerly opens **the current folder** as a Git repo, but we need to clone a new folder, so that "improvement" is actually not necessary and locks the .git folder in the Gradle daemon.
2. `grgit` is an instance from the project extension, but we need just need `org.ajoberstar.grgit.Grgit` which is on the classpath already even without applying the plugin.
3. `grgit.clone()` is a static method call on an instance of Grgit.
4. `grgit` instance created by `open`/`clone` is never closed, so therefore the `paparazzi\build\prebuilts\studio\layoutlib\.git` folder is locked inside the Gradle daemon (e.g. cannot delete without `gradlew --stop`)
5. There's an operation missing when an existing repo is `open`ed, the hash might not exist yet, so a `fetch()` is necessary to get the new updates. When the repo was just cloned this is essentially a no-op.