### PR TITLE
Safely split all lists in build/intermediates/paparazzi/debug/resources.txt

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -67,12 +67,15 @@ fun detectEnvironment(): Environment {
     assetsDir = appTestDir.resolve(configLines[4]).toString(),
     packageName = configLines[0],
     compileSdkVersion = configLines[2].toInt(),
-    resourcePackageNames = configLines[5].split(","),
-    localResourceDirs = configLines[6].split(",").map { projectDir.resolve(it).toString() },
-    moduleResourceDirs = configLines[7].split(",").filter { it.isNotEmpty() }.map { projectDir.resolve(it).toString() },
-    libraryResourceDirs = configLines[8].split(",").map { artifactsCacheDir.resolve(it).toString() }
+    resourcePackageNames = configLines[5].split(),
+    localResourceDirs = configLines[6].split().map { projectDir.resolve(it).toString() },
+    moduleResourceDirs = configLines[7].split().map { projectDir.resolve(it).toString() },
+    libraryResourceDirs = configLines[8].split().map { artifactsCacheDir.resolve(it).toString() }
   )
 }
+
+private fun String.split(): List<String> =
+  this.split(",").filter { it.isNotEmpty() }
 
 private fun androidSdkPath(): String {
   val osName = System.getProperty("os.name").lowercase(Locale.US)


### PR DESCRIPTION
Safe:
 * empty string is handled correctly because `"".split(",") == listOf("")`
 * `foo,,bar` will also be handled correctly

This has been already applied to one of the lists, I generalized it to all of them.

Example where it was failing (I found this while investigating #956):
```shell
gradlew -x :paparazzi:dokkaHtml :paparazzi-gradle-plugin:test --tests app.cash.paparazzi.gradle.PaparazziPluginTest.withoutAppCompat
```

> `Environment(platformDir=Z:\tools\sdk\android\platforms\android-33, appTestDir=...\appcompat-missing\build, resDir=...\appcompat-missing\build\intermediates\merged_res\debug, assetsDir=...\appcompat-missing\build\intermediates\assets\debug, packageName=app.cash.paparazzi.plugin.test, compileSdkVersion=33, resourcePackageNames=[app.cash.paparazzi.plugin.test], localResourceDirs=[...\appcompat-missing\src\main\res, ...\appcompat-missing\src\debug\res], moduleResourceDirs=[...\appcompat-missing], libraryResourceDirs=[P:\paparazzi\paparazzi-gradle-plugin\build\tmp\test\work\.gradle-test-kit])`

_(Note: `...` was `P:\projects\contrib\github-paparazzi\paparazzi-gradle-plugin\src\test\projects\`)_

Notice the last `libraryResourceDirs` is not a library dir, it got there because `"".split(",") == listOf("")`

If the `GRADLE_USER_HOME` on a user's env doesn't have a parent
<details><summary>This can be simulated in paparazzi repo with (expand for patch)</summary>

```patch
Index: paparazzi-gradle-plugin/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/paparazzi-gradle-plugin/build.gradle b/paparazzi-gradle-plugin/build.gradle
--- a/paparazzi-gradle-plugin/build.gradle	(revision 68fecc13d1d57493ae581ace4880c1b4d4f39fe9)
+++ b/paparazzi-gradle-plugin/build.gradle	(date 1689417864441)
@@ -47,6 +47,7 @@
 tasks.withType(Test).configureEach {
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
   dependsOn(':paparazzi-agent:publishMavenPublicationToProjectLocalMavenRepository')
+  systemProperty("org.gradle.testkit.dir", "D:\\.gradle-test-kit")
 }
 
 // When cleaning this project, we also want to clean the test projects.
```

</details>

This would yield this memory state:

> `Environment(platformDir=Z:\tools\sdk\android\platforms\android-33, appTestDir=...\appcompat-missing\build, resDir=...\appcompat-missing\build\intermediates\merged_res\debug, assetsDir=...\appcompat-missing\build\intermediates\assets\debug, packageName=app.cash.paparazzi.plugin.test, compileSdkVersion=33, resourcePackageNames=[app.cash.paparazzi.plugin.test], localResourceDirs=[...\appcompat-missing\src\main\res, ...\appcompat-missing\src\debug\res], moduleResourceDirs=[], libraryResourceDirs=[D:\.gradle-test-kit])`

<details><summary>then throw an exception: <code>resourceDirPath.parent.fileName must not be null</code> (expand for stack)</summary>

```
java.lang.NullPointerException: resourceDirPath.parent.fileName must not be null
	at app.cash.paparazzi.internal.Renderer.prepare(Renderer.kt:87)
	at app.cash.paparazzi.Paparazzi.prepare(Paparazzi.kt:158)
	at app.cash.paparazzi.Paparazzi$apply$statement$1.evaluate(Paparazzi.kt:124)
	at app.cash.paparazzi.agent.AgentTestRule$apply$1.evaluate(AgentTestRule.kt:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:108)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

</details>
