### PR TITLE
Fix deprecated conventions usage

### DIFF
--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -5,8 +5,10 @@ apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'com.google.devtools.ksp'
 
-sourceCompatibility = libs.versions.javaTarget.get()
-targetCompatibility = libs.versions.javaTarget.get()
+java {
+  sourceCompatibility = libs.versions.javaTarget.get()
+  targetCompatibility = libs.versions.javaTarget.get()
+}
 
 def artifactType = Attribute.of('artifactType', String)
 


### PR DESCRIPTION
```
> Configure project :paparazzi
Build file 'P:\projects\contrib\github-paparazzi\paparazzi\build.gradle': line 8
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.2.1/userguide/upgrad
ing_version_8.html#java_convention_deprecation
        at build_ax8rd4cvgazdmc86hax3upudp.run(P:\projects\contrib\github-paparazzi\paparazzi\build.gradle:8)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file 'P:\projects\contrib\github-paparazzi\paparazzi\build.gradle': line 8
The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.2.1/userguide/upgrading_versio
n_8.html#deprecated_access_to_conventions
        at build_ax8rd4cvgazdmc86hax3upudp.run(P:\projects\contrib\github-paparazzi\paparazzi\build.gradle:8)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file 'P:\projects\contrib\github-paparazzi\paparazzi\build.gradle': line 9
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.2.1/userguide/upgrad
ing_version_8.html#java_convention_deprecation
        at build_ax8rd4cvgazdmc86hax3upudp.run(P:\projects\contrib\github-paparazzi\paparazzi\build.gradle:9)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file 'P:\projects\contrib\github-paparazzi\paparazzi\build.gradle': line 9
The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.2.1/userguide/upgrading_versio
n_8.html#deprecated_access_to_conventions
        at build_ax8rd4cvgazdmc86hax3upudp.run(P:\projects\contrib\github-paparazzi\paparazzi\build.gradle:9)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```