### PR TITLE
Fix negative SystemClock.uptimeMillis()

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -251,6 +251,7 @@ public class PaparazziSdk @JvmOverloads constructor(
     }
 
     System_Delegate.setNanosTime(0L)
+    System_Delegate.setBootTimeNanos(0L)
     try {
       withTime(0L) {
         // Initialize the choreographer at time=0.

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -21,6 +21,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.graphics.Canvas
 import android.graphics.Color
+import android.os.SystemClock
 import android.view.Choreographer
 import android.view.Choreographer.CALLBACK_ANIMATION
 import android.view.View
@@ -135,11 +136,11 @@ class PaparazziTest {
     }
     animator.addListener(object : AnimatorListenerAdapter() {
       override fun onAnimationStart(animation: Animator?, isReverse: Boolean) {
-        log += "onAnimationStart uptimeMillis=$time"
+        log += "onAnimationStart uptimeMillis=$uptime"
       }
 
       override fun onAnimationEnd(animator: Animator) {
-        log += "onAnimationEnd uptimeMillis=$time"
+        log += "onAnimationEnd uptimeMillis=$uptime"
       }
     })
 
@@ -244,5 +245,10 @@ class PaparazziTest {
   private val time: Long
     get() {
       return TimeUnit.NANOSECONDS.toMillis(System_Delegate.nanoTime())
+    }
+
+  private val uptime: Long
+    get() {
+      return SystemClock.uptimeMillis()
     }
 }


### PR DESCRIPTION
Uptime is calculated based on bootTime which if not set defaults to the System's bootTime which combined with our overriding nanoTime causes SystemClock.uptimeMillis() to return a negative number.