### PR TITLE
Force colocated Gradle home with project dir due to external resource relative path constraint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+  GRADLE_USER_HOME: ${{ github.workspace }} # required for Windows due to resource relative paths
 
 jobs:
   build:


### PR DESCRIPTION
Part of https://github.com/cashapp/paparazzi/issues/524

cc @kevinzheng-ap

Q: Why does Gradle cache go to C: while git does to D:?

A: According to https://github.com/actions/checkout
```
    # Relative path under $GITHUB_WORKSPACE to place the repository
    path: ''
```
in Github Actions yml:
```
    steps:
      - name: Echo envvars
        run: env
```
```
GITHUB_WORKSPACE=D:\a\paparazzi\paparazzi
```
```
Restore Gradle state from cache
  Received 117231600 of 117231600 (100.0%), 130.6 MBs/sec
  Cache Size: ~112 MB (117231600 B)
  "C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/c96358d7-feb9-49ca-b77f-16bc580e282f/cache.tzst -P -C D:/a/paparazzi/paparazzi --force-local --use-compress-program "zstd -d"
  Cache restored successfully
  Restored Gradle User Home from cache key: v7-gradle|Windows|build[43ab0e1a05934a87a85af6ae78be82bc]-864ae2f624330f224d5620539e20ac8ca1bddcb1
  Received 24560 of 24560 (100.0%), 0.3 MBs/sec
  Cache Size: ~0 MB (24560 B)
  "C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/d893dffd-b090-49f7-b98f-82c26d607026/cache.tzst -P -C D:/a/paparazzi/paparazzi --force-local --use-compress-program "zstd -d"
  Cache restored successfully
  Restored generated-gradle-jars with key generated-gradle-jars-631b98c57f67cf849e2976089ce526c6 to C:\Users\runneradmin\.gradle\caches\7.6\generated-gradle-jars\gradle-test-kit-7.6.jar
```
  
According to https://github.com/gradle/gradle-build-action

https://github.com/gradle/gradle-build-action/blob/d23c38fad3e837961b39af2b98b046694927aca4/src/setup-gradle.ts#L71-L77
  
HOME=C:\Users\runneradmin

GRADLE_USER_HOME
Specifies the Gradle user home directory (which defaults to <home directory of the current user>/.gradle if not set).