### PR TITLE
Bump LayoutLib to Flamingo

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,10 +12,10 @@ moshi = "1.13.0"
 minSdk = "25"
 compileSdk = "33"
 
-# Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/f5f9f71
+# Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/5128371
 # which runs on JDK 11.
-layoutlib = "2022.1.1-beta4-f5f9f71"
-layoutlibPrebuiltSha = "f5f9f71"
+layoutlib = "2022.2.1-5128371-2"
+layoutlibPrebuiltSha = "5128371"
 
 [libraries]
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.3.0" }
@@ -52,7 +52,7 @@ moshi-kotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", vers
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
 tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
-tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version.ref = "androidTools" }
+tools-layoutlib = { module = "com.android.tools.layoutlib:layoutlib-api", version = "31.0.0" }
 tools-ninepatch = { module = "com.android.tools:ninepatch", version.ref = "androidTools" }
 tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "androidTools" }
 

--- a/paparazzi/libs/native-linux/build.gradle
+++ b/paparazzi/libs/native-linux/build.gradle
@@ -7,6 +7,7 @@ tasks.register('linuxJar', Jar) {
     include 'data/linux/**'
     include 'data/fonts/**'
     include 'data/icu/**'
+    include 'data/keyboards/**'
     exclude '**/BUILD'
   }
   dependsOn(':libs:layoutlib:cloneLayoutlib')

--- a/paparazzi/libs/native-macarm/build.gradle
+++ b/paparazzi/libs/native-macarm/build.gradle
@@ -7,6 +7,7 @@ tasks.register('macArmJar', Jar) {
     include 'data/mac-arm/**'
     include 'data/fonts/**'
     include 'data/icu/**'
+    include 'data/keyboards/**'
     exclude '**/BUILD'
   }
   dependsOn(':libs:layoutlib:cloneLayoutlib')

--- a/paparazzi/libs/native-macosx/build.gradle
+++ b/paparazzi/libs/native-macosx/build.gradle
@@ -7,6 +7,7 @@ tasks.register('macJar', Jar) {
     include 'data/mac/**'
     include 'data/fonts/**'
     include 'data/icu/**'
+    include 'data/keyboards/**'
     exclude '**/BUILD'
   }
   dependsOn(':libs:layoutlib:cloneLayoutlib')

--- a/paparazzi/libs/native-win/build.gradle
+++ b/paparazzi/libs/native-win/build.gradle
@@ -7,6 +7,7 @@ tasks.register('winJar', Jar) {
     include 'data/win/**'
     include 'data/fonts/**'
     include 'data/icu/**'
+    include 'data/keyboards/**'
     exclude '**/BUILD'
   }
   dependsOn(':libs:layoutlib:cloneLayoutlib')

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -156,9 +156,8 @@ internal class PaparazziCallback(
   ): Any? = null
 
   override fun getAdapterBinding(
-    adapterViewRef: ResourceReference,
-    adapterCookie: Any,
-    viewObject: Any
+    viewObject: Any?,
+    attributes: MutableMap<String, String>?
   ): AdapterBinding? = null
 
   override fun getActionBarCallback(): ActionBarCallback = actionBarCallback

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -70,6 +70,7 @@ internal class Renderer(
     val fontLocation = File(platformDataDir, "fonts")
     val nativeLibLocation = File(platformDataDir, getNativeLibDir())
     val icuLocation = File(platformDataDir, "icu" + File.separator + "icudt70l.dat")
+    val keyboardLocation = File(platformDataDir, "keyboards" + File.separator + "Generic.kcm")
     val buildProp = File(environment.platformDir, "build.prop")
     val attrs = File(platformDataResDir, "values" + File.separator + "attrs.xml")
     val systemProperties = DeviceConfig.loadProperties(buildProp) + mapOf(
@@ -83,6 +84,7 @@ internal class Renderer(
           fontLocation,
           nativeLibLocation.path,
           icuLocation.path,
+          arrayOf(keyboardLocation.path),
           DeviceConfig.getEnumMap(attrs),
           logger
         )


### PR DESCRIPTION
Closes #754 (but kudos to @ZacSweers for the assist to highlight the changes to layoutlib-api!)

Key difference is explicitly bumping only layoutlib-api's version in order to avoid all the Gradle/AGP noise, which also brought in the Spotless updates in #754.  

Related: https://github.com/diffplug/spotless/issues/1572