### PR TITLE
Fix relative path for module

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -89,6 +89,7 @@ class PaparazziPlugin : Plugin<Project> {
       val mergeAssetsProvider =
         project.tasks.named("merge${variantSlug}Assets") as TaskProvider<MergeSourceSetFolders>
       val mergeAssetsOutputDir = mergeAssetsProvider.flatMap { it.outputDir }
+      val projectDirectory = project.layout.projectDirectory
       val buildDirectory = project.layout.buildDirectory
       val gradleUserHomeDir = project.gradle.gradleUserHomeDir
       val reportOutputDir = buildDirectory.dir("reports/paparazzi")
@@ -175,6 +176,7 @@ class PaparazziPlugin : Plugin<Project> {
       val testTaskProvider = project.tasks.named("test$testVariantSlug", Test::class.java) { test ->
         test.systemProperties["paparazzi.test.resources"] =
           writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
+        test.systemProperties["paparazzi.project.dir"] = projectDirectory.toString()
         test.systemProperties["paparazzi.build.dir"] = buildDirectory.get().toString()
         test.systemProperties["paparazzi.artifacts.cache.dir"] = gradleUserHomeDir.path
         test.systemProperties["kotlinx.coroutines.main.delay"] = true

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -118,6 +118,10 @@ tasks.withType(Test).configureEach {
     generateTestConfig.map { it.outputs.files.singleFile }.get().path
   )
   systemProperty(
+    "paparazzi.project.dir",
+    project.layout.projectDirectory.toString()
+  )
+  systemProperty(
     "paparazzi.build.dir",
     project.layout.buildDirectory.get().toString()
   )

--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -55,6 +55,7 @@ fun detectEnvironment(): Environment {
   val resourcesFile = File(System.getProperty("paparazzi.test.resources"))
   val configLines = resourcesFile.readLines()
 
+  val projectDir = Paths.get(System.getProperty("paparazzi.project.dir"))
   val appTestDir = Paths.get(System.getProperty("paparazzi.build.dir"))
   val artifactsCacheDir = Paths.get(System.getProperty("paparazzi.artifacts.cache.dir"))
   val androidHome = Paths.get(androidHome())
@@ -66,7 +67,7 @@ fun detectEnvironment(): Environment {
     packageName = configLines[0],
     compileSdkVersion = configLines[2].toInt(),
     resourcePackageNames = configLines[5].split(","),
-    localResourceDirs = configLines[6].split(","),
+    localResourceDirs = configLines[6].split(",").map { projectDir.resolve(it).toString() },
     libraryResourceDirs = configLines[7].split(",").map { artifactsCacheDir.resolve(it).toString() }
   )
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
@@ -930,12 +930,11 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
     if (file.isAbsolute) {
       return resourceDirectoryOrFilePath.relativize(file).portablePath
     }
+
+    // The path is already relative, drop the first "res" segment.
     assert(file.nameCount != 0)
-    // Note that Android Studio's version of RepositoryLoader asserts that /res is segments[0]
-    // we weaken this to check for existence
-    val index = file.segments.indexOf("res")
-    assert(index != -1)
-    return file.subpath(index + 1, file.nameCount).portablePath
+    assert(file.segment(0) == "res")
+    return file.subpath(1, file.nameCount).portablePath
   }
 
   private fun interface XmlTagVisitor {

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
@@ -5,13 +5,12 @@ import com.android.ide.common.rendering.api.AttributeFormat
 import com.android.resources.ResourceType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import java.io.File
 
 class AppResourceRepositoryTest {
   @Test
   fun test() {
     val repository = AppResourceRepository.create(
-      localResourceDirectories = listOf(File("src/test/resources/folders/res")),
+      localResourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile()),
       libraryRepositories = listOf(makeAarRepositoryFromExplodedAar("my_aar_lib"))
     )
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ModuleResourceRepositoryTest.kt
@@ -4,14 +4,13 @@ import com.android.ide.common.rendering.api.ResourceNamespace
 import com.android.resources.ResourceType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import java.io.File
 
 class ModuleResourceRepositoryTest {
   @Test
   fun test() {
     val repository = ModuleResourceRepository.forMainResources(
       namespace = ResourceNamespace.RES_AUTO,
-      resourceDirectories = listOf(File("src/test/resources/folders/res"))
+      resourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile())
     )
 
     val map = repository.allResources

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
@@ -3,14 +3,13 @@ package app.cash.paparazzi.internal.resources
 import com.android.resources.ResourceType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import java.io.File
 
 class ProjectResourceRepositoryTest {
   @Test
   fun test() {
     // TODO: need mapOf(package to listOf(resourceDirectory)) for each transitive project module
     val repository = ProjectResourceRepository.create(
-      resourceDirectories = listOf(File("src/test/resources/folders/res"))
+      resourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile())
     )
 
     val map = repository.allResources


### PR DESCRIPTION
In [RepositoryLoader](https://github.com/cashapp/paparazzi/blob/7e7a8486057610a00b4fba664b5aa23dce5f06f7/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt#L937), today it looks for `res` segment and get sub path if the resource file is relative path. In our resources.txt, the module path is this pattern `../module/build/intermediates/packaged_res/debug`. So current assertion fails as no exact `res` is found. 

The solution is to make locale resource paths absolute to allow it be relativized properly. I have added `sample module` in our test and confirmed it is working. 

cc @jrodbx 