### PR TITLE
Improve error message to help diagnose #732

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -74,7 +74,7 @@ internal class PaparazziCallback(
             } else if (type.isArray && type.componentType == Int::class.javaPrimitiveType) {
               // Ignore.
             } else {
-              logger.error(null, "Unknown field type in R class: $type")
+              logger.error(null, "Unknown field type ($type) in R class: $field")
             }
           } catch (e: IllegalAccessException) {
             logger.error(e, "Malformed R class: %1\$s", "$rPackageName.R")


### PR DESCRIPTION
Improve error message to help diagnose #732. `java.lang.reflect.Field` has a beautiful toString including the full signature. This should help pinpoint which field is the problem (name), in which `R` class is the problem (package in FQCN) and give a nicer human-readable type message on top of the existing one (`type`). I left the original in there for future-proofing: if the code changes and the `type` variable gets calculated differently, the error message will be still correct and help figure out the problem.

See https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Field.html#toString--