### PR TITLE
Minor fixes to formatting to prepare for KtLint 1.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,4 @@ ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,kotlinx.**,^
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
 ktlint_standard_argument-list-wrapping = disabled
+ktlint_function_naming_ignore_when_annotated_with=Composable

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,6 @@ end_of_line = lf
 
 [*.{kt, kts}]
 ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,kotlinx.**,^
-
+ij_kotlin_allow_trailing_comma = false
+ij_kotlin_allow_trailing_comma_on_call_site = false
 ktlint_standard_argument-list-wrapping = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_size = 2
+indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/build.gradle
+++ b/build.gradle
@@ -92,18 +92,8 @@ subprojects {
   spotless {
     kotlin {
       target("src/**/*.kt")
-      // ktlint doesn't honour .editorconfig yet: https://github.com/diffplug/spotless/issues/142
-      ktlint(libs.versions.ktlint.get()).editorConfigOverride([
-        'insert_final_newline': 'true',
-        'end_of_line': 'lf',
-        'charset': 'utf-8',
-        'indent_size': '2',
-        'trim_trailing_whitespace': 'true',
-        'ij_kotlin_imports_layout': '*,java.**,javax.**,kotlin.**,kotlinx.**,^',
-        'ij_kotlin_allow_trailing_comma': 'false',
-        'ij_kotlin_allow_trailing_comma_on_call_site': 'false',
-        'ktlint_standard_argument-list-wrapping': 'disabled',
-      ])
+      ktlint(libs.versions.ktlint.get())
+        .setEditorConfigPath(rootProject.file(".editorconfig"))
     }
   }
 }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -828,9 +828,21 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
-    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
+    assertThat(resourceFileContents[5]).isEqualTo(
+      commaSeparated(
+        "app.cash.paparazzi.plugin.test",
+        "com.example.mylibrary",
+        "app.cash.paparazzi.plugin.test.module1",
+        "app.cash.paparazzi.plugin.test.module2"
+      )
+    )
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[7]).isEqualTo(
+      commaSeparated(
+        "../module1/build/intermediates/packaged_res/debug",
+        "../module2/build/intermediates/packaged_res/debug"
+      )
+    )
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
@@ -851,9 +863,21 @@ class PaparazziPluginTest {
     assertThat(resourceFileContents[0]).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(resourceFileContents[1]).isEqualTo("intermediates/merged_res/debug")
     assertThat(resourceFileContents[4]).isEqualTo("intermediates/assets/debug")
-    assertThat(resourceFileContents[5]).isEqualTo("app.cash.paparazzi.plugin.test,com.example.mylibrary,app.cash.paparazzi.plugin.test.module1,app.cash.paparazzi.plugin.test.module2")
+    assertThat(resourceFileContents[5]).isEqualTo(
+      commaSeparated(
+        "app.cash.paparazzi.plugin.test",
+        "com.example.mylibrary",
+        "app.cash.paparazzi.plugin.test.module1",
+        "app.cash.paparazzi.plugin.test.module2"
+      )
+    )
     assertThat(resourceFileContents[6]).isEqualTo("src/main/res,src/debug/res")
-    assertThat(resourceFileContents[7]).isEqualTo("../module1/build/intermediates/packaged_res/debug,../module2/build/intermediates/packaged_res/debug")
+    assertThat(resourceFileContents[7]).isEqualTo(
+      commaSeparated(
+        "../module1/build/intermediates/packaged_res/debug",
+        "../module2/build/intermediates/packaged_res/debug"
+      )
+    )
     assertThat(resourceFileContents[8]).matches("^caches/transforms-3/[0-9a-f]{32}/transformed/external/res\$")
   }
 
@@ -1427,4 +1451,6 @@ class PaparazziPluginTest {
       if (generatedGradleProperties) gradleProperties.delete()
     }
   }
+
+  private fun commaSeparated(vararg items: String): String = items.joinToString(",")
 }

--- a/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/main/java/app/cash/paparazzi/plugin/test/CompositeComposable.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/main/java/app/cash/paparazzi/plugin/test/CompositeComposable.kt
@@ -48,7 +48,8 @@ fun CompositeComposable() {
     Row(modifier = Modifier.semantics(mergeDescendants = true) {}) {
       Image(
         imageVector = Icons.Filled.Add,
-        contentDescription = null // decorative
+        // decorative
+        contentDescription = null
       )
       Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {
         Text("Text")

--- a/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/src/test/java/app/cash/paparazzi/plugin/test/LifecycleUsageTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/src/test/java/app/cash/paparazzi/plugin/test/LifecycleUsageTest.kt
@@ -18,7 +18,7 @@ class LifecycleUsageTest {
   @get:Rule
   val paparazzi = Paparazzi()
 
-  @Test fun LifecycleOwner() {
+  @Test fun lifecycleOwner() {
     val view = View(paparazzi.context).apply {
       setBackgroundColor(Color.BLUE)
     }
@@ -34,7 +34,7 @@ class LifecycleUsageTest {
     assertThat(currentLifecycleState).isEqualTo(Lifecycle.State.RESUMED)
   }
 
-  @Test fun SavedStateRegistryOwner() {
+  @Test fun savedStateRegistryOwner() {
     val view = View(paparazzi.context).apply {
       setBackgroundColor(Color.RED)
     }
@@ -49,7 +49,7 @@ class LifecycleUsageTest {
     assertThat(savedStateRegistry).isNotNull()
   }
 
-  @Test fun OnBackPressedDispatcherOwner() {
+  @Test fun onBackPressedDispatcherOwner() {
     val view = View(paparazzi.context).apply {
       setBackgroundColor(Color.YELLOW)
     }

--- a/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/src/test/java/app/cash/paparazzi/plugin/test/LocaleQualifierTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/src/test/java/app/cash/paparazzi/plugin/test/LocaleQualifierTest.kt
@@ -13,7 +13,8 @@ class LocaleQualifierTest(
   @TestParameter locale: Locale
 ) {
   enum class Locale(val tag: String?) {
-    Default(null), GB("en-rGB")
+    Default(null),
+    GB("en-rGB")
   }
 
   @get:Rule

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -84,7 +84,8 @@ internal class Renderer(
                 val resourceDirPath = Paths.get(dir)
                 AarSourceResourceRepository.create(
                   resourceDirectoryOrFile = resourceDirPath,
-                  libraryName = resourceDirPath.parent.fileName.name // segment before /res
+                  // segment before /res
+                  libraryName = resourceDirPath.parent.fileName.name
                 )
               }
             )

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
@@ -2,7 +2,7 @@ package app.cash.paparazzi.internal.interceptors
 
 // Sampled from https://cs.android.com/android/platform/superproject/+/master:external/robolectric-shadows/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java;l=10-67
 object MatrixMatrixMultiplicationInterceptor {
-  @Suppress("unused")
+  @Suppress("unused", "LocalVariableName", "ktlint:standard:property-naming")
   @JvmStatic
   fun intercept(
     result: FloatArray,
@@ -17,21 +17,21 @@ object MatrixMatrixMultiplicationInterceptor {
     require(rhsOffset + 16 <= rhs.size) { "rhsOffset + 16 > rhs.length" }
     for (i in 0..3) {
       val rhs_i0 = rhs[I(i, 0, rhsOffset)]
-      var ri0 = lhs[I(0, 0, lhsOffset)] * rhs_i0
-      var ri1 = lhs[I(0, 1, lhsOffset)] * rhs_i0
-      var ri2 = lhs[I(0, 2, lhsOffset)] * rhs_i0
-      var ri3 = lhs[I(0, 3, lhsOffset)] * rhs_i0
+      var r_i0 = lhs[I(0, 0, lhsOffset)] * rhs_i0
+      var r_i1 = lhs[I(0, 1, lhsOffset)] * rhs_i0
+      var r_i2 = lhs[I(0, 2, lhsOffset)] * rhs_i0
+      var r_i3 = lhs[I(0, 3, lhsOffset)] * rhs_i0
       for (j in 1..3) {
         val rhs_ij = rhs[I(i, j, rhsOffset)]
-        ri0 += lhs[I(j, 0, lhsOffset)] * rhs_ij
-        ri1 += lhs[I(j, 1, lhsOffset)] * rhs_ij
-        ri2 += lhs[I(j, 2, lhsOffset)] * rhs_ij
-        ri3 += lhs[I(j, 3, lhsOffset)] * rhs_ij
+        r_i0 += lhs[I(j, 0, lhsOffset)] * rhs_ij
+        r_i1 += lhs[I(j, 1, lhsOffset)] * rhs_ij
+        r_i2 += lhs[I(j, 2, lhsOffset)] * rhs_ij
+        r_i3 += lhs[I(j, 3, lhsOffset)] * rhs_ij
       }
-      result[I(i, 0, resultOffset)] = ri0
-      result[I(i, 1, resultOffset)] = ri1
-      result[I(i, 2, resultOffset)] = ri2
-      result[I(i, 3, resultOffset)] = ri3
+      result[I(i, 0, resultOffset)] = r_i0
+      result[I(i, 1, resultOffset)] = r_i1
+      result[I(i, 2, resultOffset)] = r_i2
+      result[I(i, 3, resultOffset)] = r_i3
     }
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
@@ -16,28 +16,26 @@ object MatrixMatrixMultiplicationInterceptor {
     require(lhsOffset + 16 <= lhs.size) { "lhsOffset + 16 > lhs.length" }
     require(rhsOffset + 16 <= rhs.size) { "rhsOffset + 16 > rhs.length" }
     for (i in 0..3) {
-      val rhs_i0 = rhs[I(i, 0, rhsOffset)]
-      var r_i0 = lhs[I(0, 0, lhsOffset)] * rhs_i0
-      var r_i1 = lhs[I(0, 1, lhsOffset)] * rhs_i0
-      var r_i2 = lhs[I(0, 2, lhsOffset)] * rhs_i0
-      var r_i3 = lhs[I(0, 3, lhsOffset)] * rhs_i0
+      val rhs_i0 = rhs[index(i, 0, rhsOffset)]
+      var r_i0 = lhs[index(0, 0, lhsOffset)] * rhs_i0
+      var r_i1 = lhs[index(0, 1, lhsOffset)] * rhs_i0
+      var r_i2 = lhs[index(0, 2, lhsOffset)] * rhs_i0
+      var r_i3 = lhs[index(0, 3, lhsOffset)] * rhs_i0
       for (j in 1..3) {
-        val rhs_ij = rhs[I(i, j, rhsOffset)]
-        r_i0 += lhs[I(j, 0, lhsOffset)] * rhs_ij
-        r_i1 += lhs[I(j, 1, lhsOffset)] * rhs_ij
-        r_i2 += lhs[I(j, 2, lhsOffset)] * rhs_ij
-        r_i3 += lhs[I(j, 3, lhsOffset)] * rhs_ij
+        val rhs_ij = rhs[index(i, j, rhsOffset)]
+        r_i0 += lhs[index(j, 0, lhsOffset)] * rhs_ij
+        r_i1 += lhs[index(j, 1, lhsOffset)] * rhs_ij
+        r_i2 += lhs[index(j, 2, lhsOffset)] * rhs_ij
+        r_i3 += lhs[index(j, 3, lhsOffset)] * rhs_ij
       }
-      result[I(i, 0, resultOffset)] = r_i0
-      result[I(i, 1, resultOffset)] = r_i1
-      result[I(i, 2, resultOffset)] = r_i2
-      result[I(i, 3, resultOffset)] = r_i3
+      result[index(i, 0, resultOffset)] = r_i0
+      result[index(i, 1, resultOffset)] = r_i1
+      result[index(i, 2, resultOffset)] = r_i2
+      result[index(i, 3, resultOffset)] = r_i3
     }
   }
 
-  @Suppress("FunctionName")
-  private fun I(i: Int, j: Int, offset: Int): Int {
+  private fun index(i: Int, j: Int, offset: Int): Int =
     // #define I(_i, _j) ((_j)+ 4*(_i))
-    return offset + j + 4 * i
-  }
+    offset + j + 4 * i
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
@@ -21,18 +21,16 @@ object MatrixVectorMultiplicationInterceptor {
     val w = rhsVec[rhsVecOffset + 3]
     val o = lhsMatOffset
     resultVec[resultVecOffset + 0] =
-      lhsMat[I(0, 0, o)] * x + lhsMat[I(1, 0, o)] * y + lhsMat[I(2, 0, o)] * z + lhsMat[I(3, 0, o)] * w
+      lhsMat[index(0, 0, o)] * x + lhsMat[index(1, 0, o)] * y + lhsMat[index(2, 0, o)] * z + lhsMat[index(3, 0, o)] * w
     resultVec[resultVecOffset + 1] =
-      lhsMat[I(0, 1, o)] * x + lhsMat[I(1, 1, o)] * y + lhsMat[I(2, 1, o)] * z + lhsMat[I(3, 1, o)] * w
+      lhsMat[index(0, 1, o)] * x + lhsMat[index(1, 1, o)] * y + lhsMat[index(2, 1, o)] * z + lhsMat[index(3, 1, o)] * w
     resultVec[resultVecOffset + 2] =
-      lhsMat[I(0, 2, o)] * x + lhsMat[I(1, 2, o)] * y + lhsMat[I(2, 2, o)] * z + lhsMat[I(3, 2, o)] * w
+      lhsMat[index(0, 2, o)] * x + lhsMat[index(1, 2, o)] * y + lhsMat[index(2, 2, o)] * z + lhsMat[index(3, 2, o)] * w
     resultVec[resultVecOffset + 3] =
-      lhsMat[I(0, 3, o)] * x + lhsMat[I(1, 3, o)] * y + lhsMat[I(2, 3, o)] * z + lhsMat[I(3, 3, o)] * w
+      lhsMat[index(0, 3, o)] * x + lhsMat[index(1, 3, o)] * y + lhsMat[index(2, 3, o)] * z + lhsMat[index(3, 3, o)] * w
   }
 
-  @Suppress("FunctionName")
-  private fun I(i: Int, j: Int, offset: Int): Int {
+  private fun index(i: Int, j: Int, offset: Int): Int =
     // #define I(_i, _j) ((_j)+ 4*(_i))
-    return offset + j + 4 * i
-  }
+    offset + j + 4 * i
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
@@ -19,14 +19,15 @@ object MatrixVectorMultiplicationInterceptor {
     val y = rhsVec[rhsVecOffset + 1]
     val z = rhsVec[rhsVecOffset + 2]
     val w = rhsVec[rhsVecOffset + 3]
+    val o = lhsMatOffset
     resultVec[resultVecOffset + 0] =
-      lhsMat[I(0, 0, lhsMatOffset)] * x + lhsMat[I(1, 0, lhsMatOffset)] * y + lhsMat[I(2, 0, lhsMatOffset)] * z + lhsMat[I(3, 0, lhsMatOffset)] * w
+      lhsMat[I(0, 0, o)] * x + lhsMat[I(1, 0, o)] * y + lhsMat[I(2, 0, o)] * z + lhsMat[I(3, 0, o)] * w
     resultVec[resultVecOffset + 1] =
-      lhsMat[I(0, 1, lhsMatOffset)] * x + lhsMat[I(1, 1, lhsMatOffset)] * y + lhsMat[I(2, 1, lhsMatOffset)] * z + lhsMat[I(3, 1, lhsMatOffset)] * w
+      lhsMat[I(0, 1, o)] * x + lhsMat[I(1, 1, o)] * y + lhsMat[I(2, 1, o)] * z + lhsMat[I(3, 1, o)] * w
     resultVec[resultVecOffset + 2] =
-      lhsMat[I(0, 2, lhsMatOffset)] * x + lhsMat[I(1, 2, lhsMatOffset)] * y + lhsMat[I(2, 2, lhsMatOffset)] * z + lhsMat[I(3, 2, lhsMatOffset)] * w
+      lhsMat[I(0, 2, o)] * x + lhsMat[I(1, 2, o)] * y + lhsMat[I(2, 2, o)] * z + lhsMat[I(3, 2, o)] * w
     resultVec[resultVecOffset + 3] =
-      lhsMat[I(0, 3, lhsMatOffset)] * x + lhsMat[I(1, 3, lhsMatOffset)] * y + lhsMat[I(2, 3, lhsMatOffset)] * z + lhsMat[I(3, 3, lhsMatOffset)] * w
+      lhsMat[I(0, 3, o)] * x + lhsMat[I(1, 3, o)] * y + lhsMat[I(2, 3, o)] * z + lhsMat[I(3, 3, o)] * w
   }
 
   @Suppress("FunctionName")

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ModuleResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ModuleResourceRepository.kt
@@ -43,7 +43,8 @@ internal class ModuleResourceRepository private constructor(
       resourceDirectories: List<File>
     ): LocalResourceRepository {
       return ModuleResourceRepository(
-        displayName = "", // TODO
+        // TODO
+        displayName = "",
         namespace = namespace,
         delegates = addRepositoriesInReverseOverlayOrder(resourceDirectories, namespace)
       )

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.paparazzi.internal.resources
 
-/**
+/*
  * Ported from: [Pseudolocalizer.kt](https://cs.android.com/android-studio/platform/tools/base/+/cbf409d1cccb87e8b23798638a8fbf0362af070d:build-system/aaptcompiler/src/main/java/com/android/aaptcompiler/Pseudolocalizer.kt)
  */
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
@@ -347,9 +347,11 @@ class PseudoMethodAccent : PseudoMethodImpl() {
     return currentIndex
   }
 
-  // Yes, "fiveteen".
-  private val EXPANSION_STRING = "one two three four five six seven eight nine ten eleven " +
-    "twelve thirteen fourteen fiveteen sixteen seventeen nineteen twenty"
+  companion object {
+    // Yes, "fiveteen".
+    private const val EXPANSION_STRING = "one two three four five six seven eight nine ten eleven " +
+      "twelve thirteen fourteen fiveteen sixteen seventeen nineteen twenty"
+  }
 }
 
 class Pseudolocalizer(method: Method) {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
@@ -786,7 +786,9 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
   private fun addAttrWithAdjustedFormats(attr: BasicAttrResourceItem) {
     var attr = attr
     if (attr.formats.isEmpty()) {
-      attr = BasicAttrResourceItem(attr.name, attr.sourceFile, attr.visibility, attr.description, attr.groupName, DEFAULT_ATTR_FORMATS, emptyMap(), emptyMap())
+      attr = BasicAttrResourceItem(
+        attr.name, attr.sourceFile, attr.visibility, attr.description, attr.groupName, DEFAULT_ATTR_FORMATS, emptyMap(), emptyMap()
+      )
     }
     addResourceItem(attr)
   }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
@@ -120,17 +120,6 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
   val resourceFilesAndFolders: Collection<PathString>?,
   val namespace: ResourceNamespace
 ) : FileFilter {
-  /** The set of attribute formats that is used when no formats are explicitly specified and the attribute is not a flag or enum.  */
-  private val DEFAULT_ATTR_FORMATS: Set<AttributeFormat> = Sets.immutableEnumSet(
-    AttributeFormat.BOOLEAN,
-    AttributeFormat.COLOR,
-    AttributeFormat.DIMENSION,
-    AttributeFormat.FLOAT,
-    AttributeFormat.FRACTION,
-    AttributeFormat.INTEGER,
-    AttributeFormat.REFERENCE,
-    AttributeFormat.STRING
-  )
   private val fileFilter =
     PatternBasedFileFilter(AndroidAaptIgnore(System.getenv(ANDROID_AAPT_IGNORE)))
 
@@ -1118,6 +1107,18 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
     private val LOG: Logger = Logger.getLogger(RepositoryLoader::class.java.name)
     const val JAR_PROTOCOL = "jar"
     const val JAR_SEPARATOR = "!/"
+
+    /** The set of attribute formats that is used when no formats are explicitly specified and the attribute is not a flag or enum.  */
+    private val DEFAULT_ATTR_FORMATS: Set<AttributeFormat> = Sets.immutableEnumSet(
+      AttributeFormat.BOOLEAN,
+      AttributeFormat.COLOR,
+      AttributeFormat.DIMENSION,
+      AttributeFormat.FLOAT,
+      AttributeFormat.FRACTION,
+      AttributeFormat.INTEGER,
+      AttributeFormat.REFERENCE,
+      AttributeFormat.STRING
+    )
 
     @JvmStatic
     protected fun isXmlFile(file: PathString) = isXmlFile(file.fileName)

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
@@ -354,14 +354,14 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
           }
         } while (event != XmlPullParser.END_DOCUMENT)
       }
-    } // KXmlParser throws RuntimeException for an undefined prefix and an illegal attribute name.
-    catch (e: IOException) {
+    } catch (e: IOException) {
       handleParsingError(file, e)
     } catch (e: XmlPullParserException) {
       handleParsingError(file, e)
     } catch (e: XmlSyntaxException) {
       handleParsingError(file, e)
     } catch (e: RuntimeException) {
+      // KXmlParser throws RuntimeException for an undefined prefix and an illegal attribute name.
       handleParsingError(file, e)
     }
     addValueFileResources()
@@ -423,12 +423,12 @@ abstract class RepositoryLoader<T : LoadableResourceRepository>(
           }
         } while (event != XmlPullParser.END_DOCUMENT)
       }
-    } // KXmlParser throws RuntimeException for an undefined prefix and an illegal attribute name.
-    catch (e: IOException) {
+    } catch (e: IOException) {
       handleParsingError(file, e)
     } catch (e: XmlPullParserException) {
       handleParsingError(file, e)
     } catch (e: java.lang.RuntimeException) {
+      // KXmlParser throws RuntimeException for an undefined prefix and an illegal attribute name.
       handleParsingError(file, e)
     }
     addValueFileResources()

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
@@ -50,7 +50,9 @@ class ApngReaderTest {
 
     try {
       val reader = ApngReader(FileSystem.SYSTEM.openReadOnly(file.path.toPath()))
-      while (!reader.isFinished()) { reader.readNextFrame() }
+      while (!reader.isFinished()) {
+        reader.readNextFrame()
+      }
       fail("Chunks are out of order, expected to fail to decode")
     } catch (e: IOException) {
       assertThat(e).hasMessageThat().isEqualTo("Out of order sequence, expected: 1 actual: 0")
@@ -63,7 +65,9 @@ class ApngReaderTest {
 
     try {
       val reader = ApngReader(FileSystem.SYSTEM.openReadOnly(file.path.toPath()))
-      while (!reader.isFinished()) { reader.readNextFrame() }
+      while (!reader.isFinished()) {
+        reader.readNextFrame()
+      }
       fail("File has invalid CRC, should fail")
     } catch (e: IOException) {
       assertThat(e).hasMessageThat().isEqualTo("CRC Mismatch decoding IHDR, invalid data")

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepositoryTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepositoryTest.kt
@@ -56,7 +56,9 @@ class FrameworkResourceRepositoryTest {
     )
 
     val resourceUrl = repository.getResourceUrl("drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
-    assertThat(resourceUrl).isEqualTo("jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.compiled.9.png")
+    assertThat(resourceUrl).isEqualTo(
+      "jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.compiled.9.png"
+    )
   }
 
   @Test
@@ -68,7 +70,9 @@ class FrameworkResourceRepositoryTest {
     )
 
     val resourceUrl = repository.getResourceUrl("drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
-    assertThat(resourceUrl).isEqualTo("jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png")
+    assertThat(resourceUrl).isEqualTo(
+      "jar://src/test/resources/framework/framework_res.jar!/res/drawable-hdpi/textfield_search_activated_mtrl_alpha.9.png"
+    )
   }
 
   private fun getFrameworkResJar(): Path =

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/PseudolocaleGeneratorTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/resources/PseudolocaleGeneratorTest.kt
@@ -81,10 +81,15 @@ class PseudolocaleGeneratorTest {
     // STRING
     with(table[ResourceNamespace.TODO(), ResourceType.STRING]!!) {
       assertThat(size).isEqualTo(4)
-      assertThat(getValue("string_name").value).isEqualTo("${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
-      assertThat(getValue("string_name_xliff").value).isEqualTo("${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd $bidiWordStart{0}$bidiWordEnd ${bidiWordStart}with$bidiWordEnd ${bidiWordStart}suffix$bidiWordEnd")
-      assertThat(getValue("string_name_html").value).isEqualTo("${bidiWordStart}This$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
-      assertThat(getValue("string_name_html").rawXmlValue).isEqualTo("${bidiWordStart}This$bidiWordEnd $bidiWordStart<b>Test</b>$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
+      assertThat(getValue("string_name").value)
+        .isEqualTo("${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
+      @Suppress("ktlint:standard:max-line-length")
+      assertThat(getValue("string_name_xliff").value)
+        .isEqualTo("${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd $bidiWordStart{0}$bidiWordEnd ${bidiWordStart}with$bidiWordEnd ${bidiWordStart}suffix$bidiWordEnd")
+      assertThat(getValue("string_name_html").value)
+        .isEqualTo("${bidiWordStart}This$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
+      assertThat(getValue("string_name_html").rawXmlValue)
+        .isEqualTo("${bidiWordStart}This$bidiWordEnd $bidiWordStart<b>Test</b>$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
       assertThat(getValue("string_not_translate").value).isEqualTo("Not Translatable String")
     }
 
@@ -93,8 +98,10 @@ class PseudolocaleGeneratorTest {
       assertThat(size).isEqualTo(1)
       with(getValue("string_array_name") as ArrayResourceValue) {
         assertThat(elementCount).isEqualTo(2)
-        assertThat(getElement(0)).isEqualTo("${bidiWordStart}First$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
-        assertThat(getElement(1)).isEqualTo("${bidiWordStart}Second$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
+        assertThat(getElement(0))
+          .isEqualTo("${bidiWordStart}First$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
+        assertThat(getElement(1))
+          .isEqualTo("${bidiWordStart}Second$bidiWordEnd ${bidiWordStart}Test$bidiWordEnd ${bidiWordStart}String$bidiWordEnd")
       }
     }
 

--- a/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemo.kt
+++ b/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemo.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import app.cash.paparazzi.sample.ResourcesDemoView.Companion.plurals
 
-const val imageSize = 120f
+const val IMAGE_SIZE = 120f
 
 @Preview
 @Composable
@@ -37,7 +37,7 @@ fun ResourcesDemo() {
     Image(
       modifier = Modifier
         .align(alignment = Alignment.CenterHorizontally)
-        .size(imageSize.dp),
+        .size(IMAGE_SIZE.dp),
       contentScale = ContentScale.FillBounds,
       painter = painterResource(id = R.drawable.camera),
       contentDescription = "camera"
@@ -45,7 +45,7 @@ fun ResourcesDemo() {
     Image(
       modifier = Modifier
         .align(alignment = Alignment.CenterHorizontally)
-        .size(imageSize.dp),
+        .size(IMAGE_SIZE.dp),
       contentScale = ContentScale.FillBounds,
       painter = painterResource(id = R.drawable.ic_android_black_24dp),
       contentDescription = "android"

--- a/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemoView.kt
+++ b/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemoView.kt
@@ -69,8 +69,8 @@ class ResourcesDemoView(context: Context) : LinearLayout(context) {
         )
           .apply {
             gravity = Gravity.CENTER
-            height = dip(imageSize)
-            width = dip(imageSize)
+            height = dip(IMAGE_SIZE)
+            width = dip(IMAGE_SIZE)
           }
         setImageResource(drawableRes)
       }

--- a/sample/src/test/java/app/cash/paparazzi/sample/ComposeA11yTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ComposeA11yTest.kt
@@ -53,7 +53,8 @@ class ComposeA11yTest {
         Row(modifier = Modifier.semantics(mergeDescendants = true) {}) {
           Image(
             imageVector = Icons.Filled.Add,
-            contentDescription = null // decorative
+            // decorative
+            contentDescription = null
           )
           Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {
             Text("Text")

--- a/sample/src/test/java/app/cash/paparazzi/sample/ResourcesTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ResourcesTest.kt
@@ -28,6 +28,9 @@ class ResourcesTest(
   }
 
   enum class Locale(val tag: String?) {
-    Default(null), Arabic("ar"), Accent("en-rXA"), Bidi("ar-rXB")
+    Default(null),
+    Arabic("ar"),
+    Accent("en-rXA"),
+    Bidi("ar-rXB")
   }
 }


### PR DESCRIPTION
 * Prep for https://github.com/cashapp/paparazzi/pull/1076

"Preparation" as in reduce the future PR size by applying manual intervention requiring fixes earlier and fix things that prevent `spotlessApply` from executing.

The changes are exhaustive, but intentionally didn't include the fix for (i.e. #1076 will fail with this error still):
```
> Task :paparazzi:spotlessKotlin FAILED
Step 'ktlint' found problem in 'src\main\java\app\cash\paparazzi\internal\ImageUtils.kt':
Error on line: 72, column: 9
rule: standard:property-naming
Property name should start with a lowercase letter and use camel case
```
because that will be fixed in ktlint 1.0.2 or 1.1.0: https://github.com/pinterest/ktlint/issues/2352