### PR TITLE
Cleanup generated test project files sooner

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1283,19 +1283,27 @@ class PaparazziPluginTest {
     action: GradleRunner.() -> BuildResult
   ): BuildResult {
     val settings = File(projectRoot, "settings.gradle")
-    if (!settings.exists()) {
-      settings.createNewFile()
-      settings.writeText("apply from: \"../test.settings.gradle\"")
-      settings.deleteOnExit()
-    }
-
     val gradleProperties = File(projectRoot, "gradle.properties")
-    if (!gradleProperties.exists()) {
-      gradleProperties.createNewFile()
-      gradleProperties.writeText("android.useAndroidX=true")
-      gradleProperties.deleteOnExit()
-    }
+    var generatedSettings = false
+    var generatedGradleProperties = false
 
-    return withProjectDir(projectRoot).action()
+    return try {
+      if (!settings.exists()) {
+        settings.createNewFile()
+        settings.writeText("apply from: \"../test.settings.gradle\"")
+        generatedSettings = true
+      }
+
+      if (!gradleProperties.exists()) {
+        gradleProperties.createNewFile()
+        gradleProperties.writeText("android.useAndroidX=true")
+        generatedGradleProperties = true
+      }
+
+      withProjectDir(projectRoot).action()
+    } finally {
+      if (generatedSettings) settings.delete()
+      if (generatedGradleProperties) gradleProperties.delete()
+    }
   }
 }


### PR DESCRIPTION
File.deleteOnExit() defers cleanup until process shutdown, unless a Ctrl-C (kill -9) prevents this.

Instead, let's deterministically clean up files after each test method.   A well-timed Ctrl-C may still halt a single test project's cleanup, but that's better than N projects!