### PR TITLE
Only print report path if it was generated

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -251,11 +251,14 @@ class PaparazziPlugin : Plugin<Project> {
             nativePlatformFileCollection.singleFile.absolutePath
           test.systemProperties["paparazzi.test.record"] = isRecordRun.get()
           test.systemProperties["paparazzi.test.verify"] = isVerifyRun.get()
+          reportOutputDir.get().asFile.deleteRecursively()
         }
 
         test.doLast {
-          val uri = reportOutputDir.get().asFile.toPath().resolve("index.html").toUri()
-          test.logger.log(LIFECYCLE, "See the Paparazzi report at: $uri")
+          val report = reportOutputDir.get().asFile.resolve("index.html")
+          if (report.exists()) {
+            test.logger.log(LIFECYCLE, "See the Paparazzi report at: ${report.toURI()}")
+          }
         }
       }
 

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -257,7 +257,7 @@ class PaparazziPlugin : Plugin<Project> {
         test.doLast {
           val report = reportOutputDir.get().asFile.resolve("index.html")
           if (report.exists()) {
-            test.logger.log(LIFECYCLE, "See the Paparazzi report at: ${report.toURI()}")
+            test.logger.log(LIFECYCLE, "See the Paparazzi report at: ${report.toPath().toUri()}")
           }
         }
       }


### PR DESCRIPTION
Paparazzi currently assumes a report will always be written which isn't the case if you're verifying or if you use a custom snapshot handler. With this change the logging only happens if a report was written.

This fixes #1135