### PR TITLE
Remove null from name on gif screenshots

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -101,7 +101,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
         val shot = if (hashes.size == 1) {
           val original = File(imagesDirectory, "${hashes[0]}.png")
           if (isRecording) {
-            val goldenFile = File(goldenImagesDirectory, snapshot.toFileName("_", "png"))
+            val goldenFile = snapshot.goldenFile(goldenImagesDirectory)
             original.copyTo(goldenFile, overwrite = true)
           }
           snapshot.copy(file = original.toJsonPath())
@@ -110,11 +110,10 @@ public class HtmlReportWriter @JvmOverloads constructor(
 
           if (isRecording) {
             for ((index, frameHash) in hashes.withIndex()) {
-              val originalFrame = File(imagesDirectory, "$frameHash.png")
-              val frameSnapshot = snapshot.copy(name = "${snapshot.name} $index")
-              val goldenFile = File(goldenImagesDirectory, frameSnapshot.toFileName("_", "png"))
+              val goldenFile = snapshot.goldenFile(goldenImagesDirectory, frame = index)
               if (!goldenFile.exists()) {
-                originalFrame.copyTo(goldenFile)
+                val original = File(imagesDirectory, "$frameHash.png")
+                original.copyTo(goldenFile)
               }
             }
           }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -16,6 +16,7 @@
 package app.cash.paparazzi
 
 import dev.drewhamilton.poko.Poko
+import java.io.File
 import java.util.Date
 import java.util.Locale
 
@@ -46,4 +47,13 @@ internal fun Snapshot.toFileName(
     ""
   }
   return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension"
+}
+
+internal fun Snapshot.goldenFile(goldenImagesDirectory: File, frame: Int? = null): File {
+  return if (frame == null) {
+    File(goldenImagesDirectory, toFileName("_", "png"))
+  } else {
+    val frameSnapshot = copy(name = "$name $frame")
+    File(goldenImagesDirectory, frameSnapshot.toFileName("_", "png"))
+  }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -53,7 +53,7 @@ internal fun Snapshot.goldenFile(goldenImagesDirectory: File, frame: Int? = null
   return if (frame == null) {
     File(goldenImagesDirectory, toFileName("_", "png"))
   } else {
-    val frameSnapshot = copy(name = "$name $frame")
-    File(goldenImagesDirectory, frameSnapshot.toFileName("_", "png"))
+    val name = if (name == null) "$frame" else "$name $frame"
+    File(goldenImagesDirectory, copy(name = name).toFileName("_", "png"))
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -41,7 +41,7 @@ public class SnapshotVerifier @JvmOverloads constructor(
     return object : FrameHandler {
       override fun handle(image: BufferedImage) {
         // Note: does not handle videos or its frames at the moment
-        val expected = File(imagesDirectory, snapshot.toFileName(extension = "png"))
+        val expected = snapshot.goldenFile(imagesDirectory)
         if (!expected.exists()) {
           throw AssertionError("File $expected does not exist")
         }

--- a/paparazzi/src/test/java/app/cash/paparazzi/SnapshotKtTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/SnapshotKtTest.kt
@@ -52,7 +52,7 @@ class SnapshotKtTest {
     ).goldenFile(File("/a/path"), 1)
 
     assertThat(path)
-      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings_null_1.png"))
+      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings_1.png"))
   }
 }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/SnapshotKtTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/SnapshotKtTest.kt
@@ -1,0 +1,59 @@
+package app.cash.paparazzi
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+import java.time.Instant
+import java.util.Date
+
+class SnapshotKtTest {
+  @Test
+  fun withName() {
+    val path = Snapshot(
+      name = "loading",
+      testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+      timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+    ).goldenFile(File("/a/path"))
+
+    assertThat(path)
+      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings_loading.png"))
+  }
+
+  @Test
+  fun withoutName() {
+    val path = Snapshot(
+      name = null,
+      testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+      timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+    ).goldenFile(File("/a/path"))
+
+    assertThat(path)
+      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings.png"))
+  }
+
+  @Test
+  fun withNameAndFrame() {
+    val path = Snapshot(
+      name = "loading",
+      testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+      timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+    ).goldenFile(File("/a/path"), 0)
+
+    assertThat(path)
+      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings_loading_0.png"))
+  }
+
+  @Test
+  fun withoutNameAndWithFrame() {
+    val path = Snapshot(
+      name = null,
+      testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+      timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+    ).goldenFile(File("/a/path"), 1)
+
+    assertThat(path)
+      .isEqualTo(File("/a/path/app.cash.paparazzi_CelebrityTest_testSettings_null_1.png"))
+  }
+}
+
+private fun Instant.toDate() = Date(toEpochMilli())


### PR DESCRIPTION
Right now when you run paparazzi with `gif` without setting a name the files that paparazzi create ends with `_null_0.png`. That `"null"` is the `name`  that was not set. This PR aligns the naming of `gif` and `screenshot`. Now, if you don't set a name on `gif` the screenshot name will end with `_0.png`.

A diff is worth a thousand words:
https://github.com/BraisGabin/paparazzi/commit/21bc089b7f594dbd2c0feb47f97ef77794e49e35#diff-7522c35360e75c4ed0d453217b86bfe469ea3cc1b4cabc2597f1cbf9fc6d4173L55-R55

I splitted this PR in two commits. The first one extracts this logic to a different file and add tests to the current behaviour. On the second one I fix the naming issue.

Note: this PR shares the first commit with #902. I'll rebase this (or the other PR) when one of them is merged.