### PR TITLE
Restrict Paparazzi's public API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,18 +10,26 @@ buildscript {
 
   dependencies {
     classpath libs.plugin.kotlin
+    classpath libs.plugin.kotlinApiDump
     classpath libs.plugin.android
     classpath libs.plugin.mavenPublish
     classpath libs.plugin.dokka
     classpath libs.plugin.versions
     classpath libs.plugin.spotless
     classpath libs.plugin.buildConfig
+    classpath libs.plugin.poko
     classpath libs.grgit
 
     // Normally you would declare a version here, but we use dependency substitution in
     // settings.gradle to use the version built from inside the repo.
     classpath 'app.cash.paparazzi:paparazzi-gradle-plugin'
   }
+}
+
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+  ignoredProjects += ['libs', 'sample']
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,9 @@ plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp
 plugin-buildConfig = { module = "com.github.gmazzo.buildconfig:plugin", version = "5.3.5" }
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.10" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-kotlinApiDump = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = '0.13.2' }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.27.0" }
+plugin-poko = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.15.2" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.51.0" }

--- a/paparazzi-annotations/api/paparazzi-annotations.api
+++ b/paparazzi-annotations/api/paparazzi-annotations.api
@@ -1,0 +1,3 @@
+public abstract interface annotation class app/cash/paparazzi/annotations/Paparazzi : java/lang/annotation/Annotation {
+}
+

--- a/paparazzi-gradle-plugin/api/paparazzi-gradle-plugin.api
+++ b/paparazzi-gradle-plugin/api/paparazzi-gradle-plugin.api
@@ -1,0 +1,27 @@
+public final class app/cash/paparazzi/gradle/PaparazziPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public abstract class app/cash/paparazzi/gradle/PaparazziPlugin$PaparazziTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public fun setTestNameIncludePatterns (Ljava/util/List;)Lapp/cash/paparazzi/gradle/PaparazziPlugin$PaparazziTask;
+}
+
+public abstract class app/cash/paparazzi/gradle/PrepareResourcesTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public abstract fun getAarAssetDirs ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getAarExplodedDirs ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getArtifactFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getCompileSdkVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getModuleResourceDirs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getNonTransitiveRClassEnabled ()Lorg/gradle/api/provider/Property;
+	public abstract fun getPackageName ()Lorg/gradle/api/provider/Property;
+	public abstract fun getPaparazziResources ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getProjectAssetDirs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getProjectResourceDirs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getTargetSdkVersion ()Lorg/gradle/api/provider/Property;
+	public final fun writeResourcesFile ()V
+}
+

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -241,7 +241,7 @@ class PaparazziPlugin : Plugin<Project> {
     }
   }
 
-  open class PaparazziTask : DefaultTask() {
+  abstract class PaparazziTask : DefaultTask() {
     @Option(option = "tests", description = "Sets test class or method name to be included, '*' is supported.")
     open fun setTestNameIncludePatterns(testNamePattern: List<String>): PaparazziTask {
       project.tasks.withType(Test::class.java).configureEach {

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -107,7 +107,7 @@ abstract class PrepareResourcesTask : DefaultTask() {
     out.writeText(json)
   }
 
-  data class Config(
+  internal data class Config(
     val mainPackage: String,
     val targetSdkVersion: String,
     val platformDir: String,

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/utils/FileUtils.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/utils/FileUtils.kt
@@ -19,8 +19,8 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import java.io.File
 
-fun FileCollection.relativize(directory: Directory) = files.map(directory::relativize)
+internal fun FileCollection.relativize(directory: Directory) = files.map(directory::relativize)
 
-fun Directory.relativize(child: File): String {
+internal fun Directory.relativize(child: File): String {
   return asFile.toPath().relativize(child.toPath()).toFile().invariantSeparatorsPath
 }

--- a/paparazzi-preview-processor/api/paparazzi-preview-processor.api
+++ b/paparazzi-preview-processor/api/paparazzi-preview-processor.api
@@ -1,0 +1,11 @@
+public final class app/cash/paparazzi/preview/processor/PreviewProcessor : com/google/devtools/ksp/processing/SymbolProcessor {
+	public fun <init> (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)V
+	public fun process (Lcom/google/devtools/ksp/processing/Resolver;)Ljava/util/List;
+}
+
+public final class app/cash/paparazzi/preview/processor/PreviewProcessorProvider : com/google/devtools/ksp/processing/SymbolProcessorProvider {
+	public fun <init> ()V
+	public fun create (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)Lapp/cash/paparazzi/preview/processor/PreviewProcessor;
+	public synthetic fun create (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)Lcom/google/devtools/ksp/processing/SymbolProcessor;
+}
+

--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -1,0 +1,205 @@
+public final class app/cash/paparazzi/DeviceConfig {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/paparazzi/DeviceConfig$Companion;
+	public static final field GALAXY_WATCH4_CLASSIC_LARGE Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_10 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_4 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_5 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_5_LAND Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_7 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field NEXUS_7_2012 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_2 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_2_XL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_3 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_3A Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_3A_XL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_3_XL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_4 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_4A Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_4_XL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_5 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_6 Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_6_PRO Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_C Lapp/cash/paparazzi/DeviceConfig;
+	public static final field PIXEL_XL Lapp/cash/paparazzi/DeviceConfig;
+	public static final field WEAR_OS_SMALL_ROUND Lapp/cash/paparazzi/DeviceConfig;
+	public static final field WEAR_OS_SQUARE Lapp/cash/paparazzi/DeviceConfig;
+	public fun <init> ()V
+	public fun <init> (IIIILcom/android/resources/ScreenOrientation;Lcom/android/resources/UiMode;Lcom/android/resources/NightMode;Lcom/android/resources/Density;FLcom/android/resources/LayoutDirection;Ljava/lang/String;Lcom/android/resources/ScreenRatio;Lcom/android/resources/ScreenSize;Lcom/android/resources/Keyboard;Lcom/android/resources/TouchScreen;Lcom/android/resources/KeyboardState;ZLcom/android/resources/Navigation;Lcom/android/resources/ScreenRound;Ljava/lang/String;)V
+	public synthetic fun <init> (IIIILcom/android/resources/ScreenOrientation;Lcom/android/resources/UiMode;Lcom/android/resources/NightMode;Lcom/android/resources/Density;FLcom/android/resources/LayoutDirection;Ljava/lang/String;Lcom/android/resources/ScreenRatio;Lcom/android/resources/ScreenSize;Lcom/android/resources/Keyboard;Lcom/android/resources/TouchScreen;Lcom/android/resources/KeyboardState;ZLcom/android/resources/Navigation;Lcom/android/resources/ScreenRound;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (IIIILcom/android/resources/ScreenOrientation;Lcom/android/resources/UiMode;Lcom/android/resources/NightMode;Lcom/android/resources/Density;FLcom/android/resources/LayoutDirection;Ljava/lang/String;Lcom/android/resources/ScreenRatio;Lcom/android/resources/ScreenSize;Lcom/android/resources/Keyboard;Lcom/android/resources/TouchScreen;Lcom/android/resources/KeyboardState;ZLcom/android/resources/Navigation;Lcom/android/resources/ScreenRound;)Lapp/cash/paparazzi/DeviceConfig;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/DeviceConfig;IIIILcom/android/resources/ScreenOrientation;Lcom/android/resources/UiMode;Lcom/android/resources/NightMode;Lcom/android/resources/Density;FLcom/android/resources/LayoutDirection;Ljava/lang/String;Lcom/android/resources/ScreenRatio;Lcom/android/resources/ScreenSize;Lcom/android/resources/Keyboard;Lcom/android/resources/TouchScreen;Lcom/android/resources/KeyboardState;ZLcom/android/resources/Navigation;Lcom/android/resources/ScreenRound;ILjava/lang/Object;)Lapp/cash/paparazzi/DeviceConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()Lcom/android/resources/Density;
+	public final fun getFolderConfiguration ()Lcom/android/ide/common/resources/configuration/FolderConfiguration;
+	public final fun getFontScale ()F
+	public final fun getHardwareConfig ()Lcom/android/ide/common/rendering/api/HardwareConfig;
+	public final fun getKeyboard ()Lcom/android/resources/Keyboard;
+	public final fun getKeyboardState ()Lcom/android/resources/KeyboardState;
+	public final fun getLayoutDirection ()Lcom/android/resources/LayoutDirection;
+	public final fun getLocale ()Ljava/lang/String;
+	public final fun getNavigation ()Lcom/android/resources/Navigation;
+	public final fun getNightMode ()Lcom/android/resources/NightMode;
+	public final fun getOrientation ()Lcom/android/resources/ScreenOrientation;
+	public final fun getRatio ()Lcom/android/resources/ScreenRatio;
+	public final fun getReleased ()Ljava/lang/String;
+	public final fun getScreenHeight ()I
+	public final fun getScreenRound ()Lcom/android/resources/ScreenRound;
+	public final fun getScreenWidth ()I
+	public final fun getSize ()Lcom/android/resources/ScreenSize;
+	public final fun getSoftButtons ()Z
+	public final fun getTouchScreen ()Lcom/android/resources/TouchScreen;
+	public final fun getUiMode ()Lcom/android/resources/UiMode;
+	public final fun getUiModeMask ()I
+	public final fun getXdpi ()I
+	public final fun getYdpi ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/paparazzi/DeviceConfig$Companion {
+}
+
+public final class app/cash/paparazzi/Environment {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lapp/cash/paparazzi/Environment;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lapp/cash/paparazzi/Environment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllModuleAssetDirs ()Ljava/util/List;
+	public final fun getAppTestDir ()Ljava/lang/String;
+	public final fun getCompileSdkVersion ()I
+	public final fun getLibraryAssetDirs ()Ljava/util/List;
+	public final fun getLibraryResourceDirs ()Ljava/util/List;
+	public final fun getLocalResourceDirs ()Ljava/util/List;
+	public final fun getModuleResourceDirs ()Ljava/util/List;
+	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getPlatformDir ()Ljava/lang/String;
+	public final fun getResourcePackageNames ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/paparazzi/EnvironmentKt {
+	public static final fun androidHome ()Ljava/lang/String;
+	public static final fun detectEnvironment ()Lapp/cash/paparazzi/Environment;
+}
+
+public final class app/cash/paparazzi/Flags {
+	public static final field $stable I
+	public static final field DEBUG_LINKED_OBJECTS Ljava/lang/String;
+	public static final field INSTANCE Lapp/cash/paparazzi/Flags;
+}
+
+public final class app/cash/paparazzi/HtmlReportWriter : app/cash/paparazzi/SnapshotHandler {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/io/File;)V
+	public fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
+}
+
+public final class app/cash/paparazzi/InstantAnimationsRule : org/junit/rules/TestRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+}
+
+public final class app/cash/paparazzi/Paparazzi : org/junit/rules/TestRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lapp/cash/paparazzi/Environment;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;Z)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZD)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;Z)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZ)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZ)V
+	public synthetic fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+	public final fun close ()V
+	public final fun getContext ()Landroid/content/Context;
+	public final fun getLayoutInflater ()Landroid/view/LayoutInflater;
+	public final fun getResources ()Landroid/content/res/Resources;
+	public final fun gif (Landroid/view/View;)V
+	public final fun gif (Landroid/view/View;Ljava/lang/String;)V
+	public final fun gif (Landroid/view/View;Ljava/lang/String;J)V
+	public final fun gif (Landroid/view/View;Ljava/lang/String;JJ)V
+	public final fun gif (Landroid/view/View;Ljava/lang/String;JJI)V
+	public static synthetic fun gif$default (Lapp/cash/paparazzi/Paparazzi;Landroid/view/View;Ljava/lang/String;JJIILjava/lang/Object;)V
+	public final fun inflate (I)Landroid/view/View;
+	public final fun prepare (Lorg/junit/runner/Description;)V
+	public final fun snapshot (Landroid/view/View;)V
+	public final fun snapshot (Landroid/view/View;Ljava/lang/String;)V
+	public final fun snapshot (Landroid/view/View;Ljava/lang/String;J)V
+	public final fun snapshot (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun snapshot$default (Lapp/cash/paparazzi/Paparazzi;Landroid/view/View;Ljava/lang/String;JILjava/lang/Object;)V
+	public static synthetic fun snapshot$default (Lapp/cash/paparazzi/Paparazzi;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public final fun unsafeUpdateConfig (Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;)V
+	public static synthetic fun unsafeUpdateConfig$default (Lapp/cash/paparazzi/Paparazzi;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ILjava/lang/Object;)V
+}
+
+public abstract interface class app/cash/paparazzi/RenderExtension {
+	public abstract fun renderView (Landroid/view/View;)Landroid/view/View;
+}
+
+public final class app/cash/paparazzi/Snapshot {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;)Lapp/cash/paparazzi/Snapshot;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/Snapshot;Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/paparazzi/Snapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTags ()Ljava/util/List;
+	public final fun getTestName ()Lapp/cash/paparazzi/TestName;
+	public final fun getTimestamp ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/paparazzi/SnapshotHandler : java/io/Closeable {
+	public abstract fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
+}
+
+public abstract interface class app/cash/paparazzi/SnapshotHandler$FrameHandler : java/io/Closeable {
+	public abstract fun handle (Ljava/awt/image/BufferedImage;)V
+}
+
+public final class app/cash/paparazzi/SnapshotVerifier : app/cash/paparazzi/SnapshotHandler {
+	public static final field $stable I
+	public fun <init> (D)V
+	public fun <init> (DLjava/io/File;)V
+	public synthetic fun <init> (DLjava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
+}
+
+public final class app/cash/paparazzi/TestName {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lapp/cash/paparazzi/TestName;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/TestName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/paparazzi/TestName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getMethodName ()Ljava/lang/String;
+	public final fun getPackageName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/paparazzi/accessibility/AccessibilityRenderExtension : app/cash/paparazzi/RenderExtension {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun renderView (Landroid/view/View;)Landroid/view/View;
+}
+

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPluginKt
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'dev.drewhamilton.poko'
 
 java {
   sourceCompatibility = libs.versions.javaTarget.get()

--- a/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/DeviceConfig.kt
@@ -49,6 +49,7 @@ import com.android.resources.ScreenSize
 import com.android.resources.TouchScreen
 import com.android.resources.UiMode
 import com.google.android.collect.Maps
+import dev.drewhamilton.poko.Poko
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import org.xmlpull.v1.XmlPullParserFactory
@@ -66,7 +67,8 @@ import kotlin.math.min
  *
  * Defaults are for a Nexus 4 device.
  */
-data class DeviceConfig(
+@Poko
+class DeviceConfig(
   val screenHeight: Int = 1280,
   val screenWidth: Int = 768,
   val xdpi: Int = 320,
@@ -114,6 +116,49 @@ data class DeviceConfig(
         versionQualifier = VersionQualifier()
         screenRoundQualifier = ScreenRoundQualifier(screenRound)
       }
+
+  fun copy(
+    screenHeight: Int = this.screenHeight,
+    screenWidth: Int = this.screenWidth,
+    xdpi: Int = this.xdpi,
+    ydpi: Int = this.ydpi,
+    orientation: ScreenOrientation = this.orientation,
+    uiMode: UiMode = this.uiMode,
+    nightMode: NightMode = this.nightMode,
+    density: Density = this.density,
+    fontScale: Float = this.fontScale,
+    layoutDirection: LayoutDirection = this.layoutDirection,
+    locale: String? = this.locale,
+    ratio: ScreenRatio = this.ratio,
+    size: ScreenSize = this.size,
+    keyboard: Keyboard = this.keyboard,
+    touchScreen: TouchScreen = this.touchScreen,
+    keyboardState: KeyboardState = this.keyboardState,
+    softButtons: Boolean = this.softButtons,
+    navigation: Navigation = this.navigation,
+    screenRound: ScreenRound? = this.screenRound
+  ) = DeviceConfig(
+    screenHeight,
+    screenWidth,
+    xdpi,
+    ydpi,
+    orientation,
+    uiMode,
+    nightMode,
+    density,
+    fontScale,
+    layoutDirection,
+    locale,
+    ratio,
+    size,
+    keyboard,
+    touchScreen,
+    keyboardState,
+    softButtons,
+    navigation,
+    screenRound,
+    this.released
+  )
 
   private val currentWidth: Int
     get() = when (orientation) {
@@ -529,6 +574,7 @@ data class DeviceConfig(
     )
 
     // https://www.techidence.com/galaxy-watch4-features-reviews-and-price/
+    @JvmField
     val GALAXY_WATCH4_CLASSIC_LARGE: DeviceConfig = DeviceConfig(
       screenHeight = 454,
       screenWidth = 454,
@@ -590,7 +636,7 @@ data class DeviceConfig(
     private const val ATTR_VALUE = "value"
 
     @Throws(IOException::class)
-    fun loadProperties(path: File): Map<String, String> {
+    internal fun loadProperties(path: File): Map<String, String> {
       val p = Properties()
       val map = Maps.newHashMap<String, String>()
       p.load(FileInputStream(path))
@@ -601,7 +647,7 @@ data class DeviceConfig(
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    fun getEnumMap(path: File): Map<String, Map<String, Int>> {
+    internal fun getEnumMap(path: File): Map<String, Map<String, Int>> {
       val map = mutableMapOf<String, MutableMap<String, Int>>()
 
       val xmlPullParser = XmlPullParserFactory.newInstance()

--- a/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Environment.kt
@@ -17,6 +17,7 @@ package app.cash.paparazzi
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.drewhamilton.poko.Poko
 import okio.buffer
 import okio.source
 import java.io.File
@@ -26,7 +27,8 @@ import java.nio.file.Paths
 import java.util.Locale
 import kotlin.io.path.exists
 
-data class Environment(
+@Poko
+class Environment(
   val platformDir: String,
   val appTestDir: String,
   val packageName: String,
@@ -47,6 +49,31 @@ data class Environment(
       throw FileNotFoundException("Missing platform version $platformVersion. Install with sdkmanager --install \"platforms;$platform\"")
     }
   }
+
+  fun copy(
+    platformDir: String = this.platformDir,
+    appTestDir: String = this.appTestDir,
+    packageName: String = this.packageName,
+    compileSdkVersion: Int = this.compileSdkVersion,
+    resourcePackageNames: List<String> = this.resourcePackageNames,
+    localResourceDirs: List<String> = this.localResourceDirs,
+    moduleResourceDirs: List<String> = this.moduleResourceDirs,
+    libraryResourceDirs: List<String> = this.libraryResourceDirs,
+    allModuleAssetDirs: List<String> = this.allModuleAssetDirs,
+    libraryAssetDirs: List<String> = this.libraryAssetDirs
+  ): Environment =
+    Environment(
+      platformDir,
+      appTestDir,
+      packageName,
+      compileSdkVersion,
+      resourcePackageNames,
+      localResourceDirs,
+      moduleResourceDirs,
+      libraryResourceDirs,
+      allModuleAssetDirs,
+      libraryAssetDirs
+    )
 }
 
 @Suppress("unused")
@@ -81,7 +108,7 @@ fun detectEnvironment(): Environment {
   )
 }
 
-data class Config(
+internal data class Config(
   val mainPackage: String,
   val targetSdkVersion: String,
   val platformDir: String,

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -637,7 +637,7 @@ class Paparazzi @JvmOverloads constructor(
       this
     }
 
-  companion object {
+  internal companion object {
     /** The choreographer doesn't like 0 as a frame time, so start an hour later. */
     internal val TIME_OFFSET_NANOS = TimeUnit.HOURS.toNanos(1L)
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -15,16 +15,26 @@
  */
 package app.cash.paparazzi
 
+import dev.drewhamilton.poko.Poko
 import java.util.Date
 import java.util.Locale
 
-data class Snapshot(
+@Poko
+class Snapshot(
   val name: String?,
   val testName: TestName,
   val timestamp: Date,
   val tags: List<String> = listOf(),
   val file: String? = null
-)
+) {
+  fun copy(
+    name: String? = this.name,
+    testName: TestName = this.testName,
+    timestamp: Date = this.timestamp,
+    tags: List<String> = this.tags,
+    file: String? = this.file
+  ) = Snapshot(name, testName, timestamp, tags, file)
+}
 
 internal fun Snapshot.toFileName(
   delimiter: String = "_",

--- a/paparazzi/src/main/java/app/cash/paparazzi/TestName.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/TestName.kt
@@ -15,8 +15,17 @@
  */
 package app.cash.paparazzi
 
-data class TestName(
+import dev.drewhamilton.poko.Poko
+
+@Poko
+class TestName(
   val packageName: String,
   val className: String,
   val methodName: String
-)
+) {
+  fun copy(
+    packageName: String = this.packageName,
+    className: String = this.className,
+    methodName: String = this.methodName
+  ): TestName = TestName(packageName, className, methodName)
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -7,7 +7,7 @@ import net.bytebuddy.implementation.MethodDelegation
 import net.bytebuddy.matcher.ElementMatchers
 import net.bytebuddy.pool.TypePool
 
-object InterceptorRegistrar {
+internal object InterceptorRegistrar {
   private val byteBuddy = ByteBuddy()
   private val systemClassFileLocator = ClassFileLocator.ForClassLoader.ofSystemLoader()
   private val systemTypePool = TypePool.Default.ofSystemLoader()

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ComposeViewAdapter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ComposeViewAdapter.kt
@@ -10,7 +10,7 @@ import android.widget.FrameLayout
  * A wrapper layout for compose-based layouts which allows [android.view.WindowManagerImpl] to find
  * a composable root
  */
-class ComposeViewAdapter(
+internal class ComposeViewAdapter(
   context: Context,
   attrs: AttributeSet
 ) : FrameLayout(context, attrs)

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ChoreographerDelegateInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ChoreographerDelegateInterceptor.kt
@@ -3,7 +3,7 @@ package app.cash.paparazzi.internal.interceptors
 import android.view.Choreographer
 import com.android.internal.lang.System_Delegate
 
-object ChoreographerDelegateInterceptor {
+internal object ChoreographerDelegateInterceptor {
   @Suppress("unused")
   @JvmStatic
   fun intercept(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/EditModeInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/EditModeInterceptor.kt
@@ -1,6 +1,6 @@
 package app.cash.paparazzi.internal.interceptors
 
-object EditModeInterceptor {
+internal object EditModeInterceptor {
   @JvmStatic
   fun intercept(): Boolean = false
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/IInputMethodManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/IInputMethodManagerInterceptor.kt
@@ -8,7 +8,7 @@ import com.android.internal.view.IInputMethodManager
  * in [com.android.internal.view.IInputMethodManager.Stub.asInterface] to return the default
  * implementation of [IInputMethodManager].
  */
-object IInputMethodManagerInterceptor {
+internal object IInputMethodManagerInterceptor {
   @Suppress("unused")
   @JvmStatic
   fun interceptAsInterface(@Suppress("UNUSED_PARAMETER") obj: IBinder?): IInputMethodManager =

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixMatrixMultiplicationInterceptor.kt
@@ -1,7 +1,7 @@
 package app.cash.paparazzi.internal.interceptors
 
 // Sampled from https://cs.android.com/android/platform/superproject/+/master:external/robolectric-shadows/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java;l=10-67
-object MatrixMatrixMultiplicationInterceptor {
+internal object MatrixMatrixMultiplicationInterceptor {
   @Suppress("unused", "ktlint:standard:property-naming")
   @JvmStatic
   fun intercept(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/MatrixVectorMultiplicationInterceptor.kt
@@ -1,7 +1,7 @@
 package app.cash.paparazzi.internal.interceptors
 
 // Sampled from https://cs.android.com/android/platform/superproject/+/master:external/robolectric-shadows/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java;l=69-121
-object MatrixVectorMultiplicationInterceptor {
+internal object MatrixVectorMultiplicationInterceptor {
   @Suppress("unused", "ktlint:standard:property-naming")
   @JvmStatic
   fun intercept(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ResourcesInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ResourcesInterceptor.kt
@@ -3,7 +3,7 @@ package app.cash.paparazzi.internal.interceptors
 import android.content.Context
 import android.graphics.Typeface
 
-object ResourcesInterceptor {
+internal object ResourcesInterceptor {
   @JvmStatic
   fun intercept(
     context: Context,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ServiceManagerInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ServiceManagerInterceptor.kt
@@ -10,7 +10,7 @@ import android.os.IBinder
  *
  * This interceptor overrides ServiceManager.getServiceOrThrow to simply return null instead.
  */
-object ServiceManagerInterceptor {
+internal object ServiceManagerInterceptor {
   @Suppress("unused")
   @JvmStatic
   fun interceptGetServiceOrThrow(@Suppress("UNUSED_PARAMETER") name: String): IBinder? = null

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AaptAttrParser.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AaptAttrParser.kt
@@ -20,7 +20,7 @@ package app.cash.paparazzi.internal.parsers
  *
  * Interface for parsers that support declaration of inlined {@code aapt:attr} attributes
  */
-interface AaptAttrParser {
+internal interface AaptAttrParser {
   /**
    * Returns a [Map] that contains all the `aapt:attr` elements declared in this or any
    * children parsers. This list can be used to resolve `@aapt/_aapt` references into this parser.

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AaptAttrSnapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AaptAttrSnapshot.kt
@@ -25,7 +25,7 @@ import com.android.SdkConstants.AAPT_PREFIX
  * of the reference. This snapshot will generate a dynamic reference that will be used by the
  * resource resolution to be able to retrieve the inlined value.
  */
-class AaptAttrSnapshot(
+internal class AaptAttrSnapshot(
   override val namespace: String,
   override val prefix: String,
   override val name: String,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AttributeSnapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/AttributeSnapshot.kt
@@ -21,7 +21,7 @@ package app.cash.paparazzi.internal.parsers
  * A snapshot of an attribute value pulled from an XML resource.
  * Used in conjunction with [TagSnapshot].
  */
-open class AttributeSnapshot(
+internal open class AttributeSnapshot(
   open val namespace: String,
   open val prefix: String?,
   open val name: String,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/InMemoryParser.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/InMemoryParser.kt
@@ -23,7 +23,7 @@ import org.xmlpull.v1.XmlPullParserException
  *
  * A parser implementation that walks an in-memory XML DOM tree.
  */
-abstract class InMemoryParser : KXmlParser() {
+internal abstract class InMemoryParser : KXmlParser() {
   abstract fun rootTag(): TagSnapshot
 
   private val nodeStack = mutableListOf<TagSnapshot>()

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/ResourceParser.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/ResourceParser.kt
@@ -23,7 +23,7 @@ import java.io.InputStream
 /**
  * An XML resource parser that creates a tree of [TagSnapshot]s
  */
-class ResourceParser(inputStream: InputStream) : KXmlParser() {
+internal class ResourceParser(inputStream: InputStream) : KXmlParser() {
   init {
     setFeature(FEATURE_PROCESS_NAMESPACES, true)
     setInput(inputStream, null)

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/TagSnapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/parsers/TagSnapshot.kt
@@ -26,7 +26,7 @@ package app.cash.paparazzi.internal.parsers
  * of properties as they were at the time of rendering, not as they are at the current
  * instant.
  */
-data class TagSnapshot(
+internal data class TagSnapshot(
   val name: String,
   val namespace: String,
   val prefix: String?,
@@ -42,7 +42,7 @@ data class TagSnapshot(
     val output = """
       |$name:
       |${pad(indent + 1)}attributes: ${print(attributes)}
-      |${pad(indent + 1)}children: ${print(children)} 
+      |${pad(indent + 1)}children: ${print(children)}
     """.trimMargin()
     indent--
     return output

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AarSourceResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AarSourceResourceRepository.kt
@@ -32,7 +32,7 @@ import java.util.stream.Collectors
  * obtained from R.txt instead, when it is available. This means that
  * [ResourceItem.getOriginalSource] method may return null for such ID resources.
  */
-open class AarSourceResourceRepository(
+internal open class AarSourceResourceRepository(
   loader: RepositoryLoader<out AarSourceResourceRepository>,
   libraryName: String?
 ) : AbstractAarResourceRepository(loader.namespace, libraryName) {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AbstractAarResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AbstractAarResourceRepository.kt
@@ -33,7 +33,7 @@ import java.util.EnumMap
 /**
  * Ported from: [AbstractAarResourceRepository.java](https://cs.android.com/android-studio/platform/tools/base/+/47d204001bf0cb6273d8b135c7eece3a982cf0e0:resource-repository/main/java/com/android/resources/aar/AbstractAarResourceRepository.java)
  */
-abstract class AbstractAarResourceRepository internal constructor(
+internal abstract class AbstractAarResourceRepository internal constructor(
   private val namespace: ResourceNamespace,
   override val libraryName: String?
 ) : AbstractResourceRepository(), LoadableResourceRepository {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/CommentTrackingXmlPullParser.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/CommentTrackingXmlPullParser.kt
@@ -36,7 +36,7 @@ import java.io.Reader
  * &lt;eat-comment/&gt;
 </pre> *
  */
-open class CommentTrackingXmlPullParser : KXmlParser() {
+internal open class CommentTrackingXmlPullParser : KXmlParser() {
   /**
    * Returns the last encountered comment that is not an ASCII art.
    */

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/FrameworkResourceRepository.kt
@@ -35,7 +35,7 @@ import java.util.zip.ZipFile
  *
  * @see FrameworkResJarCreator
  */
-class FrameworkResourceRepository private constructor(
+internal class FrameworkResourceRepository private constructor(
   loader: RepositoryLoader<FrameworkResourceRepository>,
   private val useCompiled9Patches: Boolean
 ) : AarSourceResourceRepository(loader, null) {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LoadableResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LoadableResourceRepository.kt
@@ -12,7 +12,7 @@ import java.nio.file.Path
 /**
  * Repository of resources loaded from a file or a directory on disk.
  */
-interface LoadableResourceRepository : SingleNamespaceResourceRepository {
+internal interface LoadableResourceRepository : SingleNamespaceResourceRepository {
   /**
    * Returns the name of the library, or null if this is not an AAR resource repository.
    */

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LocalResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/LocalResourceRepository.kt
@@ -11,7 +11,7 @@ import com.google.common.collect.ListMultimap
  * Repository for Android application resources, e.g. those that show up in {@code R},
  * not {@code android.R} (which are referred to as framework resources.).
  */
-abstract class LocalResourceRepository protected constructor(
+internal abstract class LocalResourceRepository protected constructor(
   val displayName: String
 ) : AbstractResourceRepository() {
   protected abstract fun getMap(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/NamespaceResolver.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/NamespaceResolver.kt
@@ -26,7 +26,7 @@ import org.xmlpull.v1.XmlPullParser
  * Simple implementation of the [ResourceNamespace.Resolver] interface intended to be used
  * together with [XmlPullParser].
  */
-class NamespaceResolver : ResourceNamespace.Resolver {
+internal class NamespaceResolver : ResourceNamespace.Resolver {
   /** Interleaved prefixes and the corresponding URIs in order of descending priority.  */
   private val prefixesAndUris: Array<String>
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/Pseudolocalizer.kt
@@ -109,19 +109,19 @@ private fun Char.isPossiblePlaceHolderEnd() = when (this) {
   else -> false
 }
 
-abstract class PseudoMethodImpl {
+internal abstract class PseudoMethodImpl {
   open fun start() = ""
   open fun end() = ""
   abstract fun text(originalText: String): String
   abstract fun placeholder(originalText: String): String
 }
 
-object PseudoMethodNone : PseudoMethodImpl() {
+internal object PseudoMethodNone : PseudoMethodImpl() {
   override fun text(originalText: String) = originalText
   override fun placeholder(originalText: String) = originalText
 }
 
-object PseudoMethodBidi : PseudoMethodImpl() {
+internal object PseudoMethodBidi : PseudoMethodImpl() {
   private const val ESCAPE_CHAR = '\\'
 
   override fun text(originalText: String): String {
@@ -165,7 +165,7 @@ object PseudoMethodBidi : PseudoMethodImpl() {
     RLM + RLO + originalText + PDF + RLM
 }
 
-class PseudoMethodAccent : PseudoMethodImpl() {
+internal class PseudoMethodAccent : PseudoMethodImpl() {
   var depth = 0
   var wordCount = 0
   var length = 0
@@ -353,7 +353,7 @@ class PseudoMethodAccent : PseudoMethodImpl() {
     "twelve thirteen fourteen fiveteen sixteen seventeen nineteen twenty"
 }
 
-class Pseudolocalizer(method: Method) {
+internal class Pseudolocalizer(method: Method) {
   private var implementation: PseudoMethodImpl
   var lastDepth = 0
     private set

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryConfiguration.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryConfiguration.kt
@@ -24,7 +24,7 @@ import com.android.utils.HashCodes
  * and [FolderConfiguration]. This indirection saves memory because the number of [RepositoryConfiguration]
  * instances is a tiny fraction of the number of [BasicResourceItem] instances.
  */
-class RepositoryConfiguration(
+internal class RepositoryConfiguration(
   repository: LoadableResourceRepository,
   val folderConfiguration: FolderConfiguration
 ) {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/RepositoryLoader.kt
@@ -115,7 +115,7 @@ import java.util.zip.ZipFile
 /**
  * Ported from: [RepositoryLoader.java](https://cs.android.com/android-studio/platform/tools/base/+/876aaf229c1e3b8144736d3338c628ba43ccac45:resource-repository/main/java/com/android/resources/base/RepositoryLoader.java)
  */
-abstract class RepositoryLoader<T : LoadableResourceRepository>(
+internal abstract class RepositoryLoader<T : LoadableResourceRepository>(
   val resourceDirectoryOrFile: Path,
   val resourceFilesAndFolders: Collection<PathString>?,
   val namespace: ResourceNamespace

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFile.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFile.kt
@@ -25,7 +25,7 @@ import java.io.File
  * Represents a resource file from which [com.android.ide.common.resources.ResourceItem]s are
  * created by [ResourceFolderRepository]. An [Iterable] of [BasicResourceItem]s.
  */
-class ResourceFile(
+internal class ResourceFile(
   val file: File?,
   override val configuration: RepositoryConfiguration
 ) : ResourceSourceFile, Iterable<BasicResourceItem> {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFolderRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceFolderRepository.kt
@@ -32,7 +32,7 @@ import kotlin.io.path.exists
  * Each [ResourceFolderRepository] contains the resources provided by a single res folder.
  */
 @SuppressLint("NewApi")
-class ResourceFolderRepository(
+internal class ResourceFolderRepository(
   val resourceDir: File,
   private val namespace: ResourceNamespace
 ) : LocalResourceRepository(resourceDir.name), LoadableResourceRepository {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceNamespacing.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceNamespacing.kt
@@ -1,6 +1,6 @@
 package app.cash.paparazzi.internal.resources
 
-enum class ResourceNamespacing {
+internal enum class ResourceNamespacing {
   /**
    * Resources are not namespaced.
    */

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSerializationUtil.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSerializationUtil.kt
@@ -26,7 +26,7 @@ import java.util.function.Function
 /**
  * Ported from: [ResourceSerializationUtil.java](https://cs.android.com/android-studio/platform/tools/base/+/18047faf69512736b8ddb1f6a6785f58d47c893f:resource-repository/main/java/com/android/resources/base/ResourceSerializationUtil.java)
  */
-object ResourceSerializationUtil {
+internal object ResourceSerializationUtil {
   /**
    * Loads resources from the given input stream and passes them to the given consumer.
    */

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFile.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFile.kt
@@ -20,7 +20,7 @@ package app.cash.paparazzi.internal.resources
  *
  * Represents an XML file from which an Android resource was created.
  */
-interface ResourceSourceFile {
+internal interface ResourceSourceFile {
   /**
    * The path of the file relative to the resource directory, or null if the source file
    * of the resource is not available.

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFileImpl.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceSourceFileImpl.kt
@@ -26,7 +26,7 @@ import java.io.IOException
  * [relativePath] path of the file relative to the resource directory, or null if the source file of the resource is not available
  * [configuration] configuration the resource file is associated with
  */
-data class ResourceSourceFileImpl(
+internal data class ResourceSourceFileImpl(
   override val relativePath: String?,
   override val configuration: RepositoryConfiguration
 ) : ResourceSourceFile {

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceUrlParser.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/ResourceUrlParser.kt
@@ -24,7 +24,7 @@ import com.android.SdkConstants.PREFIX_THEME_REF
  * Parser of resource URLs. Unlike [com.android.resources.ResourceUrl], this class is resilient to
  * URL syntax errors that doesn't create any GC overhead.
  */
-class ResourceUrlParser {
+internal class ResourceUrlParser {
   private var resourceUrl = ""
   private var colonPos = 0
   private var slashPos = 0

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicArrayResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicArrayResourceItem.kt
@@ -30,7 +30,7 @@ import java.util.Collections
  *
  * Resource item representing an array resource.
  */
-class BasicArrayResourceItem(
+internal class BasicArrayResourceItem(
   name: String,
   sourceFile: ResourceSourceFile,
   visibility: ResourceVisibility,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicAttrReference.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicAttrReference.kt
@@ -29,7 +29,7 @@ import com.android.utils.HashCodes
  * Resource value representing a reference to an attr resource, but potentially with its own description
  * and group name. Unlike [BasicAttrResourceItem], does not contain formats and enum or flag information.
  */
-class BasicAttrReference(
+internal class BasicAttrReference(
   private val namespace: ResourceNamespace,
   name: String,
   sourceFile: ResourceSourceFile,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicAttrResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicAttrResourceItem.kt
@@ -32,7 +32,7 @@ import java.util.EnumSet
  *
  * Resource item representing an attr resource.
  */
-open class BasicAttrResourceItem(
+internal open class BasicAttrResourceItem(
   name: String,
   sourceFile: ResourceSourceFile,
   visibility: ResourceVisibility,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicDensityBasedFileResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicDensityBasedFileResourceItem.kt
@@ -28,7 +28,7 @@ import com.google.common.base.MoreObjects
  *
  * Resource item representing a density-specific file resource inside an AAR, e.g. a drawable or a layout.
  */
-class BasicDensityBasedFileResourceItem(
+internal class BasicDensityBasedFileResourceItem(
   type: ResourceType,
   name: String,
   configuration: RepositoryConfiguration,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicFileResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicFileResourceItem.kt
@@ -32,7 +32,7 @@ import java.io.IOException
  *
  * Resource item representing a file resource, e.g. a drawable or a layout.
  */
-open class BasicFileResourceItem(
+internal open class BasicFileResourceItem(
   type: ResourceType,
   name: String,
   override val repositoryConfiguration: RepositoryConfiguration,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicForeignAttrResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicForeignAttrResourceItem.kt
@@ -26,7 +26,7 @@ import com.android.resources.ResourceVisibility
  * Resource item representing an attr resource that is defined in a namespace different from the namespace
  * of the owning AAR.
  */
-class BasicForeignAttrResourceItem(
+internal class BasicForeignAttrResourceItem(
   private val namespace: ResourceNamespace,
   name: String,
   sourceFile: ResourceSourceFile,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicPluralsResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicPluralsResourceItem.kt
@@ -30,7 +30,7 @@ import java.io.IOException
  *
  * Resource item representing a plurals resource.
  */
-class BasicPluralsResourceItem private constructor(
+internal class BasicPluralsResourceItem private constructor(
   name: String,
   sourceFile: ResourceSourceFile,
   visibility: ResourceVisibility,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicResourceItem.kt
@@ -39,7 +39,7 @@ import java.io.IOException
  *
  * A merger of [BasicResourceItemBase] and [BasicResourceItem] from AOSP, to simplify.
  */
-abstract class BasicResourceItem(
+internal abstract class BasicResourceItem(
   private val type: ResourceType,
   private val name: String,
   visibility: ResourceVisibility

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicStyleResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicStyleResourceItem.kt
@@ -35,7 +35,7 @@ import java.util.logging.Logger
  *
  * Resource item representing a style resource.
  */
-class BasicStyleResourceItem(
+internal class BasicStyleResourceItem(
   name: String,
   sourceFile: ResourceSourceFile,
   visibility: ResourceVisibility,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicStyleableResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicStyleableResourceItem.kt
@@ -32,7 +32,7 @@ import java.io.IOException
  *
  * Resource item representing a styleable resource.
  */
-class BasicStyleableResourceItem(
+internal class BasicStyleableResourceItem(
   name: String,
   sourceFile: ResourceSourceFile,
   visibility: ResourceVisibility,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicTextValueResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicTextValueResourceItem.kt
@@ -26,7 +26,7 @@ import com.android.utils.HashCodes
  *
  * Resource item representing a value resource, e.g. a string or a color.
  */
-class BasicTextValueResourceItem(
+internal class BasicTextValueResourceItem(
   type: ResourceType,
   name: String,
   sourceFile: ResourceSourceFile,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItem.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItem.kt
@@ -28,7 +28,7 @@ import java.io.IOException
  *
  * Resource item representing a value resource, e.g. a string or a color.
  */
-open class BasicValueResourceItem(
+internal open class BasicValueResourceItem(
   type: ResourceType,
   name: String,
   sourceFile: ResourceSourceFile,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItemBase.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/base/BasicValueResourceItemBase.kt
@@ -35,7 +35,7 @@ import java.io.IOException
  *
  * Base class for value resource items.
  */
-abstract class BasicValueResourceItemBase(
+internal abstract class BasicValueResourceItemBase(
   type: ResourceType,
   name: String,
   val sourceFile: ResourceSourceFile,

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/parsers/InMemoryParserTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/parsers/InMemoryParserTest.kt
@@ -82,7 +82,7 @@ class InMemoryParserTest {
     return ResourceParser(resourceInputStream).createTagSnapshot()
   }
 
-  class RealInMemoryParser(private val root: TagSnapshot) : InMemoryParser() {
+  private class RealInMemoryParser(private val root: TagSnapshot) : InMemoryParser() {
     override fun rootTag(): TagSnapshot = root
   }
 


### PR DESCRIPTION
As a precursor to the SDKifying work, I've sadly realized that we haven't done a great job of restricting the API surface of the project.  This PR attempts to correct that by adding the kotlin binary validation plugin + slapping internal on a lot of things.

One thing to call out is this PR will make `HtmlReportWriter` and `SnapshotVerifier` *internal* as well.  I felt keeping `SnapshotHandler` public was enough, but due to some current design shortcomings in the snapshot pipeline (to be addressed at some point!), that level of strictness might break current consumers of the project (which I'd like to avoid!) who have implemented workarounds.

Therefore, I'd be open to reverting those 2 classes (and others!) for the time being, until we come up with a better solution/design.  Please speak up!

cc: @TWiStErRob