### PR TITLE
Upgrade BuildConfig plugin (major 3.x to 4.x)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ truth = { module = "com.google.truth:truth", version = "1.1.5" }
 
 # Plugins
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-plugin-buildConfig = { module = "com.github.gmazzo:gradle-buildconfig-plugin", version = "3.1.0" }
+plugin-buildConfig = { module = "com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin", version = "4.1.2" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.8.20" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version = "1.8.21-1.0.11" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ truth = { module = "com.google.truth:truth", version = "1.1.5" }
 
 # Plugins
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-plugin-buildConfig = { module = "com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin", version = "4.1.2" }
+plugin-buildConfig = { module = "com.github.gmazzo.buildconfig:plugin", version = "4.1.2" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.8.20" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version = "1.8.21-1.0.11" }


### PR DESCRIPTION
from v3 to v4 the artifact name changed. Start using the marker to ensure continuity in the future.

Also fixes deprecation warning: https://github.com/gmazzo/gradle-buildconfig-plugin/pull/66

Testing: `gradlew :p-g-p:publishToMavenLocal` and compare with `master`'s output.
