### PR TITLE
Fixes compose alert dialogs not rendering when using RenderingMode.SHRINK (#769)

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -109,7 +109,8 @@ class Paparazzi @JvmOverloads constructor(
 
   private val contentRoot = """
         |<?xml version="1.0" encoding="utf-8"?>
-        |<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        |<${if (hasComposeRuntime) "app.cash.paparazzi.internal.ComposeViewAdapter" else "FrameLayout"}
+        |     xmlns:android="http://schemas.android.com/apk/res/android"
         |              android:layout_width="${if (renderingMode.horizAction == RenderingMode.SizeAction.SHRINK) "wrap_content" else "match_parent"}"
         |              android:layout_height="${if (renderingMode.vertAction == RenderingMode.SizeAction.SHRINK) "wrap_content" else "match_parent"}"/>
   """.trimMargin()

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ComposeViewAdapter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ComposeViewAdapter.kt
@@ -1,0 +1,16 @@
+package app.cash.paparazzi.internal
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+
+/**
+ * Ported from: https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-tooling/src/androidMain/kotlin/androidx/compose/ui/tooling/ComposeViewAdapter.kt?q=ComposeViewAdapter
+ *
+ * A wrapper layout for compose-based layouts which allows [android.view.WindowManagerImpl] to find
+ * a composable root
+ */
+class ComposeViewAdapter(
+  context: Context,
+  attrs: AttributeSet
+) : FrameLayout(context, attrs)

--- a/sample/src/test/java/app/cash/paparazzi/sample/ComposeDialogShrinkTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ComposeDialogShrinkTest.kt
@@ -1,0 +1,82 @@
+package app.cash.paparazzi.sample
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode
+import org.junit.Rule
+import org.junit.Test
+
+class ComposeDialogShrinkTest {
+  @get:Rule
+  val paparazzi = Paparazzi(
+    maxPercentDifference = 1.0,
+    deviceConfig = DeviceConfig.PIXEL_5.copy(softButtons = false),
+    renderingMode = RenderingMode.SHRINK
+  )
+
+  @Test
+  fun test() {
+    paparazzi.snapshot {
+      AlertDialog(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(12.dp)),
+        onDismissRequest = {},
+        title = {
+          Text(
+            modifier = Modifier
+              .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            text = "Title"
+          )
+        },
+        text = {
+          Text(
+            modifier = Modifier
+              .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            text = "Subtitle"
+          )
+        },
+        buttons = {
+          Column(
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(
+                start = 16.dp,
+                end = 16.dp,
+                bottom = 16.dp
+              )
+          ) {
+            Button(
+              modifier = Modifier.fillMaxWidth(),
+              onClick = {}
+            ) {
+              Text("Button 1")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+              modifier = Modifier.fillMaxWidth(),
+              onClick = {}
+            ) {
+              Text("Button 2")
+            }
+          }
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
This address an issue with compose layouts that include an `AlertDialog` when using `RenderingMode.SHRINK` which was caused by the layout being measured not including the `AlertDialog`'s layout and as a result, it would be ignored and not rendered in the final snapshot.

The issue is that that `AlertDialog` layout is added to the Window which is usually included as part of the layout being measured. However `WindowManagerImpl` has special logic for compose layouts where it will try to find the composable root of the layout to use as the base root view and then it adds itself to that view as a child. This logic specifically looks for a root that ends with `ComposeViewAdapter` and since our root view in Paparazzi is a `FrameLayout`, `WindowManagerImpl` would never find a composable root and always return null as the base root view. This meant that the layout never included the dialog's content so when it goes to measure the layout, it would return the size of the layout excluding the dialog content.

To address this, instead of having a FrameLayout as the root when we are measuring a compose layout, we instead use a FrameLayout subclass that simply ends with `ComposeViewAdapter` which allows the `WindowManagerImpl` to successfully find the composable root and add the layout. When there is no compose layout in the snapshot, we simply use the default FrameLayout which matches how Android Studio renders previews.