### PR TITLE
fix path for uploading paparazzi-gradle-plugin test images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           path: |
             **/build/reports/tests/*/
             **/build/paparazzi/failures/
-            paparazzi/paparazzi-gradle-plugin/src/test/projects/**/build/reports/paparazzi/**/images/
+            paparazzi-gradle-plugin/src/test/projects/**/build/reports/paparazzi/**/images/
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed that the path to the Gradle plugin was wrong which caused the images to be not uploaded.