### PR TITLE
Migrate to AGP 8 APIs and off of legacy variants API

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -113,9 +113,9 @@ class PaparazziPlugin : Plugin<Project> {
       it.description = "Record golden images for all variants"
     }
 
-    variants.all { variant ->
+    variants.configureEach { variant ->
       val variantSlug = variant.name.capitalize(Locale.US)
-      val testVariant = variant.unitTestVariant ?: return@all
+      val testVariant = variant.unitTestVariant ?: return@configureEach
 
       val mergeResourcesOutputDir = variant.mergeResourcesProvider.flatMap { it.outputDir }
       val mergeAssetsProvider =

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -220,8 +220,9 @@ class PaparazziPlugin : Plugin<Project> {
       check(multiplatformExtension.targets.any { target -> target is KotlinAndroidTarget }) {
         "There must be an Android target configured when using Paparazzi with the Kotlin Multiplatform Plugin"
       }
-      project.tasks.named("compile${testVariantSlug}KotlinAndroid")
-        .configure { it.dependsOn(writeResourcesTask) }
+      project.tasks
+        .matching { it.name == "compile${testVariantSlug}KotlinAndroid" }
+        .configureEach { it.dependsOn(writeResourcesTask) }
     }
 
     project.plugins.withType(KotlinAndroidPluginWrapper::class.java) {

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -132,8 +132,7 @@ class PaparazziPlugin : Plugin<Project> {
   ) {
     val variantSlug = variant.name.capitalize(Locale.US)
     val testVariant = if (variant is HasUnitTest) {
-      @Suppress("DEPRECATION") // This API isn't actually un-deprecated in any subtypes
-      variant.unitTest ?: return
+      (variant as HasUnitTest).unitTest ?: return
     } else {
       return
     }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -131,11 +131,7 @@ class PaparazziPlugin : Plugin<Project> {
     nativePlatformFileCollection: FileCollection
   ) {
     val variantSlug = variant.name.capitalize(Locale.US)
-    val testVariant = if (variant is HasUnitTest) {
-      (variant as HasUnitTest).unitTest ?: return
-    } else {
-      return
-    }
+    val testVariant = (variant as? HasUnitTest)?.unitTest ?: return
 
     val mergeAssetsProvider = variant.artifacts.get(SingleArtifact.ASSETS)
     val mergeResourcesProvider = (variant.artifacts as ArtifactsImpl).get(InternalArtifactType.MERGED_RES)

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -134,6 +134,7 @@ class PaparazziPlugin : Plugin<Project> {
     val testVariant = (variant as? HasUnitTest)?.unitTest ?: return
 
     val mergeAssetsProvider = variant.artifacts.get(SingleArtifact.ASSETS)
+    // TODO use public API when one's available: https://issuetracker.google.com/issues/304746899
     val mergeResourcesProvider = (variant.artifacts as ArtifactsImpl).get(InternalArtifactType.MERGED_RES)
     val projectDirectory = project.layout.projectDirectory
     val buildDirectory = project.layout.buildDirectory

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -35,6 +36,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
 
   @Deprecated("legacy resource loading, to be removed in a future release")
   @get:Input
+  @get:Optional
   abstract val mergeResourcesOutputDir: Property<String>
 
   @get:Input
@@ -104,7 +106,9 @@ abstract class PrepareResourcesTask : DefaultTask() {
       .use {
         it.write(mainPackage)
         it.newLine()
-        it.write(mergeResourcesOutputDir.get())
+        if (mergeResourcesOutputDir.isPresent) {
+          it.write(mergeResourcesOutputDir.get())
+        }
         it.newLine()
         it.write(targetSdkVersion.get())
         it.newLine()

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -480,7 +480,9 @@ class PaparazziPluginTest {
     val secondResourceFile = File(fixtureRoot, "src/test/resources/colors2.xml")
 
     // Original resource
-    firstResourceFile.copyTo(destResourceFile, overwrite = false)
+    if (!destResourceFile.exists()) {
+      firstResourceFile.copyTo(destResourceFile, overwrite = false)
+    }
 
     // Take 1
     val firstRunResult = gradleRunner
@@ -829,7 +831,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
-    assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
+    assertThat(resourceFileContents[6]).isEqualTo("build/generated/res/resValues/debug,src/debug/res,src/main/res")
     assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
@@ -852,7 +854,7 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
     assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
-    assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
+    assertThat(resourceFileContents[6]).isEqualTo("build/generated/res/resValues/debug,src/debug/res,src/main/res")
     assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }


### PR DESCRIPTION
This migrates the plugin to newer AGP 8.0 APIs and using `AndroidComponents` APIs. This offers a few benefits:
- Lazier evaluation across the board
- Depending on artifact outputs rather than tasks

Note that `MergeResources` doesn't yet have a public artifact, but does have an internal one. Since Paparazzi uses multiple other internal artifact APIs, I figured this was fair game to use.

I did leave one extra note as well - there's a `compile*WithJavac` task gated on a BaseJavaPlugin block, but this task is actually created by KGP. Didn't adjust it in this PR to reduce scope, but FYI.