### PR TITLE
Fixes Issue About Extra Generated Resources Rendering

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -27,6 +27,7 @@ import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.dsl.DynamicFeatureExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
 import com.android.build.gradle.tasks.GenerateResValues
+import com.android.build.gradle.tasks.MapSourceSetPathsTask
 import org.gradle.api.DefaultTask
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
@@ -49,6 +50,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+import java.io.File
 import java.util.Locale
 
 @Suppress("unused")
@@ -158,7 +160,8 @@ public class PaparazziPlugin : Plugin<Project> {
         task.projectResourceDirs.set(
           project.provider {
             val generateResValuesDirs = project.tasks.withType(GenerateResValues::class.java).filter { it.variantName == variant.name }.map { it.resOutputDir }
-            localResourceDirs.relativize(projectDirectory) + generateResValuesDirs.map(projectDirectory::relativize)
+            val extraGeneratedResDirs = project.tasks.withType(MapSourceSetPathsTask::class.java).filter { it.variantName == variant.name }.map { it.extraGeneratedResDir.get().map { File(it) } }.flatten()
+            extraGeneratedResDirs.map(projectDirectory::relativize) + localResourceDirs.relativize(projectDirectory) + generateResValuesDirs.map(projectDirectory::relativize)
           }
         )
         task.moduleResourceDirs.set(project.provider { moduleResourceDirs.relativize(projectDirectory) })

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -798,7 +798,7 @@ class PaparazziPluginTest {
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
     )
-    assertThat(config.projectResourceDirs).containsExactly("src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
     assertThat(config.moduleResourceDirs).containsExactly(
       "../module1/build/intermediates/packaged_res/debug",
       "../module2/build/intermediates/packaged_res/debug"
@@ -829,7 +829,7 @@ class PaparazziPluginTest {
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
     )
-    assertThat(config.projectResourceDirs).containsExactly("src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
     assertThat(config.moduleResourceDirs).containsExactly(
       "../module1/build/intermediates/packaged_res/debug",
       "../module2/build/intermediates/packaged_res/debug"

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/consumer/build.gradle
@@ -13,6 +13,9 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  libraryVariants.configureEach {
+    it.registerGeneratedResFolders(project.files("${project.buildDir.path}/generated/res/extra"))
+  }
 }
 
 dependencies {

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
@@ -14,6 +14,9 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  libraryVariants.configureEach {
+    it.registerGeneratedResFolders(project.files("${project.buildDir.path}/generated/res/extra"))
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Additional fix to https://github.com/cashapp/paparazzi/issues/1067 to handle extra generated res folders, which are set via `BaseVariant.registerGeneratedResFolders`