### PR TITLE
Handle null snapshot names when recording gifs

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -111,7 +111,11 @@ class HtmlReportWriter @JvmOverloads constructor(
           if (isRecording) {
             for ((index, frameHash) in hashes.withIndex()) {
               val originalFrame = File(imagesDirectory, "$frameHash.png")
-              val frameSnapshot = snapshot.copy(name = "${snapshot.name} $index")
+              val frameSnapshot = if (snapshot.name != null) {
+                snapshot.copy(name = "${snapshot.name} $index")
+              } else {
+                snapshot.copy(name = "$index")
+              }
               val goldenFile = File(goldenImagesDirectory, frameSnapshot.toFileName("_", "png"))
               if (!goldenFile.exists()) {
                 originalFrame.copyTo(goldenFile)


### PR DESCRIPTION
Currently, when recording a single snapshot with the name parameter not specified, Paparazzi will handle this properly and will ignore this null name when writing file names

However, when recording gifs, if a name is not specified then Paparazzi will include "null" in the file name of the generated image

e.g. `MyTest_null_0.png`, `MyTest_null_1.png`, etc

This change means that if the name is not specified then these file names will instead end up like `MyTest_0.png`