### PR TITLE
Fix predraw callbacks on every frame

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Renderer.kt
@@ -74,6 +74,7 @@ internal class Renderer(
       )
     )
       .plusFlag(RenderParamsFlags.FLAG_DO_NOT_RENDER_ON_CREATE, true)
+      .plusFlag(RenderParamsFlags.FLAG_KEY_DISABLE_BITMAP_CACHING, true)
       .withTheme("AppTheme", true)
 
     val platformDataRoot = System.getProperty("paparazzi.platform.data.root")

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -218,6 +218,29 @@ class PaparazziTest {
     assertThat(thrown).isTrue()
   }
 
+  @Test
+  fun preDrawOnEveryFrame() {
+    val log = mutableListOf<String>()
+
+    val view = object : View(paparazzi.context) {
+      override fun onAttachedToWindow() {
+        viewTreeObserver.addOnPreDrawListener {
+          log += "predraw"
+          true
+        }
+      }
+
+      override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+        log += "draw"
+      }
+    }
+
+    paparazzi.gif(view, fps = 4)
+
+    assertThat(log).isEqualTo(listOf("draw", "predraw", "predraw", "predraw"))
+  }
+
   private val time: Long
     get() {
       return TimeUnit.NANOSECONDS.toMillis(System_Delegate.nanoTime())


### PR DESCRIPTION
Noticed onPreDraw stopped getting callbacks for subsequent frames in an animation. Previously RenderSessionImpl manually called `AttachInfo_Accessor.dispatchOnPreDraw(viewRoot);` however that logic has been removed in favor of [ThrededRenderer](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/ThreadedRenderer.java;l=742?q=ThreadedRenderer&ss=android%2Fplatform%2Fsuperproject%2Fmain) handling it.

Poking around AS I noticed their subsequent onPreDraw callbacks get invoked because they go down a different render code path using [FLAG_KEY_DISABLE_BITMAP_CACHING](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/layoutlib/bridge/src/com/android/layoutlib/bridge/impl/RenderSessionImpl.java;l=518?q=RenderSessionImpl)

Looking at [RenderTask](https://cs.android.com/android-studio/platform/tools/adt/idea/+/mirror-goog-studio-main:rendering/src/com/android/tools/rendering/RenderTask.java;l=676?q=FLAG_KEY_DISABLE_BITMAP_CACHING&ss=android-studio) we can see they set it.