### PR TITLE
Switch from kapt to ksp for Moshi codegen

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ plugin-buildConfig = { module = "com.github.gmazzo:gradle-buildconfig-plugin", v
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.8.10" }
 plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.2.0" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version = "1.8.21-1.0.11" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.18.0" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.46.0" }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     classpath libs.plugin.versions
     classpath libs.plugin.spotless
     classpath libs.plugin.buildConfig
+    classpath libs.plugin.ksp
   }
 }
 

--- a/paparazzi/paparazzi/build.gradle
+++ b/paparazzi/paparazzi/build.gradle
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinJvmPluginKt
 
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'com.google.devtools.ksp'
 
 sourceCompatibility = libs.versions.javaTarget.get()
 targetCompatibility = libs.versions.javaTarget.get()
@@ -51,10 +51,11 @@ dependencies {
   api platform(libs.kotlin.bom)
   implementation libs.moshi.core
   implementation libs.moshi.adapters
-  kapt libs.moshi.kotlinCodegen
   implementation libs.jcodec.core
   implementation libs.jcodec.javase
   implementation projects.paparazziAgent
+
+  ksp libs.moshi.kotlinCodegen
 
   def osName = System.getProperty("os.name").toLowerCase(Locale.US)
   if (osName.startsWith("mac")) {


### PR DESCRIPTION
Unblocks Gradle 8 migration.

Specifically, fixes a Spotless error requesting that spotless depend on output from kapt