### PR TITLE
Add docs about jacoco compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jacoco.excludes = [
 
 build.gradle.kts
 ```kotlin
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
   extensions.configure<JacocoTaskExtension> {
     excludes = listOf(
       "androidx.core.*",

--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ fun setup() {
 }
 ```
 
+JaCoCo Compatibility
+--------------------
+
+The way both JaCoCo and Paparazzi instrument may cause conflict if JDK 17+ is used. Mitigate this issue by adding the following into your JaCoCo configuration [#955](https://github.com/cashapp/paparazzi/issues/955):
+
+build.gradle
+```groovy
+jacoco.excludes = [
+  'androidx.core.*',
+  'com.android.*',
+  'android.*'
+]
+```
+
+build.gradle.kts
+```kotlin
+tasks.withType<Test> {
+  extensions.configure<JacocoTaskExtension> {
+    excludes = listOf(
+      "androidx.core.*",
+      "com.android.*",
+      "android.*",
+    )
+  }
+}
+```
+More info
+
 Releases
 --------
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ tasks.withType<Test> {
   }
 }
 ```
-More info
 
 Releases
 --------


### PR DESCRIPTION
I was looking into the below issue as I also hit that in the project that I was integrating Paparazzi. A potential fix for this could be more complex than needed. As I could find a much simpler workaround, my suggestion would be to close this issue by adding this as documentation in the README.

Let me know what you think.

Closes #955