### PR TITLE
Fix configuration cache bug when generating sources

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -330,6 +330,17 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun configurationCacheWorksWithGeneratedSources() {
+    val fixtureRoot = File("src/test/projects/configuration-cache-generated-sources")
+
+    // check to avoid plugin regressions that might affect Gradle's configuration caching
+    // https://docs.gradle.org/current/userguide/configuration_cache.html
+    gradleRunner
+      .withArguments("testDebug", "--configuration-cache", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
   fun interceptViewEditMode() {
     val fixtureRoot = File("src/test/projects/edit-mode-intercept")
 

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
+}
+
+androidComponents {
+  onVariants(selector().all()) { variant ->
+    def sourceGen = project.tasks.register("do${variant.name.capitalize()}SourceGen", SourceGenTask)
+    variant.sources.res.addGeneratedSourceDirectory(
+      sourceGen,
+      { task -> task.outputDirectory }
+    )
+  }
+}
+
+abstract class SourceGenTask extends DefaultTask {
+  @OutputDirectory
+  abstract DirectoryProperty getOutputDirectory()
+}
+
+apply from: '../guava-fix.gradle'

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/src/test/java/app/cash/paparazzi/plugin/test/VerifyTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/src/test/java/app/cash/paparazzi/plugin/test/VerifyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paparazzi.gradle.utils
+package app.cash.paparazzi.plugin.test
 
-import org.gradle.api.file.Directory
-import org.gradle.api.file.FileCollection
-import org.gradle.api.provider.Provider
-import java.io.File
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
 
-internal fun FileCollection.relativize(directory: Directory): Provider<List<String>> =
-  elements.map { files -> files.map { file -> directory.relativize(file.asFile) } }
+class VerifyTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
 
-internal fun Directory.relativize(child: File): String {
-  return asFile.toPath().relativize(child.toPath()).toFile().invariantSeparatorsPath
+  @Test
+  fun verify() {}
 }


### PR DESCRIPTION
Defers fetching of file collection elements during task configuration. Closes https://github.com/cashapp/paparazzi/issues/1376.