### PR TITLE
Fix deprecation in KMP test

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-  android()
+  androidTarget()
 }
 
 android {


### PR DESCRIPTION
```
w: Please use `androidTarget` function instead of `android` to configure android target inside `kotlin { }` block.
See the details here: https://kotl.in/android-target-dsl
```