### PR TITLE
Fix the relativePath in ResourceFile

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFile.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFile.kt
@@ -41,7 +41,7 @@ class ResourceFile(
   }
 
   override val relativePath: String?
-    get() = file?.let { repository.resourceDir.toRelativeString(it) }
+    get() = file?.let { it.toRelativeString(repository.resourceDir) }
 
   fun isValid(): Boolean = file != null
 }


### PR DESCRIPTION
Fix a bug about the relativePath in ResourceFile. In original [ResourceItemSource](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1c8e6b0a85b2dc96826c185854504f7d476868c8:android/src/com/android/tools/idea/res/ResourceItemSources.kt;drc=1c8e6b0a85b2dc96826c185854504f7d476868c8;l=113) from AOSP, the relativePath is `file` to `repository.resourceDir` using [VfsUtilCore](https://github.com/JetBrains/intellij-community/blob/8081a38537cafb1adb2c2a05d783f8d98e28639f/platform/core-api/src/com/intellij/openapi/vfs/VfsUtilCore.java#L122-L125), however our implementation was `repository.resourceDir` to `file` 

cc @jrodbx 