### PR TITLE
Disable caching when testing sandbox preview SDKs

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -256,8 +256,11 @@ class PaparazziPluginTest {
   fun buildClassNextSdkAccess() {
     val fixtureRoot = File("src/test/projects/build-class-next-sdk")
 
+    // Paparazzi detects Android platform dir contents to be static. Therefore, it re-runs only on
+    // compileSdk changes.  Sandbox previews are an exception, so let's disable caching for this
+    // test task.
     gradleRunner
-      .withArguments("testDebug", "--stacktrace")
+      .withArguments("testDebug", "-Dorg.gradle.caching=false", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
     val snapshotsDir = File(fixtureRoot, "custom/reports/paparazzi/debug/images")

--- a/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class-next-sdk/src/test/java/app/cash/paparazzi/plugin/test/BuildClassTest.kt
@@ -27,8 +27,8 @@ class BuildClassTest {
 
   @Test
   fun verifyFields() {
-    assertThat(Build.ID).isEqualTo("URD9.230712.002.A1")
-    assertThat(Build.DISPLAY).isEqualTo("sdk_phone_armv7-userdebug UpsideDownCakePrivacySandbox URD9.230712.002.A1 10628788 test-keys")
+    assertThat(Build.DISPLAY).isEqualTo("sdk_phone_armv7-userdebug UpsideDownCakePrivacySandbox URD9.231106.004.A2 11164158 test-keys")
+    assertThat(Build.ID).isEqualTo("URD9.231106.004.A2")
     assertThat(Build.PRODUCT).isEqualTo("unknown")
     assertThat(Build.DEVICE).isEqualTo("generic")
     assertThat(Build.BOARD).isEqualTo("unknown")
@@ -43,7 +43,7 @@ class BuildClassTest {
     assertThat(Build.SKU).isEqualTo("unknown")
     assertThat(Build.ODM_SKU).isEqualTo("unknown")
 
-    assertThat(Build.VERSION.INCREMENTAL).isEqualTo("10628788")
+    assertThat(Build.VERSION.INCREMENTAL).isEqualTo("11164158")
     assertThat(Build.VERSION.RELEASE).isNotNull()
     assertThat(Build.VERSION.RELEASE_OR_CODENAME).isNotNull()
     assertThat(Build.VERSION.BASE_OS).isEqualTo("")


### PR DESCRIPTION
Relevant discussion: https://github.com/cashapp/paparazzi/pull/1206/files#r1443255733

cc: @TWiStErRob 