### PR TITLE
Update delta images to support showing diff when width and height differ

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -114,33 +114,48 @@ internal object ImageUtils {
     }
     assertEquals(TYPE_INT_ARGB.toLong(), goldenImage.type.toLong())
 
-    val imageWidth = Math.min(goldenImage.width, image.width)
-    val imageHeight = Math.min(goldenImage.height, image.height)
+    val goldenImageWidth = goldenImage.width
+    val goldenImageHeight = goldenImage.height
+
+    val imageWidth = image.width
+    val imageHeight = image.height
+
+    val deltaWidth = Math.max(goldenImageWidth, imageWidth)
+    val deltaHeight = Math.max(goldenImageHeight, imageHeight)
 
     // Blur the images to account for the scenarios where there are pixel
     // differences
     // in where a sharp edge occurs
     // goldenImage = blur(goldenImage, 6);
     // image = blur(image, 6);
-
-    val width = 3 * imageWidth
-    val deltaImage = BufferedImage(width, imageHeight, TYPE_INT_ARGB)
+    val width = goldenImageWidth + deltaWidth + imageWidth
+    val deltaImage = BufferedImage(width, deltaHeight, TYPE_INT_ARGB)
     val g = deltaImage.graphics
 
     // Compute delta map
     var delta: Long = 0
-    for (y in 0 until imageHeight) {
-      for (x in 0 until imageWidth) {
-        val goldenRgb = goldenImage.getRGB(x, y)
-        val rgb = image.getRGB(x, y)
+    for (y in 0 until deltaHeight) {
+      for (x in 0 until deltaWidth) {
+        val goldenRgb = if (x >= goldenImageWidth || y >= goldenImageHeight) {
+          0x00808080
+        } else {
+          goldenImage.getRGB(x, y)
+        }
+
+        val rgb = if (x >= imageWidth || y >= imageHeight) {
+          0x00808080
+        } else {
+          image.getRGB(x, y)
+        }
+
         if (goldenRgb == rgb) {
-          deltaImage.setRGB(imageWidth + x, y, 0x00808080)
+          deltaImage.setRGB(goldenImageWidth + x, y, 0x00808080)
           continue
         }
 
         // If the pixels have no opacity, don't delta colors at all
         if (goldenRgb and -0x1000000 == 0 && rgb and -0x1000000 == 0) {
-          deltaImage.setRGB(imageWidth + x, y, 0x00808080)
+          deltaImage.setRGB(goldenImageWidth + x, y, 0x00808080)
           continue
         }
 
@@ -155,7 +170,7 @@ internal object ImageUtils {
           ((goldenRgb and -0x1000000).ushr(24) + (rgb and -0x1000000).ushr(24)) / 2 shl 24
 
         val newRGB = avgAlpha or (newR shl 16) or (newG shl 8) or newB
-        deltaImage.setRGB(imageWidth + x, y, newRGB)
+        deltaImage.setRGB(goldenImageWidth + x, y, newRGB)
 
         delta += Math.abs(deltaR)
           .toLong()
@@ -167,34 +182,34 @@ internal object ImageUtils {
     }
 
     // 3 different colors, 256 color levels
-    val total = imageHeight.toLong() * imageWidth.toLong() * 3L * 256L
+    val total = deltaHeight.toLong() * deltaWidth.toLong() * 3L * 256L
     val percentDifference = (delta * 100 / total.toDouble()).toFloat()
 
     var error: String? = null
     val imageName = getName(relativePath)
     if (percentDifference > maxPercentDifferent) {
       error = String.format("Images differ (by %.1f%%)", percentDifference)
-    } else if (Math.abs(goldenImage.width - image.width) >= 2) {
+    } else if (Math.abs(goldenImageWidth - imageWidth) >= 2) {
       error = "Widths differ too much for " + imageName + ": " +
-        goldenImage.width + "x" + goldenImage.height +
-        "vs" + image.width + "x" + image.height
-    } else if (Math.abs(goldenImage.height - image.height) >= 2) {
+        goldenImageWidth + "x" + goldenImageHeight +
+        "vs" + imageWidth + "x" + imageHeight
+    } else if (Math.abs(goldenImageHeight - imageHeight) >= 2) {
       error = "Heights differ too much for " + imageName + ": " +
-        goldenImage.width + "x" + goldenImage.height +
-        "vs" + image.width + "x" + image.height
+        goldenImageWidth + "x" + goldenImageHeight +
+        "vs" + imageWidth + "x" + imageHeight
     }
 
     if (error != null) {
       // Expected on the left
       // Golden on the right
       g.drawImage(goldenImage, 0, 0, null)
-      g.drawImage(image, 2 * imageWidth, 0, null)
+      g.drawImage(image, goldenImageWidth + deltaWidth, 0, null)
 
       // Labels
-      if (imageWidth > 80) {
+      if (deltaWidth > 80) {
         g.color = Color.RED
         g.drawString("Expected", 10, 20)
-        g.drawString("Actual", 2 * imageWidth + 10, 20)
+        g.drawString("Actual", goldenImageWidth + deltaWidth + 10, 20)
       }
 
       val output = File(failureDir, "delta-$imageName")


### PR DESCRIPTION
This address an issue raised in https://github.com/cashapp/paparazzi/issues/964 when using `RenderingMode.SHRINK` where the delta image doesn't show the correct delta and/or is missing part of the expected/actual image. 

What's happening is the calculation for the output of the delta image takes the min size between the expected and actual and uses this as the width/height for all 3 components (the expected, actual and delta images). This results in the delta not showing the correct delta or the expected/actual image not being complete when you run verify and the view has changed in one of more dimensions.

This PR addresses this issue by ensuring the delta image is a max of the expected/actual image so the full delta can be displayed and uses this calculation to ensure the final composite image doesn't have anything cut off as showed in the examples below.

**Golden Image:**
![golden-image](https://github.com/cashapp/paparazzi/assets/1827721/68d56cfd-3b55-439b-bb29-f12e148a06dc)

--------

**Comparison (changing width of expected image):**
_Before_: 
![before-verify-against-more-width](https://github.com/cashapp/paparazzi/assets/1827721/071ad61d-461e-4452-ba78-02d54c8eb3bb)
_After_:
![verify-against-more-width](https://github.com/cashapp/paparazzi/assets/1827721/f698a9cc-2413-4881-aeda-52a6741c6c1b)

----------

**Comparison (changing height of expected image):**
_Before_:
![before-verify-against-more-height](https://github.com/cashapp/paparazzi/assets/1827721/dfe41aa7-4fc0-4a83-b7f5-7dfb3c0a6afc)
_After_:
![verify-against-more-height](https://github.com/cashapp/paparazzi/assets/1827721/027654e2-cacd-4c05-b69c-24fa3f990650)

-----------

**Comparison (changing width & height of expected image):**
_Before_:
![before-verify-against-more-width-and-height](https://github.com/cashapp/paparazzi/assets/1827721/8c233f39-4774-4520-a243-b22d37d4c7ec)
_After_:
![verify-against-more-width-and-height](https://github.com/cashapp/paparazzi/assets/1827721/7a0cd532-8061-4735-812e-72fb52124772)




