### PR TITLE
Pin markdown python dep

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -3,7 +3,7 @@ future==0.18.3
 Jinja2==3.1.2
 livereload==2.6.3
 lunr==0.6.2
-Markdown==3.4.3
+Markdown<3.4
 MarkupSafe==2.1.2
 mkdocs==1.4.3
 mkdocs-macros-plugin==0.4.9


### PR DESCRIPTION
In efforts to fix:

```
INFO: pip is looking at multiple versions of mkdocs to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r .github/workflows/requirements.txt (line 8) and Markdown==3.4.3 because these package versions have conflicting dependencies.

The conflict is caused by:
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    The user requested Markdown==3.4.3
    mkdocs 1.4.3 depends on markdown<3.4 and >=3.2.1
```

Seen here: https://github.com/cashapp/paparazzi/actions/runs/4974717776/jobs/8901424424