### PR TITLE
Migrate MacOS runner from macOS 12 Intel to macOS 14 M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macOS-latest,
+          # Migrate back to macOS-latest once 'latest' workflow label is updated (April – June 2024)
+          # https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
+          macOS-14,
           windows-latest,
           ubuntu-latest
         ]

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -103,8 +103,8 @@ def generateTestConfig = tasks.register("generateTestConfig") {
     configFile.write("""{
       "mainPackage": "app.cash.paparazzi",
       "mergeResourcesOutputDir": ".",
-      "targetSdkVersion": "31",
-      "platformDir": "platforms/android-31/",
+      "targetSdkVersion": "33",
+      "platformDir": "platforms/android-33/",
       "mergeAssetsOutputDir": ".",
       "resourcePackageNames": ["app.cash.paparazzi"],
       "projectResourceDirs": [],


### PR DESCRIPTION
The divergence between MacOS Intel and M1 renderings is unreasonably high (@gabrielittner points that out here: https://github.com/cashapp/paparazzi/pull/1228/files#r1473442070).

Eventually, this will be GHA's default latest Mac runner offering (see comment in build.yml), so feels OK to bump now.

Note that this force bumps the tests in the `:paparazzi` module to platform 33, because platform 31 is not part into the macOS-14 runner.

See:
* https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#android
* https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#android