### PR TITLE
Improve error message when snapshot file read fails

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -46,7 +46,14 @@ public class SnapshotVerifier @JvmOverloads constructor(
           throw AssertionError("File $expected does not exist")
         }
 
-        val goldenImage = ImageIO.read(expected)
+        val goldenImage = ImageIO.read(expected) ?: throw NullPointerException("""
+          Failed to read the snapshot file from the file system.
+
+          If your project uses git LFS, it's possible that it's misconfigured on your machine and
+          Paparazzi has just loaded a pointer file instead of the real snapshot file. Follow git
+          LFS troubleshooting instructions and try again.
+
+          """.trimIndent())
         ImageUtils.assertImageSimilar(
           relativePath = expected.path,
           image = image,

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -46,14 +46,16 @@ public class SnapshotVerifier @JvmOverloads constructor(
           throw AssertionError("File $expected does not exist")
         }
 
-        val goldenImage = ImageIO.read(expected) ?: throw NullPointerException("""
+        val goldenImage = ImageIO.read(expected) ?: throw NullPointerException(
+          """
           Failed to read the snapshot file from the file system.
 
           If your project uses git LFS, it's possible that it's misconfigured on your machine and
           Paparazzi has just loaded a pointer file instead of the real snapshot file. Follow git
           LFS troubleshooting instructions and try again.
 
-          """.trimIndent())
+          """.trimIndent()
+        )
         ImageUtils.assertImageSimilar(
           relativePath = expected.path,
           image = image,


### PR DESCRIPTION
Fixes #1343.

Stack trace example:

```
java.lang.NullPointerException: Failed to read the snapshot file.

    If your project uses git LFS, it's possible that it's misconfigured on your machine and
    Paparazzi is trying to load a pointer file instead of the real snapshot file. Follow git
    LFS troubleshooting instructions and try again.
        at app.cash.paparazzi.SnapshotVerifier$newFrameHandler$1.handle(SnapshotVerifier.kt:49)
        at app.cash.paparazzi.PaparazziSdk$takeSnapshots$1$3.invoke(PaparazziSdk.kt:324)
        at app.cash.paparazzi.PaparazziSdk$takeSnapshots$1$3.invoke(PaparazziSdk.kt:311)
        at app.cash.paparazzi.PaparazziSdk.withTime(PaparazziSdk.kt:359)
        at app.cash.paparazzi.PaparazziSdk.takeSnapshots(PaparazziSdk.kt:311)
        at app.cash.paparazzi.PaparazziSdk.snapshot(PaparazziSdk.kt:199)
        at app.cash.paparazzi.Paparazzi.snapshot(Paparazzi.kt:104)
        at app.cash.paparazzi.Paparazzi.snapshot$default(Paparazzi.kt:102)
        at com.squareup.cash.blockers.views.PasscodeViewTest.default(PasscodeViewTest.kt:61)
```