### PR TITLE
Enable Renovate auto-merge for most dependencies except Android Tools and Kotlin

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      // Compose compiler is tightly coupled to Kotlin version
+      description: "Compose compiler is tightly coupled to Kotlin version",
       "groupName": "Kotlin and Compose",
       "matchPackagePrefixes": [
         "androidx.compose.compiler",
@@ -14,12 +14,12 @@
       ],
     },
     {
-      // Android Gradle Plugin is tightly coupled to its android/platform/tools/base dependencies
-      // LayoutLib intentionally omitted to be updated independently
+      description: "Android Gradle Plugin is tightly coupled to its android/platform/tools/base dependencies",
       "groupName": "Android Tools",
       "matchPackagePrefixes": [
         "com.android.tools:",
         "com.android.tools.build:",
+        // LayoutLib intentionally omitted to be updated independently
       ],
     }
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,12 @@
   ],
   "packageRules": [
     {
+      "description": "Auto-merge most dependency updates.",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+    },
+    {
       description: "Compose compiler is tightly coupled to Kotlin version",
       "groupName": "Kotlin and Compose",
       "matchPackagePrefixes": [
@@ -12,6 +18,7 @@
         "org.jetbrains.kotlin:kotlin",
         "com.google.devtools.ksp"
       ],
+      "automerge": false,
     },
     {
       description: "Android Gradle Plugin is tightly coupled to its android/platform/tools/base dependencies",
@@ -21,6 +28,7 @@
         "com.android.tools.build:",
         // LayoutLib intentionally omitted to be updated independently
       ],
+      "automerge": false,
     }
   ],
 }


### PR DESCRIPTION
Based on the "requirement" from @jrodbx:

> Might be worth allowing auto merges for minor and patch versions to most dependencies other than Android Tools and Kotlin things

## Required steps before this can actually work (one of below):
 * If `cashapp` is a GH Enterprise Org: Change the branch protection rule to except Renovate (exact "user-name" not known, hopefully it'll show up in autocomplete based on recent "contributions").
 * If `cashapp` is a free org: install https://github.com/apps/renovate-approve to this repo

Note: I think the first one might be too allowing if it's not possible to specify exactly to only bypass approval count. Failing CI might still merge?

Docs: https://docs.renovatebot.com/key-concepts/automerge/#required-pull-request-reviews