### PR TITLE
Fix Arity name comparison in BasicPluralsResourceItem

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicPluralsResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicPluralsResourceItem.kt
@@ -66,7 +66,7 @@ class BasicPluralsResourceItem private constructor(
   override fun getValue(index: Int): String = values[index]
 
   override fun getValue(quantity: String): String? {
-    val index = arities.indexOfFirst { it.name == quantity }
+    val index = arities.indexOfFirst { it.getName() == quantity }
     return if (index != -1) values[index] else null
   }
 


### PR DESCRIPTION
Fix the bug that in BasicPluralsResourceItem, the `name` field in enum Arity should be used to match quantity rather than the name of enum constant.

cc @jrodbx 