### PR TITLE
Set useCompiled9Patches to false in FrameworkResourceRepository

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -75,7 +75,7 @@ internal class Renderer(
           FrameworkResourceRepository.create(
             resourceDirectoryOrFile = platformDataResDir.toPath(),
             languagesToLoad = emptySet(),
-            useCompiled9Patches = true
+            useCompiled9Patches = false
           )
         ) to
           ResourceRepositoryBridge.New(

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepositoryTest.kt
@@ -47,6 +47,30 @@ class FrameworkResourceRepositoryTest {
     checkContents(withFrenchAndGerman)
   }
 
+  @Test
+  fun useCompiled9Patches() {
+    val repository = FrameworkResourceRepository.create(
+      resourceDirectoryOrFile = getFrameworkResJar(),
+      languagesToLoad = emptySet(),
+      useCompiled9Patches = true
+    )
+
+    val resourceUrl = repository.getResourceUrl("drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
+    assertThat(resourceUrl).isEqualTo("jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.compiled.9.png")
+  }
+
+  @Test
+  fun notUseCompiled9Patches() {
+    val repository = FrameworkResourceRepository.create(
+      resourceDirectoryOrFile = getFrameworkResJar(),
+      languagesToLoad = emptySet(),
+      useCompiled9Patches = false
+    )
+
+    val resourceUrl = repository.getResourceUrl("drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
+    assertThat(resourceUrl).isEqualTo("jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
+  }
+
   private fun getFrameworkResJar(): Path =
     Paths.get("src/test/resources/framework/framework_res.jar")
 


### PR DESCRIPTION
Set useCompiled9Patches to `false` in FrameworkResourceRepository to use original 9 patch file rather than the compiled one

cc @jrodbx 