### PR TITLE
Skip synthetic fields in R classes

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -61,7 +61,7 @@ internal class PaparazziCallback(
         val resourceType = ResourceType.fromClassName(resourceClass.simpleName) ?: continue
 
         for (field in resourceClass.declaredFields) {
-          if (!Modifier.isStatic(field.modifiers)) continue
+          if (!Modifier.isStatic(field.modifiers) || field.isSynthetic) continue
 
           // May not be final in library projects.
           val type = field.type


### PR DESCRIPTION
Addresses https://github.com/cashapp/paparazzi/issues/732 as suggested by https://github.com/cashapp/paparazzi/pull/1167#discussion_r1432467200.

Verified by running `./gradlew sample:testDebug` before/after this change.