### PR TITLE
Always cleanup artifacts for repeatable tests

### DIFF
--- a/paparazzi/src/test/java/app/cash/paparazzi/InstantAnimationsRuleTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/InstantAnimationsRuleTest.kt
@@ -27,10 +27,13 @@ import org.junit.Test
 
 class InstantAnimationsRuleTest {
   @get:Rule
-  val paparazzi = Paparazzi()
+  val testRule = PaparazziTestRule()
 
   @get:Rule
   val instantAnimationsRule = InstantAnimationsRule()
+
+  val paparazzi
+    get() = testRule.paparazzi
 
   /**
    * Confirm that animations and their event listeners are all executed immediately, even though

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -36,7 +36,10 @@ import java.util.concurrent.TimeUnit
 
 class PaparazziTest {
   @get:Rule
-  val paparazzi = Paparazzi()
+  val testRule = PaparazziTestRule()
+
+  val paparazzi
+    get() = testRule.paparazzi
 
   @Test
   fun drawCalls() {

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTestRule.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTestRule.kt
@@ -1,0 +1,56 @@
+package app.cash.paparazzi
+
+import org.junit.rules.ExternalResource
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.Description
+import org.junit.runners.model.MultipleFailureException
+import org.junit.runners.model.Statement
+
+class PaparazziTestRule : ExternalResource() {
+  private val tmpFolder = TemporaryFolder.builder().assureDeletion().build()
+  private val reportDirKey = "paparazzi.snapshot.dir"
+  private var oldReportDir: String? = null
+
+  internal lateinit var paparazzi: Paparazzi
+
+  override fun before() {
+    tmpFolder.create()
+
+    oldReportDir = System.getProperty(reportDirKey)
+    System.setProperty(reportDirKey, tmpFolder.newFolder().path)
+
+    paparazzi = Paparazzi()
+  }
+
+  override fun after() {
+    tmpFolder.delete()
+
+    if (oldReportDir == null) {
+      System.clearProperty(reportDirKey)
+    } else {
+      System.setProperty(reportDirKey, oldReportDir!!)
+    }
+  }
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        before()
+
+        val errors: MutableList<Throwable> = ArrayList()
+        try {
+          paparazzi.apply(base, description).evaluate()
+        } catch (t: Throwable) {
+          errors.add(t)
+        } finally {
+          try {
+            after()
+          } catch (t: Throwable) {
+            errors.add(t)
+          }
+        }
+        MultipleFailureException.assertEmpty(errors)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/cashapp/paparazzi/pull/695, Also applies the feedback given in https://github.com/cashapp/paparazzi/pull/695#pullrequestreview-1264422283.

Re: paparazzi tests, this adds a custom rule to swap out system properties.

Re: plugin tests, pre-cleaning potentially leftover state from previous test runs is an anti-pattern.  However, Gradle doesn't provide a straightforward way to pass in TemporaryFolder-based paths without resorting to custom test-specific property passing, such as attempted here: https://github.com/cashapp/paparazzi/pull/408/files#diff-8c52db63811b414fc18b3fe88650c819563e678a6cf71aa913ef4820e2c1cba4

File.deleteOnExit works well on files, but not for directories that have been populated after registering the shutdown hook with the VM. File.deleteRecursively handles non-empty directories, but doesn't register a shutdown hook, leaving stale files on test failures.

So we add a @After method to provide a hybrid of the two behaviors, allowing files to be cleaned up regardless of test success/failure.

To troubleshoot future test failures with this automatic cleanup, simply comment out the teardown logic between test runs.