### PR TITLE
Fix variant caching issues in new resource/asset loading mechanisms

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -17,6 +17,7 @@ package app.cash.paparazzi.gradle
 
 import app.cash.paparazzi.gradle.utils.artifactViewFor
 import app.cash.paparazzi.gradle.utils.artifactsFor
+import app.cash.paparazzi.gradle.utils.relativize
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
@@ -172,10 +173,10 @@ class PaparazziPlugin : Plugin<Project> {
         task.targetSdkVersion.set(android.targetSdkVersion())
         task.compileSdkVersion.set(android.compileSdkVersion())
         task.mergeAssetsOutputDir.set(buildDirectory.asRelativePathString(mergeAssetsOutputDir))
-        task.projectResourceDirs.from(localResourceDirs)
-        task.moduleResourceDirs.from(moduleResourceDirs)
+        task.projectResourceDirs.set(localResourceDirs.relativize(projectDirectory))
+        task.moduleResourceDirs.set(moduleResourceDirs.relativize(projectDirectory))
         task.aarExplodedDirs.from(aarExplodedDirs)
-        task.projectAssetDirs.from(localAssetDirs.plus(moduleAssetDirs))
+        task.projectAssetDirs.set(localAssetDirs.plus(moduleAssetDirs).relativize(projectDirectory))
         task.aarAssetDirs.from(aarAssetDirs)
         task.paparazziResources.set(buildDirectory.file("intermediates/paparazzi/${variant.name}/resources.json"))
       }
@@ -236,6 +237,18 @@ class PaparazziPlugin : Plugin<Project> {
 
         test.inputs.dir(mergeResourcesOutputDir)
         test.inputs.dir(mergeAssetsOutputDir)
+        test.inputs.files(localResourceDirs)
+          .withPropertyName("paparazzi.localResourceDirs")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+        test.inputs.files(moduleResourceDirs)
+          .withPropertyName("paparazzi.moduleResourceDirs")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+        test.inputs.files(localAssetDirs)
+          .withPropertyName("paparazzi.localAssetDirs")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+        test.inputs.files(moduleAssetDirs)
+          .withPropertyName("paparazzi.moduleAssetDirs")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
         test.inputs.files(nativePlatformFileCollection)
           .withPropertyName("paparazzi.nativePlatform")
           .withPathSensitivity(PathSensitivity.NONE)

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -21,6 +21,7 @@ import com.squareup.moshi.Moshi
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -45,21 +46,18 @@ abstract class PrepareResourcesTask : DefaultTask() {
   @get:Input
   abstract val compileSdkVersion: Property<String>
 
-  @get:InputFiles
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val projectResourceDirs: ConfigurableFileCollection
+  @get:Input
+  abstract val projectResourceDirs: ListProperty<String>
 
-  @get:InputFiles
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val moduleResourceDirs: ConfigurableFileCollection
+  @get:Input
+  abstract val moduleResourceDirs: ListProperty<String>
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val aarExplodedDirs: ConfigurableFileCollection
 
-  @get:InputFiles
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val projectAssetDirs: ConfigurableFileCollection
+  @get:Input
+  abstract val projectAssetDirs: ListProperty<String>
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -110,10 +108,10 @@ abstract class PrepareResourcesTask : DefaultTask() {
       platformDir = "platforms/android-${compileSdkVersion.get()}/",
       mergeAssetsOutputDir = mergeAssetsOutputDir.get(),
       resourcePackageNames = resourcePackageNames,
-      projectResourceDirs = projectResourceDirs.relativize(projectDirectory),
-      moduleResourceDirs = moduleResourceDirs.relativize(projectDirectory),
+      projectResourceDirs = projectResourceDirs.get(),
+      moduleResourceDirs = moduleResourceDirs.get(),
       aarExplodedDirs = aarExplodedDirs.relativize(gradleUserHomeDirectory),
-      projectAssetDirs = projectAssetDirs.relativize(projectDirectory),
+      projectAssetDirs = projectAssetDirs.get(),
       aarAssetDirs = aarAssetDirs.relativize(gradleUserHomeDirectory)
     )
     val moshi = Moshi.Builder().build()!!

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/utils/FileUtils.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/utils/FileUtils.kt
@@ -15,11 +15,11 @@
  */
 package app.cash.paparazzi.gradle.utils
 
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
+import org.gradle.api.file.FileCollection
 import java.io.File
 
-fun ConfigurableFileCollection.relativize(directory: Directory) = files.map(directory::relativize)
+fun FileCollection.relativize(directory: Directory) = files.map(directory::relativize)
 
 fun Directory.relativize(child: File): String {
   return asFile.toPath().relativize(child.toPath()).toFile().invariantSeparatorsPath

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -887,11 +887,15 @@ class PaparazziPluginTest {
     firstResourceFile.copyTo(destResourceFile, overwrite = false)
 
     val firstRun = gradleRunner
-      .withArguments(":preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments("testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(firstRun.task(":preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+    with(firstRun.task(":testDebugUnitTest")) {
       assertThat(this).isNotNull()
       assertThat(this!!.outcome).isEqualTo(SUCCESS)
     }
@@ -907,13 +911,17 @@ class PaparazziPluginTest {
     secondResourceFile.copyTo(destResourceFile, overwrite = true)
 
     val secondRun = gradleRunner
-      .withArguments(":preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(secondRun.task(":preparePaparazziDebugResources")) {
       assertThat(this).isNotNull()
-      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE) // paths didn't change
+    }
+    with(secondRun.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS) // but contents did
     }
 
     config = resourcesFile.loadConfig()
@@ -938,11 +946,15 @@ class PaparazziPluginTest {
     firstResourceFile.copyTo(destResourceFile, overwrite = false)
 
     val firstRun = gradleRunner
-      .withArguments(":consumer:preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(firstRun.task(":consumer:preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+    with(firstRun.task(":consumer:testDebugUnitTest")) {
       assertThat(this).isNotNull()
       assertThat(this!!.outcome).isEqualTo(SUCCESS)
     }
@@ -958,13 +970,17 @@ class PaparazziPluginTest {
     secondResourceFile.copyTo(destResourceFile, overwrite = true)
 
     val secondRun = gradleRunner
-      .withArguments(":consumer:preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(secondRun.task(":consumer:preparePaparazziDebugResources")) {
       assertThat(this).isNotNull()
-      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE) // paths didn't change
+    }
+    with(secondRun.task(":consumer:testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS) // but contents did
     }
 
     config = resourcesFile.loadConfig()
@@ -1031,11 +1047,16 @@ class PaparazziPluginTest {
     firstAssetFile.copyTo(destAssetFile, overwrite = false)
 
     val firstRun = gradleRunner
-      .withArguments(":preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments("testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(firstRun.task(":preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+
+    with(firstRun.task(":testDebugUnitTest")) {
       assertThat(this).isNotNull()
       assertThat(this!!.outcome).isEqualTo(SUCCESS)
     }
@@ -1051,13 +1072,18 @@ class PaparazziPluginTest {
     secondAssetFile.copyTo(destAssetFile, overwrite = true)
 
     val secondRun = gradleRunner
-      .withArguments(":preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(secondRun.task(":preparePaparazziDebugResources")) {
       assertThat(this).isNotNull()
-      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE) // paths didn't change
+    }
+
+    with(secondRun.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS) // but contents did
     }
 
     config = resourcesFile.loadConfig()
@@ -1082,11 +1108,16 @@ class PaparazziPluginTest {
     firstAssetFile.copyTo(destAssetFile, overwrite = false)
 
     val firstRun = gradleRunner
-      .withArguments(":consumer:preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(firstRun.task(":consumer:preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+
+    with(firstRun.task(":consumer:testDebugUnitTest")) {
       assertThat(this).isNotNull()
       assertThat(this!!.outcome).isEqualTo(SUCCESS)
     }
@@ -1106,13 +1137,18 @@ class PaparazziPluginTest {
     secondAssetFile.copyTo(destAssetFile, overwrite = true)
 
     val secondRun = gradleRunner
-      .withArguments(":consumer:preparePaparazziDebugResources", "--build-cache", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--build-cache", "--stacktrace")
       .forwardOutput()
       .runFixture(fixtureRoot) { build() }
 
     with(secondRun.task(":consumer:preparePaparazziDebugResources")) {
       assertThat(this).isNotNull()
-      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE) // paths didn't change
+    }
+
+    with(secondRun.task(":consumer:testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS) // but contents did
     }
 
     config = resourcesFile.loadConfig()

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1712,7 +1712,7 @@ class PaparazziPluginTest {
     assertThat(jacocoExecutionData.exists()).isTrue()
   }
 
-  private fun File.loadConfig() = CONFIG_ADAPTER.fromJson(source().buffer())!!
+  private fun File.loadConfig() = source().buffer().use { CONFIG_ADAPTER.fromJson(it)!! }
 
   private fun GradleRunner.runFixture(
     projectRoot: File,

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/build.gradle
@@ -14,4 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
@@ -1,0 +1,7 @@
+package app.cash.paparazzi.plugin.test
+
+import org.junit.Test
+
+class DummyTest {
+  @Test fun dummy() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/build.gradle
@@ -14,4 +14,7 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
@@ -1,0 +1,7 @@
+package app.cash.paparazzi.plugin.test
+
+import org.junit.Test
+
+class DummyTest {
+  @Test fun dummy() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/consumer/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/consumer/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
@@ -1,0 +1,7 @@
+package app.cash.paparazzi.plugin.test
+
+import org.junit.Test
+
+class DummyTest {
+  @Test fun dummy() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/consumer/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/consumer/src/test/java/app/cash/paparazzi/plugin/test/DummyTest.kt
@@ -1,0 +1,7 @@
+package app.cash.paparazzi.plugin.test
+
+import org.junit.Test
+
+class DummyTest {
+  @Test fun dummy() {}
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -66,7 +66,8 @@ fun detectEnvironment(): Environment {
 
   val resourcesFile = File(System.getProperty("paparazzi.test.resources"))
   val moshi = Moshi.Builder().build()!!
-  val config = moshi.adapter(Config::class.java).fromJson(resourcesFile.source().buffer())!!
+  val config =
+    resourcesFile.source().buffer().use { moshi.adapter(Config::class.java).fromJson(it)!! }
 
   return Environment(
     platformDir = androidHome.resolve(config.platformDir).toString(),


### PR DESCRIPTION
Similar to https://github.com/cashapp/paparazzi/pull/720.  Unblocks the current build failures in https://github.com/cashapp/paparazzi/pull/1235.

Using task properties like the following:
```
  @get:InputFiles
  @get:PathSensitive(PathSensitivity.RELATIVE)
  abstract val projectResourceDirs: ConfigurableFileCollection
```
is great for working with Gradle remote caching (since it ignores absolute paths which can be user-specific) and will only examine subpath contents.  However, this doesn't jive well with Android variants, which can often be similar in contents, but differ in the base path, e.g., 

`src/debug/res` vs`src/release/res` or,
`../some_module/build/intermediates/packaged_res/debug` and `../some_module/build/intermediates/packaged_res/release`

In those cases, we've seen CI jobs fail when the `prepareResourcesTask` is considered `FROM_CACHE` because the contents of the respective folders haven't changed, but the cached `resources.json` file contains, say `debug` when Paparazzi is being ran for a `release` build, resulting in a crash due to the proposed file/path not being found.

To remedy, the properties will now be `ListProperty<String>` allowing `resources.json` to be re-created on path changes due to changes in variant builds, and move the contents checking to the test task properties.