### PR TITLE
Fix #961: fix docs/1.x path it's no longer needed to be the parent of the rootProject

### DIFF
--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 }
 
 tasks.named("dokkaGfm").configure {
-  outputDirectory = rootProject.file("../docs/1.x")
+  outputDirectory = rootProject.file("docs/1.x")
 
   dokkaSourceSets.named("main") {
     configureEach {


### PR DESCRIPTION
Fixes #961