### PR TITLE
Port base resource item classes from tools/base/resource-repository

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicFileResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicFileResourceItem.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources.base
+
+import app.cash.paparazzi.internal.resources.RepositoryConfiguration
+import com.android.ide.common.rendering.api.ResourceNamespace.Resolver
+import com.android.ide.common.rendering.api.ResourceReference
+import com.android.resources.ResourceType
+import com.android.resources.ResourceVisibility
+import com.android.utils.HashCodes
+
+/**
+ * Ported from: [BasicFileResourceItem.java](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/BasicFileResourceItem.java)
+ *
+ * Resource item representing a file resource, e.g. a drawable or a layout.
+ */
+class BasicFileResourceItem(
+  type: ResourceType,
+  name: String,
+  private val repositoryConfiguration: RepositoryConfiguration,
+  visibility: ResourceVisibility,
+  private val relativePath: String
+) : BasicResourceItemBase(type, name, visibility) {
+  override fun isFileBased() = true
+
+  override fun getReference(): ResourceReference? = null
+
+  override fun getRepositoryConfiguration() = repositoryConfiguration
+
+  override fun getNamespaceResolver(): Resolver = Resolver.EMPTY_RESOLVER
+
+  override fun getValue(): String = repository.getResourceUrl(relativePath)
+
+  /**
+   * The returned PathString points either to a file on disk, or to a ZIP entry inside a res.apk file.
+   * In the latter case the filesystem URI part points to res.apk itself, e.g. `"zip:///foo/bar/res.apk"`.
+   * The path part is the path of the ZIP entry containing the resource.
+   */
+  override fun getSource() = repository.getSourceFile(relativePath, true)
+
+  override fun getOriginalSource() = repository.getOriginalSourceFile(relativePath, true)
+
+  override fun equals(obj: Any?): Boolean {
+    if (this === obj) return true
+    if (!super.equals(obj)) return false
+    val other = obj as BasicFileResourceItem
+    return configuration == other.configuration && relativePath == other.relativePath
+  }
+
+  override fun hashCode(): Int {
+    return HashCodes.mix(super.hashCode(), relativePath.hashCode())
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItem.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources.base
+
+import com.android.ide.common.rendering.api.ResourceValue
+import com.android.ide.common.resources.ResourceItemWithVisibility
+
+/**
+ * Ported from: [BasicResourceItem.java](https://cs.android.com/android-studio/platform/tools/base/+/47d204001bf0cb6273d8b135c7eece3a982cf0e0:resource-repository/main/java/com/android/resources/base/BasicResourceItem.java)
+ *
+ * Combination of [ResourceItemWithVisibility] and [ResourceValue] interfaces.
+ */
+interface BasicResourceItem : ResourceItemWithVisibility, ResourceValue

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItemBase.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItemBase.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources.base
+
+import app.cash.paparazzi.internal.resources.RepositoryConfiguration
+import com.android.ide.common.rendering.api.ResourceNamespace
+import com.android.ide.common.rendering.api.ResourceReference
+import com.android.ide.common.rendering.api.ResourceValue
+import com.android.resources.ResourceType
+import com.android.resources.ResourceVisibility
+import com.android.utils.HashCodes
+import com.google.common.base.MoreObjects
+
+/**
+ * Ported from: [BasicResourceItemBase.java](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/BasicResourceItemBase.java)
+ *
+ * Base class for implementations of the [BasicResourceItem] interface.
+ *
+ */
+abstract class BasicResourceItemBase(
+  private val type: ResourceType,
+  private val name: String,
+  visibility: ResourceVisibility
+) : BasicResourceItem, ResourceValue {
+  // Store enums as their ordinals in byte form to minimize memory footprint.
+  private val typeOrdinal: Byte = type.ordinal.toByte()
+  private val visibilityOrdinal: Byte = visibility.ordinal.toByte()
+
+  override fun getType() = resourceType
+
+  override fun getNamespace(): ResourceNamespace = repository.namespace
+
+  override fun getName() = name
+
+  override fun getLibraryName() = repository.libraryName
+
+  override fun getResourceType() = ResourceType.values()[typeOrdinal.toInt()]
+
+  override fun getVisibility() = ResourceVisibility.values()[visibilityOrdinal.toInt()]
+
+  override fun getReferenceToSelf() = asReference()
+
+  override fun getResourceValue() = this
+
+  override fun isUserDefined() = repository.containsUserDefinedResources()
+
+  override fun isFramework() = namespace == ResourceNamespace.ANDROID
+
+  override fun asReference() = ResourceReference(namespace, resourceType, name)
+
+  /**
+   * Returns the repository this resource belongs to.
+   *
+   *
+   * Framework resource items may move between repositories with the same origin.
+   * @see RepositoryConfiguration.transferOwnershipTo
+   */
+  override fun getRepository() = getRepositoryConfiguration().repository
+
+  override fun getConfiguration() = getRepositoryConfiguration().folderConfiguration
+
+  abstract fun getRepositoryConfiguration(): RepositoryConfiguration
+
+  override fun getKey(): String {
+    val qualifiers = configuration.qualifierString
+    return if (qualifiers.isNotEmpty()) {
+      (type.getName() + '-') + qualifiers + '/' + name
+    } else (type.getName() + '/') + name
+  }
+
+  override fun setValue(value: String?) = throw UnsupportedOperationException()
+
+  override fun equals(obj: Any?): Boolean {
+    if (this === obj) {
+      return true
+    }
+    if (obj == null || javaClass != obj.javaClass) {
+      return false
+    }
+
+    val other = obj as BasicResourceItemBase
+    return typeOrdinal == other.typeOrdinal && name == other.name && visibilityOrdinal == other.visibilityOrdinal
+  }
+
+  override fun hashCode(): Int {
+    // The visibilityOrdinal field is intentionally not included in hash code because having two resource items
+    // differing only by visibility in the same hash table is extremely unlikely.
+    return HashCodes.mix(typeOrdinal.toInt(), name.hashCode())
+  }
+
+  override fun toString(): String {
+    return MoreObjects.toStringHelper(this)
+      .add("namespace", namespace)
+      .add("type", resourceType)
+      .add("name", name)
+      .add("value", value)
+      .toString()
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItem.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItem.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources.base
+
+import app.cash.paparazzi.internal.resources.ResourceSourceFile
+import com.android.resources.ResourceType
+import com.android.resources.ResourceVisibility
+import com.android.utils.HashCodes
+import java.util.Objects
+
+/**
+ * Ported from: [BasicValueResourceItem.java](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/BasicValueResourceItem.java)
+ *
+ * Resource item representing a value resource, e.g. a string or a color.
+ */
+class BasicValueResourceItem(
+  type: ResourceType,
+  name: String,
+  sourceFile: ResourceSourceFile,
+  visibility: ResourceVisibility,
+  private val value: String?
+) : BasicValueResourceItemBase(type, name, sourceFile, visibility) {
+  override fun getValue() = value
+
+  override fun equals(obj: Any?): Boolean {
+    if (this === obj) return true
+    if (!super.equals(obj)) return false
+    val other = obj as BasicValueResourceItem
+    return Objects.equals(value, other.value)
+  }
+
+  override fun hashCode(): Int {
+    return HashCodes.mix(super.hashCode(), value.hashCode())
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItemBase.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItemBase.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.resources.base
+
+import app.cash.paparazzi.internal.resources.RepositoryConfiguration
+import app.cash.paparazzi.internal.resources.ResourceSourceFile
+import com.android.ide.common.rendering.api.ResourceNamespace.Resolver
+import com.android.ide.common.util.PathString
+import com.android.resources.ResourceType
+import com.android.resources.ResourceVisibility
+import com.android.utils.HashCodes
+import java.util.Objects
+
+/**
+ * Ported from: [BasicValueResourceItemBase.java](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/BasicValueResourceItemBase.java)
+ *
+ * Base class for value resource items.
+ */
+abstract class BasicValueResourceItemBase(
+  type: ResourceType,
+  name: String,
+  val sourceFile: ResourceSourceFile,
+  visibility: ResourceVisibility
+) : BasicResourceItemBase(type, name, visibility) {
+  private var namespaceResolver: Resolver =
+    Resolver.EMPTY_RESOLVER
+
+  override fun getValue(): String? = null
+
+  override fun isFileBased() = false
+
+  override fun getRepositoryConfiguration(): RepositoryConfiguration = sourceFile.configuration
+
+  override fun getNamespaceResolver() = namespaceResolver
+
+  fun setNamespaceResolver(resolver: Resolver) {
+    namespaceResolver = resolver
+  }
+
+  override fun getSource(): PathString? = originalSource
+
+  override fun getOriginalSource(): PathString? {
+    val sourcePath = sourceFile.relativePath
+    return if (sourcePath == null) null else repository.getOriginalSourceFile(sourcePath, false)
+  }
+
+  override fun equals(obj: Any?): Boolean {
+    if (this === obj) return true
+    if (!super.equals(obj)) return false
+    val other = obj as BasicValueResourceItemBase
+    return Objects.equals(sourceFile, other.sourceFile)
+  }
+
+  override fun hashCode(): Int {
+    return HashCodes.mix(super.hashCode(), sourceFile.hashCode())
+  }
+}


### PR DESCRIPTION
Part of https://github.com/cashapp/paparazzi/issues/524

keep them under `resource/base` for now to prevent conflicts with existing `BasicResourceItem`

cc @jrodbx