### PR TITLE
Explicitly declare inputs to the Test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,16 @@ subprojects {
   plugins.withId('com.vanniktech.maven.publish') {
     publishing {
       repositories {
+        def localMavenDir = rootProject.layout.buildDirectory.dir("localMaven")
         maven {
           name = "projectLocalMaven"
-          url = rootProject.layout.buildDirectory.dir("localMaven")
+          url = localMavenDir
+        }
+        publications.configureEach {
+          tasks.named("publish${name.capitalize()}PublicationToProjectLocalMavenRepository").configure {
+	          // Ensure task is up to date, when there are no input changes, fo this we need to declare outputs.
+            outputs.dir(localMavenDir).withPropertyName("repository")
+          }
         }
         /**
          * Want to push to an internal repository for testing?

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -48,7 +48,10 @@ tasks.withType(Test).configureEach {
   // These are referenced with relative paths in src/test/projects/test.settings.gradle.
   // They need to be declared on the Test task to make sure it runs with the new files.
   inputs.file(rootProject.layout.projectDirectory.file("gradle/libs.versions.toml"))
-  inputs.dir(rootProject.layout.buildDirectory.dir("localMaven"))
+  inputs.dir(fileTree(rootProject.layout.buildDirectory.dir("localMaven")) {
+    // Exclude Maven repository files, to prevent cache misses because of changing `<lastUpdated>20230715095719</lastUpdated>`.
+    exclude("**/maven-metadata.xml")
+  })
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
   dependsOn(':paparazzi-agent:publishMavenPublicationToProjectLocalMavenRepository')
 }

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -48,12 +48,9 @@ tasks.withType(Test).configureEach {
   // These are referenced with relative paths in src/test/projects/test.settings.gradle.
   // They need to be declared on the Test task to make sure it runs with the new files.
   inputs.file(rootProject.layout.projectDirectory.file("gradle/libs.versions.toml"))
-	  .withPropertyName("libs.versions.toml")
-  inputs.dir(fileTree(rootProject.layout.buildDirectory.dir("localMaven")) {
-    // Exclude Maven repository files, to prevent cache misses because of changing `<lastUpdated>20230715095719</lastUpdated>`.
-    exclude("**/maven-metadata.xml")
-    exclude("**/maven-metadata.xml.*")
-  }).withPropertyName("localMaven")
+    .withPropertyName("libs.versions.toml")
+  inputs.dir(rootProject.layout.buildDirectory.dir("localMaven"))
+    .withPropertyName("localMaven")
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
   dependsOn(':paparazzi-agent:publishMavenPublicationToProjectLocalMavenRepository')
 }

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -45,6 +45,10 @@ buildConfig {
 }
 
 tasks.withType(Test).configureEach {
+  // These are referenced with relative paths in src/test/projects/test.settings.gradle.
+  // They need to be declared on the Test task to make sure it runs with the new files.
+  inputs.file(rootProject.layout.projectDirectory.file("gradle/libs.versions.toml"))
+  inputs.dir(rootProject.layout.buildDirectory.dir("localMaven"))
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
   dependsOn(':paparazzi-agent:publishMavenPublicationToProjectLocalMavenRepository')
 }

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -48,10 +48,12 @@ tasks.withType(Test).configureEach {
   // These are referenced with relative paths in src/test/projects/test.settings.gradle.
   // They need to be declared on the Test task to make sure it runs with the new files.
   inputs.file(rootProject.layout.projectDirectory.file("gradle/libs.versions.toml"))
+	  .withPropertyName("libs.versions.toml")
   inputs.dir(fileTree(rootProject.layout.buildDirectory.dir("localMaven")) {
     // Exclude Maven repository files, to prevent cache misses because of changing `<lastUpdated>20230715095719</lastUpdated>`.
     exclude("**/maven-metadata.xml")
-  })
+    exclude("**/maven-metadata.xml.*")
+  }).withPropertyName("localMaven")
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
   dependsOn(':paparazzi-agent:publishMavenPublicationToProjectLocalMavenRepository')
 }


### PR DESCRIPTION
to make sure they're re-executed whenever the `:paparazzi` code changes.

I kept "rerunning tests" after changing Environment.kt, but my changes were not reflected in the test results. I was baffled, until I realized how the paparazzi.jar gets into the test projects.