### PR TITLE
Update AccessibilityRenderExtension to ignore invisible/gone views

### DIFF
--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/main/java/app/cash/paparazzi/plugin/test/MixedView.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/main/java/app/cash/paparazzi/plugin/test/MixedView.kt
@@ -1,6 +1,7 @@
 package app.cash.paparazzi.plugin.test
 
 import android.content.Context
+import android.view.View.GONE
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -15,6 +16,14 @@ class MixedView(context: Context) : LinearLayout(context) {
       TextView(context).apply {
         id = 1
         text = "Legacy Text View"
+      }
+    )
+
+    addView(
+      TextView(context).apply {
+        id = 1
+        text = "Hidden Legacy Text View"
+        visibility = GONE
       }
     )
 

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
@@ -17,6 +17,7 @@ package app.cash.paparazzi.accessibility
 
 import android.graphics.Rect
 import android.view.View
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
@@ -63,7 +64,7 @@ class AccessibilityRenderExtension : RenderExtension {
   private fun View.processAccessibleChildren(
     processElement: (AccessibilityElement) -> Unit
   ) {
-    if (isImportantForAccessibility && !iterableTextForAccessibility.isNullOrBlank()) {
+    if (isImportantForAccessibility && !iterableTextForAccessibility.isNullOrBlank() && visibility == VISIBLE) {
       val bounds = Rect().also(::getBoundsOnScreen)
 
       processElement(


### PR DESCRIPTION
This updates the AccessibilityRenderExtension to ignore non-compose Android views that have their visibility set to `GONE` or `INVISIBLE` to match what a user would experience with TalkBack