### PR TITLE
Document Lottie issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ android.jetifier.ignorelist=android-base-common,common
 Lottie
 --------
 
-When taking screenshots of Lottie animations, Paparazzi can throw weird exceptions ([#494](https://github.com/cashapp/paparazzi/issues/494), [#630](https://github.com/cashapp/paparazzi/issues/630)). 
-
-As a workaround, you need to force Lottie to not run on the background thread:
+When taking screenshots of Lottie animations, you need to force Lottie to not run on a background thread, otherwise Paparazzi can throw exceptions [#494](https://github.com/cashapp/paparazzi/issues/494), [#630](https://github.com/cashapp/paparazzi/issues/630). 
 
 ```kotlin
 @Before

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ exclude bundled Android dependencies.
 android.jetifier.ignorelist=android-base-common,common
 ```
 
+Lottie
+--------
+
+When taking screenshots of Lottie animations, Paparazzi can throw weird exceptions ([#494](https://github.com/cashapp/paparazzi/issues/494), [#630](https://github.com/cashapp/paparazzi/issues/630)). 
+
+As a workaround, you need to force Lottie to not run on the background thread:
+
+```kotlin
+@Before
+fun setup() {
+    LottieTask.EXECUTOR = Executor(Runnable::run)
+}
+```
+
 Releases
 --------
 


### PR DESCRIPTION
Add workaround from https://github.com/cashapp/paparazzi/issues/630#issuecomment-1512516656 to README to warn developers about this behavior.

I realize referencing other projects in the README of this project is not ideal, but I'm not sure what else we could do to help this situation. Thrown errors are very weird and unhelpful, while workaround is at the moment only found buried inside comments of closed Github issues.