### PR TITLE
Remove JUnit usages from files in main source set

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngVerifier.kt
@@ -19,7 +19,6 @@ import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.ImageUtils.resize
 import okio.FileSystem
 import okio.Path
-import org.junit.Assert.fail
 import java.awt.image.BufferedImage
 import java.io.Closeable
 import kotlin.math.max
@@ -122,7 +121,7 @@ internal class ApngVerifier(
     }
 
     if (error.isNotEmpty()) {
-      fail(error)
+      throw AssertionError(error)
     }
   }
 


### PR DESCRIPTION
The `paparazzi` module has been designed as a JUnit rule, so it's been tempting to use Junit assertions in both test sources as well as main sources.  However, moving core classes out into an SDK non-JUnit module reveals the tight coupling in some classes, so let's fix that.