### PR TITLE
Fixes issues with preparePaparazzi{Variant}Resources task that is caching incorrectly for different variants.

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -99,6 +99,7 @@ class PaparazziPlugin : Plugin<Project> {
         val nonTransitiveRClassEnabled =
           (project.findProperty("android.nonTransitiveRClass") as? String).toBoolean()
 
+        task.variantName.set(variant.name)
         task.packageName.set(android.packageName())
         task.artifactFiles.from(packageAwareArtifacts.artifactFiles)
         task.nonTransitiveRClassEnabled.set(nonTransitiveRClassEnabled)

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -84,7 +84,8 @@ class PaparazziPlugin : Plugin<Project> {
       val mergeAssetsProvider =
         project.tasks.named("merge${variantSlug}Assets") as TaskProvider<MergeSourceSetFolders>
       val mergeAssetsOutputDir = mergeAssetsProvider.flatMap { it.outputDir }
-      val reportOutputDir = project.layout.buildDirectory.dir("reports/paparazzi")
+      val buildDirectory = project.layout.buildDirectory
+      val reportOutputDir = buildDirectory.dir("reports/paparazzi")
       val snapshotOutputDir = project.layout.projectDirectory.dir("src/test/snapshots")
 
       val packageAwareArtifacts = project.configurations
@@ -99,13 +100,6 @@ class PaparazziPlugin : Plugin<Project> {
         "preparePaparazzi${variantSlug}Resources",
         PrepareResourcesTask::class.java
       ) { task ->
-        fun DirectoryProperty.asRelativePathString(childDirectory: Provider<Directory>): Provider<String> =
-          flatMap { buildDir ->
-            childDirectory.map { childDir ->
-              buildDir.asFile.toPath().relativize(childDir.asFile.toPath()).invariantSeparatorsPathString
-            }
-          }
-
         val android = project.extensions.getByType(BaseExtension::class.java)
         val nonTransitiveRClassEnabled =
           (project.findProperty("android.nonTransitiveRClass") as? String).toBoolean()
@@ -113,11 +107,11 @@ class PaparazziPlugin : Plugin<Project> {
         task.packageName.set(android.packageName())
         task.artifactFiles.from(packageAwareArtifacts.artifactFiles)
         task.nonTransitiveRClassEnabled.set(nonTransitiveRClassEnabled)
-        task.mergeResourcesOutput.set(project.layout.buildDirectory.asRelativePathString(mergeResourcesOutputDir))
+        task.mergeResourcesOutputDir.set(buildDirectory.asRelativePathString(mergeResourcesOutputDir))
         task.targetSdkVersion.set(android.targetSdkVersion())
         task.compileSdkVersion.set(android.compileSdkVersion())
-        task.mergeAssetsOutput.set(project.layout.buildDirectory.asRelativePathString(mergeAssetsOutputDir))
-        task.paparazziResources.set(project.layout.buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
+        task.mergeAssetsOutputDir.set(buildDirectory.asRelativePathString(mergeAssetsOutputDir))
+        task.paparazziResources.set(buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
       }
 
       val testVariantSlug = testVariant.name.capitalize(Locale.US)
@@ -163,7 +157,7 @@ class PaparazziPlugin : Plugin<Project> {
         test.systemProperties["paparazzi.test.resources"] =
           writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
         test.systemProperties["paparazzi.build.dir"] =
-          project.layout.buildDirectory.get().toString()
+          buildDirectory.get().toString()
 
         test.inputs.dir(mergeResourcesOutputDir)
         test.inputs.dir(mergeAssetsOutputDir)
@@ -274,6 +268,13 @@ class PaparazziPlugin : Plugin<Project> {
       ?: DEFAULT_COMPILE_SDK_VERSION.toString()
   }
 }
+
+private fun Directory.relativize(child: Directory): String {
+  return asFile.toPath().relativize(child.asFile.toPath()).invariantSeparatorsPathString
+}
+
+private fun DirectoryProperty.asRelativePathString(child: Provider<Directory>): Provider<String> =
+  flatMap { root -> child.map { root.relativize(it) } }
 
 // TODO: Migrate to ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE when Gradle 7.3 is
 //  acceptable as the minimum supported version

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -17,13 +17,10 @@ package app.cash.paparazzi.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -32,15 +29,12 @@ import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class PrepareResourcesTask : DefaultTask() {
-  @get:Input
-  abstract val variantName: Property<String>
 
   @get:Input
   abstract val packageName: Property<String>
 
-  @get:InputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val mergeResourcesOutput: DirectoryProperty
+  @get:Input
+  abstract val mergeResourcesOutput: Property<String>
 
   @get:Input
   abstract val targetSdkVersion: Property<String>
@@ -48,9 +42,8 @@ abstract class PrepareResourcesTask : DefaultTask() {
   @get:Input
   abstract val compileSdkVersion: Property<String>
 
-  @get:InputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val mergeAssetsOutput: DirectoryProperty
+  @get:Input
+  abstract val mergeAssetsOutput: Property<String>
 
   @get:Input
   abstract val nonTransitiveRClassEnabled: Property<Boolean>
@@ -61,8 +54,6 @@ abstract class PrepareResourcesTask : DefaultTask() {
 
   @get:OutputFile
   abstract val paparazziResources: RegularFileProperty
-
-  private val buildDirectory = project.layout.buildDirectory
 
   @TaskAction
   // TODO: figure out why this can't be removed as of Kotlin 1.6+
@@ -82,27 +73,22 @@ abstract class PrepareResourcesTask : DefaultTask() {
     } else {
       mainPackage
     }
-    val projectDirectory = buildDirectory.get()
 
     out.bufferedWriter()
       .use {
         it.write(mainPackage)
         it.newLine()
-        it.write(projectDirectory.relativize(mergeResourcesOutput.get()))
+        it.write(mergeResourcesOutput.get())
         it.newLine()
         it.write(targetSdkVersion.get())
         it.newLine()
         // Use compileSdkVersion for system framework resources.
         it.write("platforms/android-${compileSdkVersion.get()}/")
         it.newLine()
-        it.write(projectDirectory.relativize(mergeAssetsOutput.get()))
+        it.write(mergeAssetsOutput.get())
         it.newLine()
         it.write(resourcePackageNames)
         it.newLine()
       }
-  }
-
-  private fun Directory.relativize(child: Directory): String {
-    return asFile.toPath().relativize(child.asFile.toPath()).toFile().invariantSeparatorsPath
   }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -33,6 +33,9 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class PrepareResourcesTask : DefaultTask() {
   @get:Input
+  abstract val variantName: Property<String>
+
+  @get:Input
   abstract val packageName: Property<String>
 
   @get:InputDirectory

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -29,12 +29,11 @@ import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class PrepareResourcesTask : DefaultTask() {
-
   @get:Input
   abstract val packageName: Property<String>
 
   @get:Input
-  abstract val mergeResourcesOutput: Property<String>
+  abstract val mergeResourcesOutputDir: Property<String>
 
   @get:Input
   abstract val targetSdkVersion: Property<String>
@@ -43,7 +42,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
   abstract val compileSdkVersion: Property<String>
 
   @get:Input
-  abstract val mergeAssetsOutput: Property<String>
+  abstract val mergeAssetsOutputDir: Property<String>
 
   @get:Input
   abstract val nonTransitiveRClassEnabled: Property<Boolean>
@@ -78,14 +77,14 @@ abstract class PrepareResourcesTask : DefaultTask() {
       .use {
         it.write(mainPackage)
         it.newLine()
-        it.write(mergeResourcesOutput.get())
+        it.write(mergeResourcesOutputDir.get())
         it.newLine()
         it.write(targetSdkVersion.get())
         it.newLine()
         // Use compileSdkVersion for system framework resources.
         it.write("platforms/android-${compileSdkVersion.get()}/")
         it.newLine()
-        it.write(mergeAssetsOutput.get())
+        it.write(mergeAssetsOutputDir.get())
         it.newLine()
         it.write(resourcePackageNames)
         it.newLine()

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -122,8 +122,6 @@ class PaparazziPluginTest {
       .withArguments("testRelease", "testDebug", "--build-cache", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
-    println(firstRun.output)
-
     with(firstRun.task(":preparePaparazziDebugResources")) {
       assertThat(this).isNotNull()
       assertThat(this!!.outcome).isNotEqualTo(FROM_CACHE)

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
@@ -9,7 +9,6 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
   }
   mavenCentral()
-  //mavenLocal()
   google()
 }
 

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/settings.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/settings.gradle
@@ -1,0 +1,7 @@
+apply from: '../test.settings.gradle'
+
+buildCache {
+  local {
+    directory = new File(rootDir, 'build-cache')
+  }
+}


### PR DESCRIPTION
Fixes the issue [this pr](https://github.com/cashapp/paparazzi/pull/707) attempted to reproduce/solve.

[Investigation doc](https://docs.google.com/document/d/17jlBWeuWV0M68uYUALX1HAGcLpA6EWTcQv8l3FJ-skc/edit#) on this issue for Cash.

TL;DR
> Looking into the generated cache key it seems that it creates a build cache for the same generated key. So to recap preparePaparazziDebugResources runs around 6m into the build process and generates the correct debug resource file for paparazzi. At 9m into the build preparePaparazziReleaseResources runs to generate the correct release resource file for paparazzi but stores the output for the same cache key 8c39bb.
> So this validates why the output for the debug task contains references to release paths.

I added a test gradle plugin project here to simulate the exact issue in [the first commit](https://github.com/cashapp/paparazzi/pull/720/commits/d15ef7b348374644fbc04295d3ed449f1c00404a) - [Sample Build Failure](https://github.com/cashapp/paparazzi/actions/runs/4235006678/jobs/7358079374#step:6:446)

[The last commit](https://github.com/cashapp/paparazzi/pull/720/commits/5d4aefabe0b686677558a25f6cd76e1a86832bf9) adds variantName as a build input and causes the failing test to pass.

cc @mohsin-motorway this may fix the issue you were having as well.

Fixes issue https://github.com/cashapp/paparazzi/issues/560 as well.