### PR TITLE
Wrap composables with a CompositionLocalProvider to set LocalInspectionMode to true

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -32,7 +32,9 @@ import android.view.ViewGroup
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.annotation.LayoutRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
@@ -196,8 +198,16 @@ class Paparazzi @JvmOverloads constructor(
   fun <V : View> inflate(@LayoutRes layoutId: Int): V = layoutInflater.inflate(layoutId, null) as V
 
   fun snapshot(name: String? = null, composable: @Composable () -> Unit) {
+    // Mimics ComposeViewAdapter behavior to let a composable know this is a local preview
+    val previewComposable = @Composable {
+      CompositionLocalProvider(
+        LocalInspectionMode provides true,
+        content = composable
+      )
+    }
+
     val hostView = ComposeView(context)
-    hostView.setContent(composable)
+    hostView.setContent(previewComposable)
 
     snapshot(hostView, name)
   }


### PR DESCRIPTION
This addresses issue #709 where the `GoogleMap`s composable would crash when taking a snapshot. This was happening because the `GoogleMap`s composable was trying to initialize as it would when placed in an app. This doesn't happen in Android Studio's preview mode since the composable is wrapped with a `CompositionLocalProvider` which sets `LocalInspectionMode` to `true`. This is done in the `ComposeViewAdpater`. To mimic this behavior, before we set the composable to be snapshot on the ComposeView, we wrap it the same way the ComposeViewAdapter does. 

The ComposeViewAdapter used by `Preview` does internally, but since we don't have a reference to the paparazzi `ComposeViewAdapter` when snapshot is called, we do the wrapping outside before the `ComposeView` is added to the `ComposeViewAdapter`. The end result and layout tree is identical, it just happens at slightly different times in Paparazzi vs Android Studio (both happen before any preview/snapshot is generated)