### PR TITLE
Simplify plugin publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           java-version: 17
 
       - name: Publish Artifacts
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository --no-parallel
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository --no-parallel
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 17
 
       - name: Publish Artifacts
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository --no-parallel
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository --no-parallel
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION

```bash
./gradlew :paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository --dry-run
```
<details close>
<summary>Output</summary>
<br>

```bash
:paparazzi-gradle-plugin:createStagingRepository SKIPPED
:paparazzi-gradle-plugin:generateBuildConfig SKIPPED
:paparazzi-gradle-plugin:compileKotlin SKIPPED
:paparazzi-gradle-plugin:compileJava SKIPPED
:paparazzi-gradle-plugin:pluginDescriptors SKIPPED
:paparazzi-gradle-plugin:processResources SKIPPED
:paparazzi-gradle-plugin:classes SKIPPED
:paparazzi-gradle-plugin:jar SKIPPED
:paparazzi-gradle-plugin:sourcesJar SKIPPED
:paparazzi-gradle-plugin:generateMetadataFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:signPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:javadoc SKIPPED
:paparazzi-gradle-plugin:simpleJavadocJar SKIPPED
:paparazzi-gradle-plugin:signPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository SKIPPED
```

</details>

```bash
./gradlew :paparazzi-gradle-plugin:publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository --dry-run
```
<details close>
<summary>Output</summary>
<br>

```
:paparazzi-gradle-plugin:createStagingRepository SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:signPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:generateBuildConfig SKIPPED
:paparazzi-gradle-plugin:compileKotlin SKIPPED
:paparazzi-gradle-plugin:compileJava SKIPPED
:paparazzi-gradle-plugin:pluginDescriptors SKIPPED
:paparazzi-gradle-plugin:processResources SKIPPED
:paparazzi-gradle-plugin:classes SKIPPED
:paparazzi-gradle-plugin:jar SKIPPED
:paparazzi-gradle-plugin:sourcesJar SKIPPED
:paparazzi-gradle-plugin:generateMetadataFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:javadoc SKIPPED
:paparazzi-gradle-plugin:simpleJavadocJar SKIPPED
:paparazzi-gradle-plugin:signPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository SKIPPED
```

</details>

```bash
./gradlew :paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository --dry-run
```
<details close>
<summary>Output</summary>
<br>

```
:paparazzi-gradle-plugin:createStagingRepository SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:signPaparazziPluginMarkerMavenPublication SKIPPED
:paparazzi-gradle-plugin:generateBuildConfig SKIPPED
:paparazzi-gradle-plugin:compileKotlin SKIPPED
:paparazzi-gradle-plugin:compileJava SKIPPED
:paparazzi-gradle-plugin:pluginDescriptors SKIPPED
:paparazzi-gradle-plugin:processResources SKIPPED
:paparazzi-gradle-plugin:classes SKIPPED
:paparazzi-gradle-plugin:jar SKIPPED
:paparazzi-gradle-plugin:sourcesJar SKIPPED
:paparazzi-gradle-plugin:generateMetadataFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:generatePomFileForPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:javadoc SKIPPED
:paparazzi-gradle-plugin:simpleJavadocJar SKIPPED
:paparazzi-gradle-plugin:signPluginMavenPublication SKIPPED
:paparazzi-gradle-plugin:publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository SKIPPED
:paparazzi-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository SKIPPED
:paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository SKIPPED
```

</details>

Removing common tasks from all runs show that `publishAllPublicationsToMavenCentralRepository` depends on `publishPluginMavenPublicationToMavenCentralRepository` and `publishPaparazziPluginMarkerMavenPublicationToMavenCentralRepository`