### PR TITLE
Removes FileTree when loading resources files in PaparazziPlugin

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -94,14 +94,12 @@ class PaparazziPlugin : Plugin<Project> {
       // local resources
       val localResourceFiles = project
         .files(variant.sourceSets.flatMap { it.resDirectories })
-        .asFileTree
 
       // library resources
       // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
       val libraryResourceFiles = variant.runtimeConfiguration
         .artifactsFor(ArtifactType.ANDROID_RES.type)
         .artifactFiles
-        .asFileTree
 
       val packageAwareArtifactFiles = variant.runtimeConfiguration
         .artifactsFor(ArtifactType.SYMBOL_LIST_WITH_PACKAGE_NAME.type)

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -738,8 +738,8 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
-    assertThat(resourceFileContents[6]).isEqualTo("src/main/res/values/strings.xml")
-    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/447a80cf40ceaa09b49db1df799dcb00/transformed/external/res/values/values.xml")
+    assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
+    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/57296c8dafa8e42375ba5dc0569953b4/transformed/external/res")
   }
 
   @Test
@@ -760,8 +760,8 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
-    assertThat(resourceFileContents[6]).isEqualTo("src/main/res/values/strings.xml")
-    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/447a80cf40ceaa09b49db1df799dcb00/transformed/external/res/values/values.xml")
+    assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
+    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/57296c8dafa8e42375ba5dc0569953b4/transformed/external/res")
   }
 
   @Test


### PR DESCRIPTION
Per feedback from @jrodbx [#766 comment](https://github.com/cashapp/paparazzi/pull/766/files#r1185546121)