### PR TITLE
Gradle 8.3 compatible build: Project.buildDir is deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ subprojects {
 }
 
 tasks.register("clean", Delete).configure {
-  delete rootProject.buildDir
+  delete(rootProject.layout.buildDirectory)
 }
 
 allprojects { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
       repositories {
         maven {
           name = "projectLocalMaven"
-          url = "${rootProject.buildDir}/localMaven"
+          url = rootProject.layout.buildDirectory.dir("localMaven")
         }
         /**
          * Want to push to an internal repository for testing?

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -1,1 +1,1 @@
-ext.repoDir = new File("$rootProject.buildDir/prebuilts/studio/layoutlib")
+ext.repoDir = rootProject.layout.buildDirectory.dir("prebuilts/studio/layoutlib").get().asFile

--- a/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'app.cash.paparazzi'
 }
 
-project.buildDir = 'custom'
+project.layout.buildDirectory = 'custom'
 
 android {
   namespace 'app.cash.paparazzi.plugin.test'


### PR DESCRIPTION
https://docs.gradle.org/8.3-rc-1/javadoc/org/gradle/api/Project.html#getBuildDir--
