### PR TITLE
Only fetch the layoutlib tag that is necessary (10GB+ -> 300M)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,7 @@ minSdk = "25"
 compileSdk = "33"
 
 # Maps to this tag: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.3.1
-layoutlib = "2022.3.1-5e972ea"
-layoutlibPrebuiltSha = "2022.3.1"
+layoutlib = "2022.3.1"
 
 [libraries]
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.7.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,9 @@ moshi = "1.15.0"
 minSdk = "25"
 compileSdk = "33"
 
-# Maps to this commit: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/5e972ea
+# Maps to this tag: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.3.1
 layoutlib = "2022.3.1-5e972ea"
-layoutlibPrebuiltSha = "5e972ea"
+layoutlibPrebuiltSha = "2022.3.1"
 
 [libraries]
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.7.0" }

--- a/libs/README.md
+++ b/libs/README.md
@@ -22,16 +22,16 @@ Note that layoutlib's version tracks [Android Studio Releases][studio_releases] 
    layoutlib = "2022.2.1"
    ```
 5. Build and upload:
-    ```
-    ./gradlew publishMavenNativeLibraryPublicationToMavenCentralRepository
-    ```
+   ```
+   ./gradlew publishMavenNativeLibraryPublicationToMavenCentralRepository
+   ```
 
    This may take a few minutes.
    It clones a large repo (300 MiB) and then uploads a large artifact (30 MiB) to Maven Central.
 
 6. Visit [Sonatype Nexus][nexus] to promote the artifact. Or drop it if there is a problem!
 7. Once deploy is live, continue with changeset from step 4 to update Paparazzi to consume this
-   latest version.  Here's an [example PR][dolphin_bump].
+   latest version. Here's an [example PR][dolphin_bump].
 
 
 Prerequisites

--- a/libs/README.md
+++ b/libs/README.md
@@ -11,18 +11,15 @@ Note that layoutlib's version tracks [Android Studio Releases][studio_releases] 
    Flamingo => 2022.2.1
    ```
 2. Find and click the [tag][prebuilt_refs] for the prebuilt corresponding to that version.
-3. Copy the commit short sha from the resulting page
+3. Copy the end of the tag name from the resulting page
+   Example: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.2.1
    ```
-   # Example: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.2.1
-
-   512837137ea60b9b86836cab7169fec5c635f422 => 5128371
+   refs/tags/studio-2022.2.1 => studio-2022.2.1
    ```
-4. Update commit link, `layoutlib` and `layoutlibPrebuiltSha` in `libs.versions.toml` as expected.
+4. Update & commit the link and `layoutlib` version in `libs.versions.toml`:
    ```
-   https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/5128371
-   ...
-   layoutlib = "2022.2.1-5128371"
-   layoutlibPrebuiltSha = "5128371"
+   # Maps to this tag: https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.2.1
+   layoutlib = "2022.2.1"
    ```
 5. Build and upload:
     ```

--- a/libs/README.md
+++ b/libs/README.md
@@ -26,8 +26,8 @@ Note that layoutlib's version tracks [Android Studio Releases][studio_releases] 
     ./gradlew publishMavenNativeLibraryPublicationToMavenCentralRepository
     ```
 
-   This may take a few minutes. It clones a large repo (2.4 GiB) and then uploads a large artifact
-   (30 MiB) to Maven Central.
+   This may take a few minutes.
+   It clones a large repo (300 MiB) and then uploads a large artifact (30 MiB) to Maven Central.
 
 6. Visit [Sonatype Nexus][nexus] to promote the artifact. Or drop it if there is a problem!
 7. Once deploy is live, continue with changeset from step 4 to update Paparazzi to consume this

--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.vanniktech.maven.publish'
  */
 tasks.register('cloneLayoutlib') {
   it.outputs.dir(repoDir)
-  it.inputs.property('sha', libs.versions.layoutlibPrebuiltSha)
+  it.inputs.property('layoutlibVersion', libs.versions.layoutlib)
 
   doFirst {
     // Gradle aggressively creates outputs directories, which interferes with the git clone check
@@ -17,7 +17,7 @@ tasks.register('cloneLayoutlib') {
       repoDir.delete()
     }
     Grgit grgit
-    String tag = "refs/tags/studio-${libs.versions.layoutlibPrebuiltSha.get()}"
+    String tag = "refs/tags/studio-${libs.versions.layoutlib.get()}"
     if (!repoDir.exists()) {
       logger.lifecycle('Cloning prebuilt layoutlib: this may take a few minutes...')
       grgit = Grgit.clone {

--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -19,7 +19,7 @@ tasks.register('cloneLayoutlib') {
     Grgit grgit
     String tag = "refs/tags/studio-${libs.versions.layoutlib.get()}"
     if (!repoDir.exists()) {
-      logger.lifecycle('Cloning prebuilt layoutlib: this may take a few minutes...')
+      logger.lifecycle("Cloning prebuilt layoutlib to ${repoDir}...")
       grgit = Grgit.clone {
         dir = repoDir
         uri = "https://android.googlesource.com/platform/prebuilts/studio/layoutlib"
@@ -30,7 +30,7 @@ tasks.register('cloneLayoutlib') {
       }
       logger.lifecycle('Cloned prebuilt layoutlib.')
     } else {
-      logger.lifecycle('Using existing prebuilt layoutlib clone.')
+      logger.lifecycle("Using existing prebuilt layoutlib clone in ${repoDir}.")
       grgit = Grgit.open {
         dir = repoDir
       }

--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -17,11 +17,16 @@ tasks.register('cloneLayoutlib') {
       repoDir.delete()
     }
     Grgit grgit
+    String tag = "refs/tags/studio-${libs.versions.layoutlibPrebuiltSha.get()}"
     if (!repoDir.exists()) {
       logger.warn('Cloning prebuilt layoutlib: this may take a few minutes...')
       grgit = Grgit.clone {
         dir = repoDir
         uri = "https://android.googlesource.com/platform/prebuilts/studio/layoutlib"
+        depth = 1
+        branches = [ tag ]
+        all = false
+        refToCheckout = tag
       }
       logger.warn('Cloned prebuilt layoutlib.')
     } else {
@@ -31,10 +36,14 @@ tasks.register('cloneLayoutlib') {
       }
     }
     grgit.withCloseable { repo ->
-      repo.fetch()
-      logger.warn("Checking out SHA ${libs.versions.layoutlibPrebuiltSha.get()}")
+      logger.warn("Fetching tag ${tag}")
+      repo.fetch {
+        refSpecs = [ tag ]
+        depth = 1
+      }
+      logger.warn("Checking out tag ${tag}")
       repo.checkout {
-        branch = libs.versions.layoutlibPrebuiltSha.get()
+        branch = tag
       }
     }
   }

--- a/libs/layoutlib/build.gradle
+++ b/libs/layoutlib/build.gradle
@@ -19,7 +19,7 @@ tasks.register('cloneLayoutlib') {
     Grgit grgit
     String tag = "refs/tags/studio-${libs.versions.layoutlibPrebuiltSha.get()}"
     if (!repoDir.exists()) {
-      logger.warn('Cloning prebuilt layoutlib: this may take a few minutes...')
+      logger.lifecycle('Cloning prebuilt layoutlib: this may take a few minutes...')
       grgit = Grgit.clone {
         dir = repoDir
         uri = "https://android.googlesource.com/platform/prebuilts/studio/layoutlib"
@@ -28,20 +28,20 @@ tasks.register('cloneLayoutlib') {
         all = false
         refToCheckout = tag
       }
-      logger.warn('Cloned prebuilt layoutlib.')
+      logger.lifecycle('Cloned prebuilt layoutlib.')
     } else {
-      logger.warn('Using existing prebuilt layoutlib clone.')
+      logger.lifecycle('Using existing prebuilt layoutlib clone.')
       grgit = Grgit.open {
         dir = repoDir
       }
     }
     grgit.withCloseable { repo ->
-      logger.warn("Fetching tag ${tag}")
+      logger.lifecycle("Fetching tag ${tag}")
       repo.fetch {
         refSpecs = [ tag ]
         depth = 1
       }
-      logger.warn("Checking out tag ${tag}")
+      logger.lifecycle("Checking out tag ${tag}")
       repo.checkout {
         branch = tag
       }


### PR DESCRIPTION
Fixes #717

The "sha" from master is pointing to the "object" of this tag:
https://android.googlesource.com/platform/prebuilts/studio/layoutlib/+/refs/tags/studio-2022.2.1

Relevant GrGit docs:
 * https://ajoberstar.org/grgit/main/grgit-clone.html
 * https://ajoberstar.org/grgit/main/grgit-fetch.html

cc @AfzalivE

```
> Task :libs:layoutlib:cloneLayoutlib
Cloning prebuilt layoutlib: this may take a few minutes...
Cloned prebuilt layoutlib.
Fetching tag refs/tags/studio-2022.2.1
Checking out tag refs/tags/studio-2022.2.1

BUILD SUCCESSFUL in 1m 30s
```

```
paparazzi\build\prebuilts\studio\layoutlib>git status
Not currently on any branch.
nothing to commit, working tree clean

paparazzi\build\prebuilts\studio\layoutlib>git branch -a
* (no branch)

paparazzi\build\prebuilts\studio\layoutlib>git tag
studio-2022.2.1
studio-2022.2.1-beta5
```

![image](https://github.com/cashapp/paparazzi/assets/2906988/c744ba35-cd68-4cd8-874d-8f0ebf286b60)
