### PR TITLE
Use Dispatchers.Main for `delay` functionality

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -173,6 +173,7 @@ class PaparazziPlugin : Plugin<Project> {
               nativePlatformFileCollection.singleFile.absolutePath
             test.systemProperties["paparazzi.test.record"] = isRecordRun.get()
             test.systemProperties["paparazzi.test.verify"] = isVerifyRun.get()
+            test.systemProperties["kotlinx.coroutines.main.delay"] = true
             test.systemProperties.putAll(paparazziProperties)
           }
         })

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1110,6 +1110,17 @@ class PaparazziPluginTest {
       .runFixture(fixtureRoot) { build() }
   }
 
+  @Test
+  fun verifyCoroutineDelay() {
+    val fixtureRoot = File("src/test/projects/coroutine-delay-main")
+
+    val result = gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":testDebugUnitTest")).isNotNull()
+  }
+
   private fun GradleRunner.runFixture(
     projectRoot: File,
     action: GradleRunner.() -> BuildResult

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  buildFeatures {
+    compose true
+  }
+  composeOptions {
+    kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+  }
+}
+
+dependencies {
+  implementation libs.composeUi.material
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/CoroutineDelayMainTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/CoroutineDelayMainTest.kt
@@ -1,0 +1,35 @@
+package app.cash.paparazzi.plugin.test
+
+import android.os.SystemClock
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.ComposeView
+import app.cash.paparazzi.Paparazzi
+import kotlinx.coroutines.delay
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class CoroutineDelayMainTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test fun delayUsesMainDispatcher() {
+    var start = 0L
+    var end = 0L
+    paparazzi.gif(
+      ComposeView(paparazzi.context).apply {
+        setContent {
+          start = SystemClock.uptimeMillis()
+          LaunchedEffect(Unit) {
+            delay(250)
+            end = SystemClock.uptimeMillis()
+          }
+        }
+      },
+      end = 1000,
+      fps = 4
+    )
+
+    assertEquals(250L, end - start)
+  }
+}


### PR DESCRIPTION
When using `delay` with LaunchedEffect, ex. to delay animation, the default implementation uses a separate DefaultExecutor for tracking time causing delay to be tied to unit test time not Paparazzi frame time. By taking advantage of this system property we force `delay` to use Main which is driven by Paparazzi's frame time.

System Property: https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt#L11-L25

Resolves the timing issues reported as part of https://github.com/cashapp/paparazzi/issues/513