### PR TITLE
Port ResourceSourceFile from tools/base/resource-repository

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFile.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFile.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources
+
+/**
+ * Ported from: [ResourceSourceFile.kt](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/ResourceSourceFile.kt)
+ *
+ * Represents an XML file from which an Android resource was created.
+ */
+interface ResourceSourceFile {
+  /**
+   * The path of the file relative to the resource directory, or null if the source file
+   * of the resource is not available.
+   */
+  val relativePath: String?
+
+  /**
+   * The configuration the resource file is associated with.
+   */
+  val configuration: RepositoryConfiguration
+
+  val repository: LoadableResourceRepository
+    get() = configuration.repository
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFileImpl.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFileImpl.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources
+
+/**
+ * Ported from: [ResourceSourceFileImpl.kt](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/ResourceSourceFileImpl.kt)
+ *
+ * A simple implementation of the [ResourceSourceFile] interface.
+ *
+ * [relativePath] path of the file relative to the resource directory, or null if the source file of the resource is not available
+ * [configuration] configuration the resource file is associated with
+ */
+data class ResourceSourceFileImpl(
+  override val relativePath: String?,
+  override val configuration: RepositoryConfiguration
+) : ResourceSourceFile


### PR DESCRIPTION
Part of https://github.com/cashapp/paparazzi/issues/524

Port ResourceSourceFile from tools/base/resource-repository without serialization. Keep original interface-implementation pattern to be compatible with other parts 

cc: @jrodbx 