### PR TITLE
Draft fix to solve layout issues when animateContentSize is used on compose layouts

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/LastFrameSnapshotHandler.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/LastFrameSnapshotHandler.kt
@@ -1,0 +1,32 @@
+package app.cash.paparazzi
+
+import app.cash.paparazzi.SnapshotHandler.FrameHandler
+import java.awt.image.BufferedImage
+
+class LastFrameSnapshotHandler(
+  private val maxPercentDifference: Double = 0.1,
+) : SnapshotHandler {
+  override fun newFrameHandler(snapshot: Snapshot, frameCount: Int, fps: Int): FrameHandler {
+    val handler = if (isVerifying) SnapshotVerifier(maxPercentDifference) else HtmlReportWriter()
+    val frameHandler = handler.newFrameHandler(snapshot, 1, -1)
+    return object : FrameHandler {
+      private lateinit var lastFrame: BufferedImage
+      override fun handle(image: BufferedImage) {
+        lastFrame = image
+      }
+
+      override fun close() {
+        frameHandler.handle(lastFrame)
+        frameHandler.close()
+      }
+    }
+  }
+
+  override fun close() = Unit
+
+  companion object {
+    private val isVerifying: Boolean =
+      System.getProperty("paparazzi.test.verify")?.toBoolean() == true
+  }
+}
+

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/InstantMotionDurationScale.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/InstantMotionDurationScale.kt
@@ -1,0 +1,12 @@
+package app.cash.paparazzi.internal
+
+import androidx.compose.ui.MotionDurationScale
+
+/**
+ * An implementation of [MotionDurationScale] that returns 0 for the scale factor to make compose
+ * animations complete instantly.
+ */
+class InstantMotionDurationScale : MotionDurationScale {
+  override val scaleFactor: Float
+    get() = 0f
+}

--- a/sample/src/test/java/app/cash/paparazzi/sample/ComposeAnimationTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ComposeAnimationTest.kt
@@ -1,0 +1,83 @@
+package app.cash.paparazzi.sample
+
+import android.view.ViewGroup.LayoutParams
+import android.widget.LinearLayout
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.InstantAnimationsRule
+import app.cash.paparazzi.LastFrameSnapshotHandler
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * This sample tests the use of compose animations (animateContentSize) and ensures that the content
+ * correctly renders in the right place. To do this, we add the view to a container where it only
+ * fills 50% of the space using a weight. The remaining 50% is filled with an empty box.
+ */
+class ComposeAnimationTest {
+  @get:Rule val instantAnimationsRule = InstantAnimationsRule()
+
+  @get:Rule
+  val paparazzi = Paparazzi(
+    deviceConfig = DeviceConfig.PIXEL.copy(
+      screenWidth = DeviceConfig.PIXEL.screenWidth * 2,
+      softButtons = false
+    ),
+    snapshotHandler = LastFrameSnapshotHandler()
+  )
+
+  @Test
+  fun compositeItems() {
+    val view = LinearLayout(paparazzi.context).apply {
+      orientation = LinearLayout.HORIZONTAL
+      weightSum = 2f
+      layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+
+      addView(
+        ComposeView(paparazzi.context).apply {
+          setContent {
+            Column(
+              modifier = Modifier
+                .animateContentSize()
+                .border(
+                  width = 2.dp,
+                  color = Color.Cyan,
+                  shape = RoundedCornerShape(2.dp)
+                )
+            ) {
+              Row(modifier = Modifier.fillMaxWidth()) {
+                Text("This is a row of text", Modifier.weight(1f))
+              }
+              Row(modifier = Modifier.fillMaxWidth()) {
+                Text("This is some more text")
+                Text(text = "And even more text")
+              }
+            }
+          }
+        },
+        LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1f)
+      )
+
+      addView(
+        LinearLayout(paparazzi.context).apply {
+          setBackgroundColor(Color.Blue.toArgb())
+        },
+        LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1f)
+      )
+    }
+
+    paparazzi.gif(view = view, fps = 2)
+  }
+}


### PR DESCRIPTION
This is a draft PR that demonstrates a fix for https://github.com/cashapp/paparazzi/issues/1165

There are 2 components to the fix:
1. Creating an implementation of `MotionDurtionScale` that returns a scaleDuration of 0 instead of 1 to allow compose animations to "complete" instantly. In practice, this appears to cause the the animations to complete after the initial composition and thus requires 2 compositions.
2. To solve the re-composition, this is using a `LastFrameSnapshotHandler` to grab the final frame.

I created a new sample test to demonstrate the issue without the using AccessibilityRenderExtension to eliminate extra variables as the core of the issue seems to revolve around placing a composable view within a layout where it doesn't fill the entire layout and hasn't been measured.

Some references I found around MotionDurationScale: 
1. https://slack-chats.kotlinlang.org/t/2913570/is-there-a-way-to-turn-off-animations-for-a-compose-hierarch
2. This is [where the MotionDurationScale is used](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowRecomposer.android.kt;l=342?q=motiondurationScale&amp;ss=androidx%2Fplatform%2Fframeworks%2Fsupport) internally.

Here is what a before the fix and after looks like:
| Before | After
|----|----
![before](https://github.com/cashapp/paparazzi/assets/1827721/d389db75-bddc-4508-8ddc-c07053ac66b3) |  ![after](https://github.com/cashapp/paparazzi/assets/1827721/1a2741ec-eed1-415b-89a5-7a5703c2026a)