### PR TITLE
Port ModuleResourceRepository from platform/tools/adt/idea

### DIFF
--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LocalResourceRepository.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LocalResourceRepository.kt
@@ -1,6 +1,5 @@
 package app.cash.paparazzi.internal.resources
 
-import app.cash.paparazzi.internal.MultiResourceRepository
 import com.android.ide.common.rendering.api.ResourceNamespace
 import com.android.ide.common.resources.AbstractResourceRepository
 import com.android.ide.common.resources.ResourceItem

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ModuleResourceRepository.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ModuleResourceRepository.kt
@@ -1,0 +1,71 @@
+package app.cash.paparazzi.internal.resources
+
+import com.android.ide.common.rendering.api.ResourceNamespace
+import com.android.ide.common.resources.SingleNamespaceResourceRepository
+import java.io.File
+
+/**
+ * Ported from: [ModuleResourceRepository.java](https://cs.android.com/android-studio/platform/tools/adt/idea/+/c847337ee5caa1d57cb1cb991cfcafaf6c90d0c6:android/src/com/android/tools/idea/res/ModuleResourceRepository.java)
+ *
+ * A repository responsible for all resources defined in all resource folders of a given module.
+ * A resource folder can point to:
+ * - A resource source set (src/main/res, src/debug/res)
+ * - A location where [res values](https://developer.android.com/build/gradle-tips#share-custom-fields-and-resource-values-with-your-app-code) are generated
+ */
+internal class ModuleResourceRepository private constructor(
+  displayName: String,
+  private val namespace: ResourceNamespace,
+  delegates: List<LocalResourceRepository>
+) : MultiResourceRepository(displayName), SingleNamespaceResourceRepository {
+  init {
+    setChildren(delegates, emptyList())
+  }
+
+  override fun getNamespace(): ResourceNamespace = namespace
+
+  override fun getPackageName(): String? = namespace.packageName
+  override fun getNamespaces(): Set<ResourceNamespace> =
+    super<MultiResourceRepository>.getNamespaces()
+
+  override fun getLeafResourceRepositories(): Collection<SingleNamespaceResourceRepository> =
+    super<MultiResourceRepository>.getLeafResourceRepositories()
+
+  companion object {
+    /**
+     * Returns the resource repository for a single module (which can possibly have multiple resource folders).
+     * Does not include resources from any dependencies.
+     *
+     * @param namespace the namespace for the repository
+     * @return the resource repository
+     */
+    fun forMainResources(
+      namespace: ResourceNamespace,
+      resourceDirectories: List<File>
+    ): LocalResourceRepository {
+      return ModuleResourceRepository(
+        displayName = "", // TODO
+        namespace = namespace,
+        delegates = addRepositoriesInReverseOverlayOrder(resourceDirectories, namespace)
+      )
+    }
+
+    /**
+     * Inserts repositories for the given [resourceDirectories] as [ResourceFolderRepository] instances, in the right order.
+     *
+     * [resourceDirectories] is assumed to be in the inverse order of what we need. The code in
+     * [MultiResourceRepository.getMap] gives priority to child repositories which are earlier
+     * in the list, so after creating repositories for every folder, we add them in reverse to the list.
+     *
+     * @param resourceDirectories directories for which repositories should be constructed
+     */
+    private fun addRepositoriesInReverseOverlayOrder(
+      resourceDirectories: List<File>,
+      namespace: ResourceNamespace
+    ): List<LocalResourceRepository> =
+      buildList {
+        resourceDirectories.asReversed().forEach {
+          add(ResourceFolderRepository(it, namespace))
+        }
+      }
+  }
+}

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/MultiResourceRepository.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/MultiResourceRepository.kt
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paparazzi.internal
+package app.cash.paparazzi.internal.resources
 
-import app.cash.paparazzi.internal.resources.AarSourceResourceRepository
-import app.cash.paparazzi.internal.resources.LocalResourceRepository
 import com.android.ide.common.rendering.api.ResourceNamespace
 import com.android.ide.common.resources.ResourceItem
 import com.android.ide.common.resources.ResourceRepository
@@ -51,7 +49,7 @@ import kotlin.collections.Map.Entry
  *
  * <p>In the resource repository hierarchy, MultiResourceRepository is an internal node, never a leaf.
  */
-abstract class MultiResourceRepository internal constructor(displayName: String) :
+internal abstract class MultiResourceRepository internal constructor(displayName: String) :
   LocalResourceRepository(displayName) {
   private var localResources = listOf<LocalResourceRepository>()
 

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
@@ -1,0 +1,24 @@
+package app.cash.paparazzi.internal.resources
+
+import com.android.ide.common.rendering.api.ResourceNamespace
+import com.android.resources.ResourceType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+class ModuleResourceRepositoryTest {
+  @Test
+  fun test() {
+    val repository = ModuleResourceRepository.forMainResources(
+      namespace = ResourceNamespace.RES_AUTO,
+      resourceDirectories = listOf(File("src/test/resources/folders/res"))
+    )
+
+    val map = repository.allResources
+
+    assertThat(map[0].name).isEqualTo("slide_in_from_left")
+    assertThat(map[0].type).isEqualTo(ResourceType.ANIM)
+    assertThat(map[1].name).isEqualTo("test_animator")
+    assertThat(map[1].type).isEqualTo(ResourceType.ANIMATOR)
+  }
+}

--- a/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ResourceFolderRepositoryTest.kt
+++ b/paparazzi/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ResourceFolderRepositoryTest.kt
@@ -1,7 +1,5 @@
-package app.cash.paparazzi.internal
+package app.cash.paparazzi.internal.resources
 
-import app.cash.paparazzi.internal.resources.ResourceFolderRepository
-import app.cash.paparazzi.internal.resources.resolveProjectPath
 import com.android.ide.common.rendering.api.ArrayResourceValue
 import com.android.ide.common.rendering.api.AttrResourceValue
 import com.android.ide.common.rendering.api.AttributeFormat


### PR DESCRIPTION
Also, move MultiResourceRepository into /resources namespace

Part of https://github.com/cashapp/paparazzi/issues/524

cc: @kevinzheng-ap