### PR TITLE
Update external library paths to be relative to gradle user home not project root directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
-  GRADLE_USER_HOME: ${{ github.workspace }}/gradle-home # required for Windows due to resource relative paths
 
 jobs:
   build:

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -88,6 +88,7 @@ class PaparazziPlugin : Plugin<Project> {
         project.tasks.named("merge${variantSlug}Assets") as TaskProvider<MergeSourceSetFolders>
       val mergeAssetsOutputDir = mergeAssetsProvider.flatMap { it.outputDir }
       val buildDirectory = project.layout.buildDirectory
+      val gradleUserHomeDir = project.gradle.gradleUserHomeDir
       val reportOutputDir = buildDirectory.dir("reports/paparazzi")
       val snapshotOutputDir = project.layout.projectDirectory.dir("src/test/snapshots")
 
@@ -167,8 +168,8 @@ class PaparazziPlugin : Plugin<Project> {
       val testTaskProvider = project.tasks.named("test$testVariantSlug", Test::class.java) { test ->
         test.systemProperties["paparazzi.test.resources"] =
           writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
-        test.systemProperties["paparazzi.build.dir"] =
-          buildDirectory.get().toString()
+        test.systemProperties["paparazzi.build.dir"] = buildDirectory.get().toString()
+        test.systemProperties["paparazzi.artifacts.cache.dir"] = gradleUserHomeDir.path
         test.systemProperties["kotlinx.coroutines.main.delay"] = true
         test.systemProperties.putAll(project.properties.filterKeys { it.startsWith("app.cash.paparazzi") })
 

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -65,6 +65,8 @@ abstract class PrepareResourcesTask : DefaultTask() {
 
   private val projectDirectory = project.layout.projectDirectory
 
+  private val gradleUserHomeDirectory = projectDirectory.dir(project.gradle.gradleUserHomeDir.path)
+
   @TaskAction
   // TODO: figure out why this can't be removed as of Kotlin 1.6+
   @OptIn(ExperimentalStdlibApi::class)
@@ -101,7 +103,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
         it.newLine()
         it.write(localResourceDirs.joinFiles(projectDirectory))
         it.newLine()
-        it.write(libraryResourceDirs.joinFiles(projectDirectory))
+        it.write(libraryResourceDirs.joinFiles(gradleUserHomeDirectory))
         it.newLine()
       }
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -751,7 +751,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/05b86fef7254f66e4a9c0b458c40632f/transformed/external/res")
+    assertThat(resourceFileContents[7]).isEqualTo("caches/transforms-3/135dc2e5a62508cf0936920a52f88fbd/transformed/external/res")
   }
 
   @Test
@@ -773,7 +773,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("../../../../build/tmp/test/work/.gradle-test-kit/caches/transforms-3/05b86fef7254f66e4a9c0b458c40632f/transformed/external/res")
+    assertThat(resourceFileContents[7]).isEqualTo("caches/transforms-3/135dc2e5a62508cf0936920a52f88fbd/transformed/external/res")
   }
 
   @Test

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -122,6 +122,10 @@ tasks.withType(Test).configureEach {
     project.layout.buildDirectory.get().toString()
   )
   systemProperty(
+    "paparazzi.artifacts.cache.dir",
+    project.gradle.gradleUserHomeDir.path
+  )
+  systemProperty(
     "paparazzi.platform.data.root",
     configurations.unzip.singleFile.absolutePath
   )

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -56,6 +56,7 @@ fun detectEnvironment(): Environment {
   val configLines = resourcesFile.readLines()
 
   val appTestDir = Paths.get(System.getProperty("paparazzi.build.dir"))
+  val artifactsCacheDir = Paths.get(System.getProperty("paparazzi.artifacts.cache.dir"))
   val androidHome = Paths.get(androidHome())
   return Environment(
     platformDir = androidHome.resolve(configLines[3]).toString(),
@@ -66,7 +67,7 @@ fun detectEnvironment(): Environment {
     compileSdkVersion = configLines[2].toInt(),
     resourcePackageNames = configLines[5].split(","),
     localResourceDirs = configLines[6].split(","),
-    libraryResourceDirs = configLines[7].split(",")
+    libraryResourceDirs = configLines[7].split(",").map { artifactsCacheDir.resolve(it).toString() }
   )
 }
 


### PR DESCRIPTION
This should eliminate the constraint for Windows users having to have the Gradle user home and the project root on the same drive.

cc: @kevinzheng-ap