### PR TITLE
Introduce resource visibility to BasicResourceItem

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.cash.paparazzi.internal
 
 import com.android.SdkConstants.ATTR_FORMAT

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
@@ -39,7 +39,7 @@ import com.android.ide.common.rendering.api.StyleItemResourceValueImpl
 import com.android.ide.common.rendering.api.StyleResourceValueImpl
 import com.android.ide.common.rendering.api.StyleableResourceValueImpl
 import com.android.ide.common.rendering.api.TextResourceValueImpl
-import com.android.ide.common.resources.ResourceItem
+import com.android.ide.common.resources.ResourceItemWithVisibility
 import com.android.ide.common.resources.SingleNamespaceResourceRepository
 import com.android.ide.common.resources.ValueXmlHelper
 import com.android.ide.common.resources.configuration.FolderConfiguration
@@ -47,6 +47,7 @@ import com.android.ide.common.util.PathString
 import com.android.resources.ResourceType
 import com.android.resources.ResourceType.PUBLIC
 import com.android.resources.ResourceUrl
+import com.android.resources.ResourceVisibility
 import com.android.utils.XmlUtils
 import org.w3c.dom.Element
 import java.io.File
@@ -55,12 +56,14 @@ import java.util.EnumSet
 class BasicResourceItem(
   type: ResourceType,
   private val name: String,
+  visibility: ResourceVisibility,
   file: File,
   tag: Element?,
   private val repository: SingleNamespaceResourceRepository
-) : ResourceItem {
+) : ResourceItemWithVisibility {
   // Store enums as their ordinals in byte form to minimize memory footprint.
   private val typeOrdinal: Byte
+  private val visibilityOrdinal: Byte
 
   private val resourceValue: ResourceValue
 
@@ -73,6 +76,7 @@ class BasicResourceItem(
 
   init {
     typeOrdinal = type.ordinal.toByte()
+    visibilityOrdinal = visibility.ordinal.toByte()
 
     resourceValue = if (tag == null || type == PUBLIC) {
       val density =
@@ -95,6 +99,8 @@ class BasicResourceItem(
   override fun getName() = name
 
   override fun getLibraryName() = null
+
+  override fun getVisibility() = ResourceVisibility.values()[visibilityOrdinal.toInt()]
 
   override fun getReferenceToSelf(): ResourceReference =
     ResourceReference(namespace, type, name)

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/BasicResourceItem.kt
@@ -53,12 +53,15 @@ import java.io.File
 import java.util.EnumSet
 
 class BasicResourceItem(
-  private val type: ResourceType,
+  type: ResourceType,
   private val name: String,
   file: File,
   tag: Element?,
   private val repository: SingleNamespaceResourceRepository
 ) : ResourceItem {
+  // Store enums as their ordinals in byte form to minimize memory footprint.
+  private val typeOrdinal: Byte
+
   private val resourceValue: ResourceValue
 
   private val folderConfiguration: FolderConfiguration =
@@ -69,6 +72,8 @@ class BasicResourceItem(
   private val isFileBased = tag == null
 
   init {
+    typeOrdinal = type.ordinal.toByte()
+
     resourceValue = if (tag == null || type == PUBLIC) {
       val density =
         if (type == ResourceType.DRAWABLE || type == ResourceType.MIPMAP) configuration.densityQualifier?.value else null
@@ -83,7 +88,7 @@ class BasicResourceItem(
     }
   }
 
-  override fun getType() = type
+  override fun getType() = ResourceType.values()[typeOrdinal.toInt()]
 
   override fun getNamespace(): ResourceNamespace = repository.namespace
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/BasicResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/BasicResourceItem.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paparazzi.internal
+package app.cash.paparazzi.internal.resources
 
 import com.android.SdkConstants.ATTR_FORMAT
 import com.android.SdkConstants.ATTR_NAME


### PR DESCRIPTION
Also, some minor cleanup to BasicResourceItem:

- add license to top of file
- order file by private vals, init block, overridden methods, private methods
- store type as ordinal
- move file to new internal resources namespace