### PR TITLE
Set Java and Kotlin options to use the same JDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     targetCompatibility = libs.versions.javaTarget.get()
   }
 
-  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {
     kotlinOptions {
       jvmTarget = libs.versions.javaTarget.get()
     }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -44,7 +44,7 @@ subprojects {
     targetCompatibility = libs.versions.javaTarget.get()
   }
 
-  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach {
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {
     kotlinOptions {
       jvmTarget = libs.versions.javaTarget.get()
     }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-a11y/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-a11y/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-recomposition/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-recomposition/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
@@ -21,4 +21,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
@@ -18,4 +18,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
@@ -19,6 +19,10 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }
 
 androidComponents {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/exclude-androidtest/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/exclude-androidtest/build.gradle
@@ -18,4 +18,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-new-resource-loading-off/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-new-resource-loading-off/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-new-resource-loading-on/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-new-resource-loading-on/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
@@ -18,6 +18,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
@@ -19,6 +19,10 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
@@ -23,4 +23,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
@@ -19,4 +19,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-compose/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-xml/build.gradle
@@ -18,6 +18,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
@@ -20,6 +20,13 @@ android {
     minSdk libs.versions.minSdk.get() as int
     vectorDrawables.useSupportLibrary = true
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
@@ -18,4 +18,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/consumer/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/consumer/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/producer/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/producer/build.gradle
@@ -18,4 +18,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prefer-dsl-namespace/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prefer-dsl-namespace/build.gradle
@@ -18,4 +18,8 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
@@ -18,4 +18,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-property-change/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-property-change/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/validate-accessibility/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/validate-accessibility/build.gradle
@@ -18,6 +18,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 tasks.withType(Test).configureEach {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
@@ -20,6 +20,13 @@ android {
     minSdk libs.versions.minSdk.get() as int
     vectorDrawables.useSupportLibrary = true
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-compose/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
@@ -20,6 +20,13 @@ android {
     minSdk libs.versions.minSdk.get() as int
     vectorDrawables.useSupportLibrary = true
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-recyclerview/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-recyclerview/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     viewBinding true
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
@@ -18,6 +18,10 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -19,6 +19,10 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -19,4 +19,11 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -20,6 +20,13 @@ android {
     minSdk libs.versions.minSdk.get() as int
     vectorDrawables.useSupportLibrary = true
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }
 
 dependencies {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
@@ -19,6 +19,13 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
   }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,6 +9,10 @@ android {
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
     viewBinding true


### PR DESCRIPTION
Unblocks Gradle 8 migration.

Specifically, fixes:
```
    Caused by: org.gradle.api.GradleException: 'compileDebugUnitTestJavaWithJavac' task (current target is 11) and 'compileDebugUnitTestKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
    Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```