### PR TITLE
Updates the DeviceConfig screenWidth internally for accessibility tests so consumers do not have to

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
 import app.cash.paparazzi.agent.InterceptorRegistrar
 import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.PaparazziCallback
@@ -166,7 +167,7 @@ class Paparazzi @JvmOverloads constructor(
     sessionParamsBuilder = sessionParamsBuilder
       .copy(
         layoutPullParser = LayoutPullParser.createFromString(contentRoot),
-        deviceConfig = deviceConfig,
+        deviceConfig = deviceConfig.updateIfAccessibilityTest(),
         renderingMode = renderingMode,
         supportsRtl = supportsRtl,
         decor = showSystemUi
@@ -249,7 +250,9 @@ class Paparazzi @JvmOverloads constructor(
       )
 
     if (deviceConfig != null) {
-      sessionParamsBuilder = sessionParamsBuilder.copy(deviceConfig = deviceConfig)
+      sessionParamsBuilder = sessionParamsBuilder.copy(
+        deviceConfig = deviceConfig.updateIfAccessibilityTest()
+      )
     }
 
     if (theme != null) {
@@ -619,6 +622,16 @@ class Paparazzi @JvmOverloads constructor(
       Handler_Delegate.executeCallbacks()
     }
   }
+
+  private fun DeviceConfig.updateIfAccessibilityTest(): DeviceConfig =
+    if (renderExtensions.any { it is AccessibilityRenderExtension }) {
+      copy(
+        screenWidth = screenWidth * 2,
+        softButtons = false
+      )
+    } else {
+      this
+    }
 
   companion object {
     /** The choreographer doesn't like 0 as a frame time, so start an hour later. */

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
@@ -27,11 +27,7 @@ class AccessibilityRenderExtensionTest {
 
   @get:Rule
   val paparazzi = Paparazzi(
-    deviceConfig = DeviceConfig.NEXUS_5.copy(
-      // Needed to render accessibility content next to main content.
-      screenWidth = DeviceConfig.NEXUS_5.screenWidth * 2,
-      softButtons = false
-    ),
+    deviceConfig = DeviceConfig.NEXUS_5,
     snapshotHandler = snapshotHandler,
     renderExtensions = setOf(AccessibilityRenderExtension())
   )

--- a/sample/src/test/java/app/cash/paparazzi/sample/ComposeA11yTest.kt
+++ b/sample/src/test/java/app/cash/paparazzi/sample/ComposeA11yTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 class ComposeA11yTest {
   @get:Rule
   val paparazzi = Paparazzi(
-    deviceConfig = DeviceConfig.PIXEL.copy(screenWidth = DeviceConfig.PIXEL.screenWidth * 2, softButtons = false),
+    deviceConfig = DeviceConfig.PIXEL,
     renderExtensions = setOf(AccessibilityRenderExtension())
   )
 


### PR DESCRIPTION
This removes the need to double the `DeviceConfig.screenWidth` in individual tests when using the `AccessibilityRenderExtension` and instead Paparazzi will handle this internally 