### PR TITLE
Make AGP and KGP deps compileOnly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ docs/1.x
 docs/changelog.md
 docs/index.md
 site/
+
+# Generated in tests
+/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/src/main/res/values/colors.xml
+/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/src/main/assets/secret.txt

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 
+  testImplementation libs.plugin.kotlin
+  testImplementation libs.plugin.android
+  testImplementation(libs.tools.sdkCommon) {
+    because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
+  }
   testImplementation libs.junit
   testImplementation libs.truth
 }

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -20,6 +20,23 @@ gradlePlugin {
   }
 }
 
+// Fix missing implicit task dependency in Gradle's test kit
+tasks.named("processTestResources") { dependsOn("pluginUnderTestMetadata") }
+
+// Fix missing implicit task dependency in Gradle's test kit
+tasks.named("processTestResources") { it.dependsOn("pluginUnderTestMetadata") }
+
+Configuration addTestPlugin = configurations.create("addTestPlugin")
+
+configurations {
+  testImplementation.extendsFrom(addTestPlugin)
+}
+
+tasks.pluginUnderTestMetadata {
+  // make sure the test can access plugins for coordination.
+  pluginClasspath.from(addTestPlugin)
+}
+
 dependencies {
   compileOnly gradleApi()
   implementation platform(libs.kotlin.bom)
@@ -29,9 +46,9 @@ dependencies {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 
-  testImplementation libs.plugin.kotlin
-  testImplementation libs.plugin.android
-  testImplementation(libs.tools.sdkCommon) {
+  add(addTestPlugin.name, libs.plugin.kotlin)
+  add(addTestPlugin.name, libs.plugin.android)
+  add(addTestPlugin.name, libs.tools.sdkCommon) {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
   testImplementation libs.junit

--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -23,9 +23,9 @@ gradlePlugin {
 dependencies {
   compileOnly gradleApi()
   implementation platform(libs.kotlin.bom)
-  implementation libs.plugin.kotlin
-  implementation libs.plugin.android
-  implementation(libs.tools.sdkCommon) {
+  compileOnly libs.plugin.kotlin
+  compileOnly libs.plugin.android
+  compileOnly(libs.tools.sdkCommon) {
     because "SymbolUtils.getPackageNameFromManifest removed in AGP 7.0.  Replace?"
   }
 


### PR DESCRIPTION
Dependencies on other gradle plugins should be `compileOnly` dependencies, as it can accidentally impose the version paparazzi depends on rather than just use the one that the consuming project uses. For example – in our project, this transitive dep prevents us from testing newer AGP versions due to multiple versions appearing on the buildscript classpath.

<img width="1049" alt="image" src="https://github.com/cashapp/paparazzi/assets/1361086/3901ea4f-60f1-4b61-acf8-87e483ec7556">
