### PR TITLE
Use a class file locator that queries the system class loader

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1387,6 +1387,18 @@ class PaparazziPluginTest {
     )
   }
 
+  @Test
+  fun jacoco() {
+    val fixtureRoot = File("src/test/projects/jacoco")
+
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    val jacocoExecutionData = File(fixtureRoot, "build/jacoco/testDebugUnitTest.exec")
+    assertThat(jacocoExecutionData.exists()).isTrue()
+  }
+
   private fun GradleRunner.runFixture(
     projectRoot: File,
     action: GradleRunner.() -> BuildResult

--- a/paparazzi-gradle-plugin/src/test/projects/jacoco/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/jacoco/build.gradle
@@ -1,11 +1,12 @@
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'app.cash.paparazzi'
-apply plugin: 'jacoco'
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+  id 'jacoco'
+}
 
 android {
-  namespace 'app.cash.paparazzi.sample'
-
+  namespace 'app.cash.paparazzi.plugin.test'
   compileSdk libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
@@ -14,9 +15,11 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
   buildFeatures {
     compose true
-    viewBinding true
   }
   composeOptions {
     kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
@@ -25,12 +28,4 @@ android {
 
 dependencies {
   implementation libs.composeUi.material
-  implementation libs.composeUi.uiTooling
-
-  testImplementation libs.testParameterInjector
-}
-
-// https://github.com/diffplug/spotless/issues/1572
-tasks.withType(com.diffplug.gradle.spotless.SpotlessTask).configureEach {
-  dependsOn(tasks.withType(Test))
 }

--- a/paparazzi-gradle-plugin/src/test/projects/jacoco/src/main/java/app/cash/paparazzi/plugin/test/HelloPaparazzi.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/jacoco/src/main/java/app/cash/paparazzi/plugin/test/HelloPaparazzi.kt
@@ -1,0 +1,23 @@
+package app.cash.paparazzi.plugin.test
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun HelloPaparazzi() {
+  val text = "Hello, Paparazzi"
+  Column(
+    Modifier
+      .background(Color.White)
+      .fillMaxSize()
+      .wrapContentSize()
+  ) {
+    Text(text)
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/jacoco/src/test/java/app/cash/paparazzi/plugin/test/ComposeTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/jacoco/src/test/java/app/cash/paparazzi/plugin/test/ComposeTest.kt
@@ -1,0 +1,17 @@
+package app.cash.paparazzi.plugin.test
+
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class ComposeTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun compose() {
+    paparazzi.snapshot {
+      HelloPaparazzi()
+    }
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -551,9 +551,8 @@ class Paparazzi @JvmOverloads constructor(
    */
   private fun registerFontLookupInterceptionIfResourceCompatDetected() {
     try {
-      val resourcesCompatClass = Class.forName("androidx.core.content.res.ResourcesCompat")
       InterceptorRegistrar.addMethodInterceptor(
-        resourcesCompatClass,
+        "androidx.core.content.res.ResourcesCompat",
         "getFont",
         ResourcesInterceptor::class.java
       )
@@ -563,36 +562,32 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   private fun registerServiceManagerInterception() {
-    val serviceManager = Class.forName("android.os.ServiceManager")
     InterceptorRegistrar.addMethodInterceptor(
-      serviceManager,
+      "android.os.ServiceManager",
       "getServiceOrThrow",
       ServiceManagerInterceptor::class.java
     )
   }
 
   private fun registerIInputMethodManagerInterception() {
-    val iimm = Class.forName("com.android.internal.view.IInputMethodManager\$Stub")
     InterceptorRegistrar.addMethodInterceptor(
-      iimm,
+      "com.android.internal.view.IInputMethodManager\$Stub",
       "asInterface",
       IInputMethodManagerInterceptor::class.java
     )
   }
 
   private fun registerViewEditModeInterception() {
-    val viewClass = Class.forName("android.view.View")
     InterceptorRegistrar.addMethodInterceptor(
-      viewClass,
+      "android.view.View",
       "isInEditMode",
       EditModeInterceptor::class.java
     )
   }
 
   private fun registerMatrixMultiplyInterception() {
-    val matrixClass = Class.forName("android.opengl.Matrix")
     InterceptorRegistrar.addMethodInterceptors(
-      matrixClass,
+      "android.opengl.Matrix",
       setOf(
         "multiplyMM" to MatrixMatrixMultiplicationInterceptor::class.java,
         "multiplyMV" to MatrixVectorMultiplicationInterceptor::class.java
@@ -601,9 +596,8 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   private fun registerChoreographerDelegateInterception() {
-    val choreographerDelegateClass = Class.forName("android.view.Choreographer_Delegate")
     InterceptorRegistrar.addMethodInterceptor(
-      choreographerDelegateClass,
+      "android.view.Choreographer_Delegate",
       "getFrameTimeNanos",
       ChoreographerDelegateInterceptor::class.java
     )

--- a/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
@@ -10,7 +10,7 @@ class InterceptorRegistrarTest {
   @Before
   fun setup() {
     InterceptorRegistrar.addMethodInterceptors(
-      Utils::class.java,
+      "app.cash.paparazzi.agent.InterceptorRegistrarTest\$Utils",
       setOf(
         "log1" to Interceptor1::class.java,
         "log2" to Interceptor2::class.java


### PR DESCRIPTION
Paparazzi's current usage of ByteBuddy conflicts with Jacoco and other bytecode-transformation libraries.

Relevant issue: https://github.com/raphw/byte-buddy/issues/1248

This PR slightly changes this from:

```
      var builder = byteBuddy
        .redefine(foo.Bar::class.java)
```

which calls:
```
    public <T> DynamicType.Builder<T> redefine(Class<T> type) {
        return redefine(type, ClassFileLocator.ForClassLoader.of(type.getClassLoader()));
    }

    public <T> DynamicType.Builder<T> redefine(Class<T> type, ClassFileLocator classFileLocator) {
        return redefine(TypeDescription.ForLoadedType.of(type), classFileLocator);
    }
```

to:
```
      var builder = byteBuddy
        .redefine(TypePool.Default.ofSystemLoader().describe("foo.Bar").resolve(), ClassFileLocator.ForClassLoader.ofSystemLoader())
```

Per https://github.com/raphw/byte-buddy/issues/1248#issuecomment-1121619704, it appears this allows Bytebuddy to 
find the manipulated class file in-memory vs loading the original class definition from disk.

See also "Working with unloaded classes" in https://bytebuddy.net/#/tutorial.

Closes https://github.com/cashapp/paparazzi/issues/979.
Closes https://github.com/cashapp/paparazzi/issues/955.
Closes https://github.com/cashapp/paparazzi/pull/1030.