### PR TITLE
Bump to AGP 8.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.2"
+agp = "8.3.1"
 androidTools = "31.2.2" # == 23.0.0 + agp version
 bytebuddy = "1.14.12"
 composeCompiler = "1.5.10"

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -802,8 +802,8 @@ class PaparazziPluginTest {
     )
     assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
     assertThat(config.moduleResourceDirs).containsExactly(
-      "../module1/build/intermediates/packaged_res/debug",
-      "../module2/build/intermediates/packaged_res/debug"
+      "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
+      "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
     assertThat(config.aarExplodedDirs)
       .comparingElementsUsing(MATCHES_PATTERN)
@@ -833,8 +833,8 @@ class PaparazziPluginTest {
     )
     assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
     assertThat(config.moduleResourceDirs).containsExactly(
-      "../module1/build/intermediates/packaged_res/debug",
-      "../module2/build/intermediates/packaged_res/debug"
+      "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
+      "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
     assertThat(config.aarExplodedDirs)
       .comparingElementsUsing(MATCHES_PATTERN)
@@ -931,7 +931,7 @@ class PaparazziPluginTest {
     val resourcesFile = File(consumerModuleRoot, "build/intermediates/paparazzi/debug/resources.json")
 
     var config = resourcesFile.loadConfig()
-    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug")
+    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
 
     buildDir.deleteRecursively()
 
@@ -953,7 +953,7 @@ class PaparazziPluginTest {
     }
 
     config = resourcesFile.loadConfig()
-    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug")
+    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
   }
 
   @Test
@@ -1107,7 +1107,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
-      "../producer/build/intermediates/library_assets/debug/out"
+      "../producer/build/intermediates/library_assets/debug/packageDebugAssets/out"
     )
 
     buildDir.deleteRecursively()
@@ -1134,7 +1134,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
-      "../producer/build/intermediates/library_assets/debug/out"
+      "../producer/build/intermediates/library_assets/debug/packageDebugAssets/out"
     )
   }
 


### PR DESCRIPTION
Intentionally bumping only AGP, as this moves some of the changeset out of https://github.com/cashapp/paparazzi/pull/1314.