### PR TITLE
Split local resources to local and module in resources.txt

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -127,7 +127,8 @@ class PaparazziPlugin : Plugin<Project> {
         task.targetSdkVersion.set(android.targetSdkVersion())
         task.compileSdkVersion.set(android.compileSdkVersion())
         task.mergeAssetsOutputDir.set(buildDirectory.asRelativePathString(mergeAssetsOutputDir))
-        task.projectResourceDirs.from(localResourceDirs.plus(moduleResourceDirs))
+        task.projectResourceDirs.from(localResourceDirs)
+        task.moduleResourceDirs.from(moduleResourceDirs)
         task.aarExplodedDirs.from(aarExplodedDirs)
         task.paparazziResources.set(buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.txt"))
       }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -48,6 +48,10 @@ abstract class PrepareResourcesTask : DefaultTask() {
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.NONE)
+  abstract val moduleResourceDirs: ConfigurableFileCollection
+
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.NONE)
   abstract val aarExplodedDirs: ConfigurableFileCollection
 
   @get:Input
@@ -102,6 +106,8 @@ abstract class PrepareResourcesTask : DefaultTask() {
         it.write(resourcePackageNames)
         it.newLine()
         it.write(projectResourceDirs.joinFiles(projectDirectory))
+        it.newLine()
+        it.write(moduleResourceDirs.joinFiles(projectDirectory))
         it.newLine()
         it.write(aarExplodedDirs.joinFiles(gradleUserHomeDirectory))
         it.newLine()

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -741,9 +741,10 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
-    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary")
+    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
+    assertThat(resourceFileContents[7]).isEqualTo("module1/build/intermediates/packaged_res/debug,module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
   @Test
@@ -763,9 +764,10 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
-    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary")
+    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
+    assertThat(resourceFileContents[7]).isEqualTo("module1/build/intermediates/packaged_res/debug,module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'com.android.library'
+  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
 android {
-  namespace 'app.cash.paparazzi.plugin.test'
+  namespace 'app.cash.paparazzi.plugin.test.module1'
   compileSdk libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
@@ -13,10 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
-}
-
-dependencies {
-  implementation files('libs/external.aar')
-  implementation project("module1")
-  implementation project("module2")
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'com.android.library'
+  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
 android {
-  namespace 'app.cash.paparazzi.plugin.test'
+  namespace 'app.cash.paparazzi.plugin.test.module2'
   compileSdk libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
@@ -13,10 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
-}
-
-dependencies {
-  implementation files('libs/external.aar')
-  implementation project("module1")
-  implementation project("module2")
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/settings.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/settings.gradle
@@ -1,0 +1,4 @@
+apply from: '../test.settings.gradle'
+
+include ':module1'
+include ':module2'

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -18,4 +18,6 @@ android {
 
 dependencies {
   implementation files('libs/external.aar')
+  implementation project("module1")
+  implementation project("module2")
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'com.android.library'
+  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
 android {
-  namespace 'app.cash.paparazzi.plugin.test'
+  namespace 'app.cash.paparazzi.plugin.test.module1'
   compileSdk libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
@@ -13,10 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
-}
-
-dependencies {
-  implementation files('libs/external.aar')
-  implementation project("module1")
-  implementation project("module2")
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'com.android.library'
+  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
 android {
-  namespace 'app.cash.paparazzi.plugin.test'
+  namespace 'app.cash.paparazzi.plugin.test.module2'
   compileSdk libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
@@ -13,10 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
-}
-
-dependencies {
-  implementation files('libs/external.aar')
-  implementation project("module1")
-  implementation project("module2")
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/settings.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/settings.gradle
@@ -1,0 +1,4 @@
+apply from: '../test.settings.gradle'
+
+include ':module1'
+include ':module2'

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -107,6 +107,7 @@ def generateTestConfig = tasks.register("generateTestConfig") {
       writer.writeLine("app.cash.paparazzi")
       writer.writeLine("")
       writer.writeLine("")
+      writer.writeLine("")
     }
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -31,6 +31,7 @@ data class Environment(
   val compileSdkVersion: Int,
   val resourcePackageNames: List<String>,
   val localResourceDirs: List<String>,
+  val moduleResourceDirs: List<String>,
   val libraryResourceDirs: List<String>
 ) {
   init {
@@ -68,7 +69,8 @@ fun detectEnvironment(): Environment {
     compileSdkVersion = configLines[2].toInt(),
     resourcePackageNames = configLines[5].split(","),
     localResourceDirs = configLines[6].split(",").map { projectDir.resolve(it).toString() },
-    libraryResourceDirs = configLines[7].split(",").map { artifactsCacheDir.resolve(it).toString() }
+    moduleResourceDirs = configLines[7].split(",").filter { it.isNotEmpty() }.map { projectDir.resolve(it).toString() },
+    libraryResourceDirs = configLines[8].split(",").map { artifactsCacheDir.resolve(it).toString() }
   )
 }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -81,6 +81,7 @@ internal class Renderer(
           ResourceRepositoryBridge.New(
             AppResourceRepository.create(
               localResourceDirectories = environment.localResourceDirs.map { File(it) },
+              moduleResourceDirectories = environment.moduleResourceDirs.map { File(it) },
               libraryRepositories = environment.libraryResourceDirs.map { dir ->
                 val resourceDirPath = Paths.get(dir)
                 AarSourceResourceRepository.create(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AppResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AppResourceRepository.kt
@@ -25,11 +25,12 @@ internal class AppResourceRepository private constructor(
   companion object {
     fun create(
       localResourceDirectories: List<File>,
+      moduleResourceDirectories: List<File>,
       libraryRepositories: Collection<AarSourceResourceRepository>
     ): AppResourceRepository {
       return AppResourceRepository(
         displayName = "",
-        listOf(ProjectResourceRepository.create(localResourceDirectories)),
+        listOf(ProjectResourceRepository.create(localResourceDirectories, moduleResourceDirectories)),
         libraryRepositories
       )
     }

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/AppResourceRepositoryTest.kt
@@ -11,6 +11,7 @@ class AppResourceRepositoryTest {
   fun test() {
     val repository = AppResourceRepository.create(
       localResourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile()),
+      moduleResourceDirectories = emptyList(),
       libraryRepositories = listOf(makeAarRepositoryFromExplodedAar("my_aar_lib"))
     )
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/ProjectResourceRepositoryTest.kt
@@ -9,7 +9,8 @@ class ProjectResourceRepositoryTest {
   fun test() {
     // TODO: need mapOf(package to listOf(resourceDirectory)) for each transitive project module
     val repository = ProjectResourceRepository.create(
-      resourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile())
+      resourceDirectories = listOf(resolveProjectPath("src/test/resources/folders/res").toFile()),
+      moduleResourceDirectories = emptyList()
     )
 
     val map = repository.allResources


### PR DESCRIPTION
Split local resources to `local` and `module` in resources.txt to make sure correct orders are used in repository later


cc @jrodbx 