### PR TITLE
Close snapshot handler on paparazzi close

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -88,6 +88,7 @@ public class Paparazzi @JvmOverloads constructor(
   public fun close() {
     testName = null
     sdk.teardown()
+    snapshotHandler.close()
   }
 
   public fun <V : View> inflate(@LayoutRes layoutId: Int): V = sdk.inflate(layoutId)


### PR DESCRIPTION
Need to close the snapshot handler in order for `HtmlReportWriter` to save the test run data