### PR TITLE
Bump Truth 1.1.5 => 1.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version = "1.0.20200
 # Test libraries
 junit = { module = "junit:junit", version = "4.13.2" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.14" }
-truth = { module = "com.google.truth:truth", version = "1.1.5" }
+truth = { module = "com.google.truth:truth", version = "1.2.0" }
 
 # Plugins
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -256,8 +256,11 @@ class PaparazziPluginTest {
   fun buildClassNextSdkAccess() {
     val fixtureRoot = File("src/test/projects/build-class-next-sdk")
 
+    // Paparazzi detects Android platform dir contents to be static. Therefore, it re-runs only on
+    // compileSdk changes.  Sandbox previews are an exception, so let's disable caching for this
+    // test task.
     gradleRunner
-      .withArguments("testDebug", "--stacktrace")
+      .withArguments("testDebug", "-Dorg.gradle.caching=false", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
     val snapshotsDir = File(fixtureRoot, "custom/reports/paparazzi/debug/images")

--- a/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/build.gradle
@@ -22,3 +22,5 @@ android {
 dependencies {
   testImplementation libs.truth
 }
+
+apply from: '../common.gradle'

--- a/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
@@ -27,8 +27,8 @@ class BuildClassTest {
 
   @Test
   fun verifyFields() {
-    assertThat(Build.ID).isEqualTo("URD9.230712.002.A1")
-    assertThat(Build.DISPLAY).isEqualTo("sdk_phone_armv7-userdebug UpsideDownCakePrivacySandbox URD9.230712.002.A1 10628788 test-keys")
+    assertThat(Build.DISPLAY).isEqualTo("sdk_phone_armv7-userdebug UpsideDownCakePrivacySandbox URD9.231106.004.A2 11164158 test-keys")
+    assertThat(Build.ID).isEqualTo("URD9.231106.004.A2")
     assertThat(Build.PRODUCT).isEqualTo("unknown")
     assertThat(Build.DEVICE).isEqualTo("generic")
     assertThat(Build.BOARD).isEqualTo("unknown")
@@ -43,7 +43,7 @@ class BuildClassTest {
     assertThat(Build.SKU).isEqualTo("unknown")
     assertThat(Build.ODM_SKU).isEqualTo("unknown")
 
-    assertThat(Build.VERSION.INCREMENTAL).isEqualTo("10628788")
+    assertThat(Build.VERSION.INCREMENTAL).isEqualTo("11164158")
     assertThat(Build.VERSION.RELEASE).isNotNull()
     assertThat(Build.VERSION.RELEASE_OR_CODENAME).isNotNull()
     assertThat(Build.VERSION.BASE_OS).isEqualTo("")

--- a/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
@@ -22,3 +22,5 @@ android {
 dependencies {
   testImplementation libs.truth
 }
+
+apply from: '../common.gradle'

--- a/paparazzi-gradle-plugin/src/test/projects/common.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/common.gradle
@@ -1,0 +1,20 @@
+// TODO:
+//   Remove when https://github.com/google/guava/issues/6567 is fixed.
+//   See also: https://github.com/google/guava/issues/6801.
+plugins.withId("app.cash.paparazzi") {
+  // Defer until afterEvaluate so that testImplementation is created by Android plugin.
+  afterEvaluate {
+    dependencies.constraints {
+      add("testImplementation", "com.google.guava:guava") {
+        attributes {
+          attribute(
+            TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+            objects.named(TargetJvmEnvironment, TargetJvmEnvironment.STANDARD_JVM)
+          )
+        }
+        because("LayoutLib and sdk-common depend on Guava's -jre published variant." +
+          "See https://github.com/cashapp/paparazzi/issues/906.")
+      }
+    }
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
@@ -23,3 +23,5 @@ dependencies {
   testImplementation 'androidx.activity:activity-compose:1.6.1'
   testImplementation libs.truth
 }
+
+apply from: '../common.gradle'

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets-legacy-asset-loading-off/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets-legacy-asset-loading-off/consumer/build.gradle
@@ -25,3 +25,5 @@ dependencies {
   implementation projects.producer2
   testImplementation libs.truth
 }
+
+apply from: '../../common.gradle'

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets-legacy-asset-loading-on/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets-legacy-asset-loading-on/consumer/build.gradle
@@ -25,3 +25,5 @@ dependencies {
   implementation projects.producer2
   testImplementation libs.truth
 }
+
+apply from: '../../common.gradle'


### PR DESCRIPTION
Relates to https://github.com/cashapp/paparazzi/issues/906.  Closes https://github.com/cashapp/paparazzi/pull/1195.

Guava's publishing changed slightly in v33.0.0, using Gradle Module Metadata to help guide consumers' resolution of the appropriate variant, i.e., -jre vs -android: https://github.com/google/guava/pull/3683

Truth 1.2.0 bumps to Guava 33.0.0, so the preceding PR was failing because that new publishing mechanism by default forces the -android variant, which doesn't have the methods we expect and that are present in the -jre variant.

This is a frustrating ongoing problem and this PR is only solving the most recent manifestation of this issue. See the discussion in https://github.com/google/guava/issues/6801 for the latest discussion.