### PR TITLE
Remove reliance on kotlinx.coroutines.main.delay

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -229,7 +229,6 @@ class PaparazziPlugin : Plugin<Project> {
         test.systemProperties["paparazzi.report.dir"] = reportOutputDir.get().toString()
         test.systemProperties["paparazzi.snapshot.dir"] = snapshotOutputDir.toString()
         test.systemProperties["paparazzi.artifacts.cache.dir"] = gradleUserHomeDir.path
-        test.systemProperties["kotlinx.coroutines.main.delay"] = true
         test.systemProperties.putAll(project.properties.filterKeys { it.startsWith("app.cash.paparazzi") })
 
         test.inputs.property("paparazzi.test.record", isRecordRun)


### PR DESCRIPTION
Forcing delay on main was convenient however undesirable in that it effects all tests not just Paparazzi tests. By overriding the WindowRecomposerFactory that ComposeUi uses we can inject our own Recomposer and give it an appropriate CoroutineContext which includes delay on main.

Resolves:  https://github.com/cashapp/paparazzi/issues/1101

