### PR TITLE
Point to androidx compose compiler, not jetbrains

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,7 +8,7 @@
       // Compose compiler is tightly coupled to Kotlin version
       "groupName": "Kotlin and Compose",
       "matchPackagePrefixes": [
-        "org.jetbrains.compose.compiler",
+        "androidx.compose.compiler",
         "org.jetbrains.kotlin:kotlin",
       ],
     },


### PR DESCRIPTION
Oops, copied too quickly and didn't realize this grouped the *Jetbrains* compose compiler instead of the Androidx one!