### PR TITLE
Ignore xliff in XmlTextExtractor

### DIFF
--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
@@ -16,7 +16,7 @@ class AppResourceRepositoryTest {
     )
 
     val map = repository.allResources
-    assertThat(map.size).isEqualTo(44)
+    assertThat(map.size).isEqualTo(45)
 
     assertThat(map[0].name).isEqualTo("slide_in_from_left")
     assertThat(map[0].type).isEqualTo(ResourceType.ANIM)
@@ -27,7 +27,7 @@ class AppResourceRepositoryTest {
     assertThat(map[4].type).isEqualTo(ResourceType.ATTR)
     assertThat((map[4].resourceValue as AttrResourceValue).formats).isEqualTo(setOf(AttributeFormat.COLOR))
 
-    assertThat(map[43].name).isEqualTo("test_network_security_config")
-    assertThat(map[43].type).isEqualTo(ResourceType.XML)
+    assertThat(map[44].name).isEqualTo("test_network_security_config")
+    assertThat(map[44].type).isEqualTo(ResourceType.XML)
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
@@ -15,14 +15,14 @@ class ModuleResourceRepositoryTest {
     )
 
     val map = repository.allResources
-    assertThat(map.size).isEqualTo(31)
+    assertThat(map.size).isEqualTo(32)
 
     assertThat(map[0].name).isEqualTo("slide_in_from_left")
     assertThat(map[0].type).isEqualTo(ResourceType.ANIM)
     assertThat(map[1].name).isEqualTo("test_animator")
     assertThat(map[1].type).isEqualTo(ResourceType.ANIMATOR)
 
-    assertThat(map[30].name).isEqualTo("test_network_security_config")
-    assertThat(map[30].type).isEqualTo(ResourceType.XML)
+    assertThat(map[31].name).isEqualTo("test_network_security_config")
+    assertThat(map[31].type).isEqualTo(ResourceType.XML)
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
@@ -14,14 +14,14 @@ class ProjectResourceRepositoryTest {
     )
 
     val map = repository.allResources
-    assertThat(map.size).isEqualTo(31)
+    assertThat(map.size).isEqualTo(32)
 
     assertThat(map[0].name).isEqualTo("slide_in_from_left")
     assertThat(map[0].type).isEqualTo(ResourceType.ANIM)
     assertThat(map[1].name).isEqualTo("test_animator")
     assertThat(map[1].type).isEqualTo(ResourceType.ANIMATOR)
 
-    assertThat(map[30].name).isEqualTo("test_network_security_config")
-    assertThat(map[30].type).isEqualTo(ResourceType.XML)
+    assertThat(map[31].name).isEqualTo("test_network_security_config")
+    assertThat(map[31].type).isEqualTo(ResourceType.XML)
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ResourceFolderRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ResourceFolderRepositoryTest.kt
@@ -22,7 +22,7 @@ class ResourceFolderRepositoryTest {
     )
 
     val map = repository.allResources
-    assertThat(map.size).isEqualTo(31)
+    assertThat(map.size).isEqualTo(32)
 
     // ANIM
     assertThat(map[0].name).isEqualTo("slide_in_from_left")
@@ -135,11 +135,15 @@ class ResourceFolderRepositoryTest {
     // STRINGS
     assertThat(map[27].name).isEqualTo("string_name")
     assertThat(map[27].type).isEqualTo(ResourceType.STRING)
+    assertThat(map[27].resourceValue.value).isEqualTo("Test String")
+    assertThat(map[28].name).isEqualTo("string_name_xliff")
+    assertThat(map[28].type).isEqualTo(ResourceType.STRING)
+    assertThat(map[28].resourceValue.value).isEqualTo("Test String {0} with suffix")
 
     // STYLE XML
-    assertThat(map[28].name).isEqualTo("TestStyle")
-    assertThat(map[28].type).isEqualTo(ResourceType.STYLE)
-    with(map[28].resourceValue as StyleResourceValue) {
+    assertThat(map[29].name).isEqualTo("TestStyle")
+    assertThat(map[29].type).isEqualTo(ResourceType.STYLE)
+    with(map[29].resourceValue as StyleResourceValue) {
       assertThat(definedItems.size).isEqualTo(2)
       assertThat(definedItems.elementAt(0).attrName).isEqualTo("android:scrollbars")
       assertThat(definedItems.elementAt(0).value).isEqualTo("horizontal")
@@ -148,9 +152,9 @@ class ResourceFolderRepositoryTest {
     }
 
     // STYLEABLE
-    assertThat(map[29].name).isEqualTo("test_styleable")
-    assertThat(map[29].type).isEqualTo(ResourceType.STYLEABLE)
-    with(map[29].resourceValue as StyleableResourceValue) {
+    assertThat(map[30].name).isEqualTo("test_styleable")
+    assertThat(map[30].type).isEqualTo(ResourceType.STYLEABLE)
+    with(map[30].resourceValue as StyleableResourceValue) {
       assertThat(allAttributes.size).isEqualTo(3)
       assertThat(allAttributes[0].name).isEqualTo("TestAttr")
       assertThat(allAttributes[1].name).isEqualTo("TestAttrInt")
@@ -158,7 +162,7 @@ class ResourceFolderRepositoryTest {
     }
 
     // XML
-    assertThat(map[30].name).isEqualTo("test_network_security_config")
-    assertThat(map[30].type).isEqualTo(ResourceType.XML)
+    assertThat(map[31].name).isEqualTo("test_network_security_config")
+    assertThat(map[31].type).isEqualTo(ResourceType.XML)
   }
 }

--- a/paparazzi/src/test/resources/folders/res/values/strings.xml
+++ b/paparazzi/src/test/resources/folders/res/values/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="plural_name">
     <item quantity="zero">Nothing</item>
     <item quantity="one">One String</item>
   </plurals>
   <string name="string_name">Test String</string>
+  <string name="string_name_xliff">Test String <xliff:g id="number" example="9">{0}</xliff:g> with suffix</string>
   <string-array name="string_array_name">
     <item>First Test String</item>
     <item>Second Test String</item>


### PR DESCRIPTION
Ignore `xliff` in XmlTextExtractor to keep original parameter like `(0)` rather than being transformed to example like `{9}`

cc @jrodbx 