### PR TITLE
Fixes configuration cache error when used with Crashlytics

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -158,10 +158,10 @@ public class PaparazziPlugin : Plugin<Project> {
         task.projectResourceDirs.set(
           project.provider {
             val resourcesComputer = variant.mergeResourcesProvider?.get()?.resourcesComputer
-            val generateResValuesDirs = resourcesComputer?.generatedResOutputDir
-            val extraGeneratedResDirs = resourcesComputer?.extraGeneratedResFolders
+            val generateResValuesDirs = resourcesComputer?.generatedResOutputDir ?: project.files()
+            val extraGeneratedResDirs = resourcesComputer?.extraGeneratedResFolders ?: project.files()
 
-            (extraGeneratedResDirs?.map(projectDirectory::relativize) ?: emptyList()) + localResourceDirs.relativize(projectDirectory) + (generateResValuesDirs?.map(projectDirectory::relativize) ?: emptyList())
+            extraGeneratedResDirs.map(projectDirectory::relativize) + localResourceDirs.relativize(projectDirectory) + generateResValuesDirs.map(projectDirectory::relativize)
           }
         )
         task.moduleResourceDirs.set(project.provider { moduleResourceDirs.relativize(projectDirectory) })

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -26,8 +26,6 @@ import com.android.build.gradle.internal.api.TestedVariant
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.dsl.DynamicFeatureExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
-import com.android.build.gradle.tasks.GenerateResValues
-import com.android.build.gradle.tasks.MapSourceSetPathsTask
 import org.gradle.api.DefaultTask
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
@@ -50,7 +48,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
-import java.io.File
 import java.util.Locale
 
 @Suppress("unused")
@@ -160,9 +157,11 @@ public class PaparazziPlugin : Plugin<Project> {
         task.compileSdkVersion.set(android.compileSdkVersion())
         task.projectResourceDirs.set(
           project.provider {
-            val generateResValuesDirs = project.tasks.withType(GenerateResValues::class.java).filter { it.variantName == variant.name }.map { it.resOutputDir }
-            val extraGeneratedResDirs = project.tasks.withType(MapSourceSetPathsTask::class.java).filter { it.variantName == variant.name }.map { it.extraGeneratedResDir.get().map { File(it) } }.flatten()
-            extraGeneratedResDirs.map(projectDirectory::relativize) + localResourceDirs.relativize(projectDirectory) + generateResValuesDirs.map(projectDirectory::relativize)
+            val resourcesComputer = variant.mergeResourcesProvider?.get()?.resourcesComputer
+            val generateResValuesDirs = resourcesComputer?.generatedResOutputDir
+            val extraGeneratedResDirs = resourcesComputer?.extraGeneratedResFolders
+
+            (extraGeneratedResDirs?.map(projectDirectory::relativize) ?: emptyList()) + localResourceDirs.relativize(projectDirectory) + (generateResValuesDirs?.map(projectDirectory::relativize) ?: emptyList())
           }
         )
         task.moduleResourceDirs.set(project.provider { moduleResourceDirs.relativize(projectDirectory) })


### PR DESCRIPTION
Closes https://github.com/cashapp/paparazzi/issues/1369.

Use `DependencyResourcesComputer` in `MergeResources` to retrieve `generateResValuesDirs` and `extraGeneratedResDirs`



