### PR TITLE
Prepare version 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.3.4] - 20204-03-07
+
+### New
+* Split Paparazzi logic into an sdk and test rule
+* Added cleanRecordPaparazzi{Variant} task to tidy orphaned snapshots
+
+### Fixed
+* Close snapshot handler so HtmlReportWriter saves all test data
+
+
 ## [1.3.3] - 2024-03-01
 
 ### New
@@ -357,7 +367,8 @@ As of this release, consumers must build on Java 11 environments.
 
 
 
-[Unreleased]: https://github.com/cashapp/paparazzi/compare/1.3.3...HEAD
+[Unreleased]: https://github.com/cashapp/paparazzi/compare/1.3.4...HEAD
+[1.3.4]: https://github.com/cashapp/paparazzi/releases/tag/1.3.4
 [1.3.3]: https://github.com/cashapp/paparazzi/releases/tag/1.3.3
 [1.3.2]: https://github.com/cashapp/paparazzi/releases/tag/1.3.2
 [1.3.1]: https://github.com/cashapp/paparazzi/releases/tag/1.3.1

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:1.3.3'
+    classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:1.3.4'
   }
 }
 
@@ -158,7 +158,7 @@ apply plugin: 'app.cash.paparazzi'
 Using the plugins DSL:
 ```groovy
 plugins {
-  id 'app.cash.paparazzi' version '1.3.3'
+  id 'app.cash.paparazzi' version '1.3.4'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.paparazzi
-VERSION_NAME=1.3.4-SNAPSHOT
+VERSION_NAME=1.3.4
 
 POM_URL=https://github.com/cashapp/paparazzi/
 POM_SCM_URL=https://github.com/cashapp/paparazzi/


### PR DESCRIPTION
Cutting release to fix missing `SnapshotHandler.close()` call