### PR TITLE
Fix paparazzi plugin tests

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -796,12 +796,12 @@ class PaparazziPluginTest {
     val fixtureRoot = File("src/test/projects/verify-resources-java")
 
     val result = gradleRunner
-      .withArguments("compileDebugUnitTestJavaWithJavac", "--stacktrace")
+      .withArguments(":consumer:compileDebugUnitTestJavaWithJavac", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
-    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+    assertThat(result.task(":consumer:preparePaparazziDebugResources")).isNotNull()
 
-    val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.txt")
+    val resourcesFile = File(fixtureRoot, "consumer/build/intermediates/paparazzi/debug/resources.txt")
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
@@ -810,7 +810,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("module1/build/intermediates/packaged_res/debug,module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
@@ -819,12 +819,12 @@ class PaparazziPluginTest {
     val fixtureRoot = File("src/test/projects/verify-resources-kotlin")
 
     val result = gradleRunner
-      .withArguments("compileDebugUnitTestKotlin", "--stacktrace")
+      .withArguments(":consumer:compileDebugUnitTestKotlin", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
-    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+    assertThat(result.task(":consumer:preparePaparazziDebugResources")).isNotNull()
 
-    val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.txt")
+    val resourcesFile = File(fixtureRoot, "consumer/build/intermediates/paparazzi/debug/resources.txt")
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()
@@ -833,7 +833,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("module1/build/intermediates/packaged_res/debug,module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
@@ -842,12 +842,12 @@ class PaparazziPluginTest {
     val fixtureRoot = File("src/test/projects/verify-resources-java")
 
     val result = gradleRunner
-      .withArguments("compileDebugUnitTestJavaWithJavac", "--stacktrace")
+      .withArguments(":consumer:compileDebugUnitTestJavaWithJavac", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
-    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+    assertThat(result.task(":consumer:preparePaparazziDebugResources")).isNotNull()
 
-    val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.txt")
+    val resourcesFile = File(fixtureRoot, "consumer/build/intermediates/paparazzi/debug/resources.txt")
     assertThat(resourcesFile.exists()).isTrue()
 
     val resourceFileContents = resourcesFile.readLines()

--- a/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/gradle.properties
@@ -1,1 +1,2 @@
 android.suppressUnsupportedCompileSdk=UpsideDownCakePrivacySandbox
+android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/test/projects/test.settings.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/test.settings.gradle
@@ -14,3 +14,5 @@ dependencyResolutionManagement {
     google()
   }
 }
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Fix failed paparazzi plugin tests introduced from https://github.com/cashapp/paparazzi/pull/1010 and https://github.com/cashapp/paparazzi/pull/959. 

The problem was not revealed in previous [CI build](https://github.com/cashapp/paparazzi/pull/1011/checks#step:5:248) because `PaparazziPluginTest` itself was not changed, so `:paparazzi-gradle-plugin:test` was actually FROM-CACHE

cc @jrodbx 