### PR TITLE
Cleanup `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,23 @@ See the [project website][paparazzi] for documentation and APIs.
 
 Tasks
 -------
-```
-$ ./gradlew sample:testDebug
+
+```bash
+./gradlew sample:testDebug
 ```
 
 Runs tests and generates an HTML report at `sample/build/reports/paparazzi/` showing all
 test runs and snapshots.
 
-```
-$ ./gradlew sample:recordPaparazziDebug
+```bash
+./gradlew sample:recordPaparazziDebug
 ```
 
 Saves snapshots as golden values to a predefined source-controlled location
 (defaults to `src/test/snapshots`).
 
-```
-$ ./gradlew sample:verifyPaparazziDebug
+```bash
+./gradlew sample:verifyPaparazziDebug
 ```
 
 Runs tests and verifies against previously-recorded golden values. Failures generate diffs at `sample/out/failures`.
@@ -62,11 +63,11 @@ Git LFS
 It is recommended you use [Git LFS][lfs] to store your snapshots.  Here's a quick setup:
 
 ```bash
-$ brew install git-lfs
-$ git config core.hooksPath  # optional, confirm where your git hooks will be installed
-$ git lfs install --local
-$ git lfs track "**/snapshots/**/*.png"
-$ git add .gitattributes
+brew install git-lfs
+git config core.hooksPath  # optional, confirm where your git hooks will be installed
+git lfs install --local
+git lfs track "**/snapshots/**/*.png"
+git add .gitattributes
 ```
 
 On CI, you might set up something like:

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ plugins {
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
 
 ```groovy
- repositories {
-   // ...
-   maven {
-     url 'https://oss.sonatype.org/content/repositories/snapshots/'
-   }
- }
+repositories {
+  // ...
+  maven {
+    url 'https://oss.sonatype.org/content/repositories/snapshots/'
+  }
+}
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Jetifier
 If using Jetifier to migrate off Support libraries, add the following to your `gradle.properties` to
 exclude bundled Android dependencies.
 
-```text
+```properties
 android.jetifier.ignorelist=android-base-common,common
 ```
 


### PR DESCRIPTION
See individual commits for more details.

Also, I wanted to update links to sample build outputs:

```diff
-Runs tests and generates an HTML report at `sample/build/reports/paparazzi/` showing all
+Runs tests and generates an HTML report at [`sample/build/reports/paparazzi`](sample/build/reports/paparazzi) showing all

...

-(defaults to `src/test/snapshots`).
+(defaults to [`sample/src/test/snapshots`](sample/src/test/snapshots)).

...

-Runs tests and verifies against previously-recorded golden values. Failures generate diffs at `sample/out/failures`.
+Runs tests and verifies against previously-recorded golden values. Failures generate diffs at [`sample/out/failures`](sample/out/failures).
```

But since these will be displayed on the MkDocs webpage, links won't work unless we add some clever tricks to either rename the links, or to disable them.
What would you do for these 3 local links?