### PR TITLE
Key test failure artifact uploads by shard type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-failures
+          name: test-failures-${{ matrix.os }}-${{ matrix.java-version }}
           path: |
             **/build/reports/tests/*/
             **/build/paparazzi/failures/


### PR DESCRIPTION
Broken in this dependency bump due to breaking API change: https://github.com/cashapp/paparazzi/commit/5cdea5bd2b73ddef40bf119512315a5d0ec6d0b3

See #2 here: https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes