### PR TITLE
Set Build.VERSION.CODENAME to fix codename checks (mainly in Compose)

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -29,6 +29,7 @@ data class Environment(
   val assetsDir: String,
   val packageName: String,
   val compileSdkVersion: Int,
+  val platformCodename: String = "REL",
   val resourcePackageNames: List<String>
 ) {
   init {


### PR DESCRIPTION
This aims to fix https://github.com/cashapp/paparazzi/issues/758

**Issue:**
`CODENAME` checks like below crash snapshot tests (this is `androidx.core.os.BuildCompat`):
```java
    public static boolean isAtLeastT() {
        return VERSION.SDK_INT >= 33
                || (VERSION.SDK_INT >= 32
                && isAtLeastPreReleaseCodename("Tiramisu", VERSION.CODENAME));
    }
```

**Cause:**
`Build.VERSION.CODENAME` is `null`.

**Solution:**
Set `CODENAME` reflectively during Paparazzi environment setup. 
Most of the times the value should be `REL` (for release builds).

Still, I'd like to leave a way to set it to another value (like `UpsideDownCake` for Android 14 that is being developed right now) if someone wants to run their snapshot tests against preview version of the platform.

