### PR TITLE
Add Gif Snapshot Handler

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/GifSnapshotHandler.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/GifSnapshotHandler.kt
@@ -21,8 +21,8 @@ import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 
-class SnapshotVerifier @JvmOverloads constructor(
-  private val maxPercentDifference: Double,
+class GifSnapshotHandler @JvmOverloads constructor(
+  private val maxPercentDifference: Double = 0.1,
   rootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
 ) : SnapshotHandler {
   private val imagesDirectory: File = File(rootDirectory, "images")
@@ -39,13 +39,21 @@ class SnapshotVerifier @JvmOverloads constructor(
     fps: Int
   ): FrameHandler {
     return object : FrameHandler {
-      override fun handle(image: BufferedImage, frameIndex: Int?) {
-        // Note: does not handle videos or its frames at the moment
-        val expected = File(imagesDirectory, snapshot.toFileName(extension = "png"))
+      override fun handle(
+        image: BufferedImage,
+        frameIndex: Int?,
+      ) {
+        // handle() gets called with each image when gif() is used
+        val expected = File(
+          imagesDirectory,
+          snapshot.toFileName(
+            extension = "png",
+            frameIndex = frameIndex
+          )
+        )
         if (!expected.exists()) {
           throw AssertionError("File $expected does not exist")
         }
-
         val goldenImage = ImageIO.read(expected)
         ImageUtils.assertImageSimilar(
           relativePath = expected.path,

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -91,7 +91,7 @@ class HtmlReportWriter @JvmOverloads constructor(
     return object : FrameHandler {
       val hashes = mutableListOf<String>()
 
-      override fun handle(image: BufferedImage) {
+      override fun handle(image: BufferedImage, frameIndex: Int?) {
         hashes += writeImage(image)
       }
 
@@ -111,7 +111,8 @@ class HtmlReportWriter @JvmOverloads constructor(
           if (isRecording) {
             for ((index, frameHash) in hashes.withIndex()) {
               val originalFrame = File(imagesDirectory, "$frameHash.png")
-              val frameSnapshot = snapshot.copy(name = "${snapshot.name} $index")
+              val name = snapshot.name?.let { "$it $index" } ?: "$index"
+              val frameSnapshot = snapshot.copy(name = name)
               val goldenFile = File(goldenImagesDirectory, frameSnapshot.toFileName("_", "png"))
               if (!goldenFile.exists()) {
                 originalFrame.copyTo(goldenFile)

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -323,7 +323,7 @@ class Paparazzi @JvmOverloads constructor(
               }
               validateLayoutAccessibility(modifiedView, image)
             }
-            frameHandler.handle(scaleImage(frameImage(image)))
+            frameHandler.handle(scaleImage(frameImage(image)), frame)
           }
         }
       } finally {
@@ -656,6 +656,13 @@ class Paparazzi @JvmOverloads constructor(
     private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
       if (isVerifying) {
         SnapshotVerifier(maxPercentDifference)
+      } else {
+        HtmlReportWriter()
+      }
+
+    fun determineGifHandler(maxPercentDifference: Double = 0.1): SnapshotHandler =
+      if (isVerifying) {
+        GifSnapshotHandler(maxPercentDifference)
       } else {
         HtmlReportWriter()
       }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -30,12 +30,18 @@ data class Snapshot(
 
 internal fun Snapshot.toFileName(
   delimiter: String = "_",
-  extension: String
+  extension: String,
+  frameIndex: Int? = null,
 ): String {
   val formattedLabel = if (name != null) {
     "$delimiter${name.toLowerCase(Locale.US).replace("\\s".toRegex(), delimiter)}"
   } else {
     ""
   }
-  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension"
+  return if (frameIndex != null) {
+    "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}_$frameIndex.$extension"
+  } else {
+    "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension"
+  }
+
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotHandler.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotHandler.kt
@@ -26,6 +26,6 @@ interface SnapshotHandler : Closeable {
   ): FrameHandler
 
   interface FrameHandler : Closeable {
-    fun handle(image: BufferedImage)
+    fun handle(image: BufferedImage, frameIndex: Int? = null)
   }
 }


### PR DESCRIPTION
The `gif()` function in paparazzi creates multiple images per test. The resulting files each have an appended index, for example:
- myGifTest0.png
- myGifTest1.png
- myGifTest2.png
etc...

When validating against existing snapshots, Paparazzi currently looks for the file name *without* the appended index, since this is what non-gif snapshots need to validate against. For example:
- mySnapshotTest.png

To solve this problem, this PR creates a`GifSnapshotHandler` which will ensure that the correct index is appended to each file name before validating against the golden images. We can easily hook this up into gif tests by overriding the `snapshotHandler` in our test rule 
```
@get: Rule
    val paparazzi = Paparazzi(
        ...
        snapshotHandler = determineGifHandler(),
    )
    
