### PR TITLE
Remove legacy manifest namespacing support

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -21,7 +21,6 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
 import com.android.build.gradle.tasks.MergeSourceSetFolders
-import com.android.ide.common.symbols.getPackageNameFromManifest
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -254,19 +253,7 @@ class PaparazziPlugin : Plugin<Project> {
     )
   }
 
-  private fun BaseExtension.packageName(): String {
-    namespace?.let { return it }
-
-    // TODO: explore whether AGP 7.x APIs can handle source set filtering
-    sourceSets
-      .filterNot { it.name.startsWith("androidTest") }
-      .map { it.manifest.srcFile }
-      .filter { it.exists() }
-      .forEach {
-        return getPackageNameFromManifest(it)
-      }
-    throw IllegalStateException("No source sets available")
-  }
+  private fun BaseExtension.packageName(): String = namespace ?: ""
 
   private fun BaseExtension.compileSdkVersion(): String {
     return compileSdkVersion!!.substringAfter("android-", DEFAULT_COMPILE_SDK_VERSION.toString())

--- a/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -98,23 +98,6 @@ class PaparazziPluginTest {
   }
 
   @Test
-  fun preferDslNamespaceOverManifestPackageDeclaration() {
-    val fixtureRoot = File("src/test/projects/prefer-dsl-namespace")
-
-    val result = gradleRunner
-      .withArguments("preparePaparazziDebugResources", "--stacktrace")
-      .runFixture(fixtureRoot) { build() }
-
-    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
-
-    val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.txt")
-    assertThat(resourcesFile.exists()).isTrue()
-
-    val resourceFileContents = resourcesFile.readLines()
-    assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.namespaced")
-  }
-
-  @Test
   fun prepareResourcesCaching() {
     val fixtureRoot = File("src/test/projects/prepare-resources-task-caching")
 


### PR DESCRIPTION
Introduced in the AGP 4.2 to 7.0 transition; this is now the expected approach in modern Android projects