### PR TITLE
Skip copying android.os.Build fields for unknown fields

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -192,6 +192,18 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun buildClassNextSdkAccess() {
+    val fixtureRoot = File("src/test/projects/build-class-next-sdk")
+
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    val snapshotsDir = File(fixtureRoot, "custom/reports/paparazzi/images")
+    assertThat(snapshotsDir.exists()).isFalse()
+  }
+
+  @Test
   fun missingPlatformDirTest() {
     val fixtureRoot = File("src/test/projects/missing-platform-dir")
 

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  //mavenLocal()
+  google()
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdkPreview "UpsideDownCake"
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+}

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import android.os.Build
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class BuildClassTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun verifyFields() {
+    println(Build.MODEL)
+    assert(Build.ID == "UPB2.230407.013")
+    assert(Build.DISPLAY == "sdk_phone_armv7-userdebug UpsideDownCake UPB2.230407.013 10043902 test-keys")
+    assert(Build.PRODUCT == "unknown")
+    assert(Build.DEVICE == "generic")
+    assert(Build.BOARD == "unknown")
+    assert(Build.MANUFACTURER == "generic")
+    assert(Build.BRAND == "generic")
+    assert(Build.MODEL == "unknown")
+    assert(Build.SOC_MANUFACTURER == "unknown")
+    assert(Build.SOC_MODEL == "unknown")
+    assert(Build.BOOTLOADER == "unknown")
+    assert(Build.RADIO == "unknown")
+    assert(Build.HARDWARE == "unknown")
+    assert(Build.SKU == "unknown")
+    assert(Build.ODM_SKU == "unknown")
+
+    assert(Build.VERSION.INCREMENTAL == "10043902")
+    assert(Build.VERSION.RELEASE != null)
+    assert(Build.VERSION.RELEASE_OR_CODENAME != null)
+    assert(Build.VERSION.BASE_OS == "")
+    assert(Build.VERSION.SECURITY_PATCH != null)
+    assert(Build.VERSION.MEDIA_PERFORMANCE_CLASS == 0)
+    assert(Build.VERSION.SDK != null)
+    assert(Build.VERSION.SDK_INT != 0)
+    assert(Build.VERSION.CODENAME == "UpsideDownCake")
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -144,15 +144,25 @@ internal class Renderer(
     }
 
     buildClass.fields.forEach {
-      val originalField = originalBuildClass.getField(it.name)
-      buildClass.getFieldReflectively(it.name).setStaticValue(originalField.get(null))
+      try {
+        val originalField = originalBuildClass.getField(it.name)
+        buildClass.getFieldReflectively(it.name).setStaticValue(originalField.get(null))
+      } catch (e: NoSuchFieldException) {
+        // android.os._Original_Build from layoutlib doesn't have this field, it's probably new.
+        // Just ignore it and keep the value in android.os.Build
+      }
     }
 
     buildClass.classes.forEach { inner ->
       val originalInnerClass = originalBuildClass.classes.single { it.simpleName == inner.simpleName }
       inner.fields.forEach {
-        val originalField = originalInnerClass.getField(it.name)
-        inner.getFieldReflectively(it.name).setStaticValue(originalField.get(null))
+        try {
+          val originalField = originalInnerClass.getField(it.name)
+          inner.getFieldReflectively(it.name).setStaticValue(originalField.get(null))
+        } catch (e: NoSuchFieldException) {
+          // android.os._Original_Build from layoutlib doesn't have this field, it's probably new.
+          // Just ignore it and keep the value in android.os.Build
+        }
       }
     }
   }


### PR DESCRIPTION
Updates the `android.os.Build` copying logic via reflection to gracefully ignore fields that exist in `android.os.Build` but don't exist in `android.os._Original_Build`. These are likely new fields, which will be introduced with new compile sdk versions.

This fixes #794.
