### PR TITLE
Migrate to modern AGP variants APIs

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -832,7 +832,12 @@ class PaparazziPluginTest {
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
     )
-    assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly(
+      "src/main/res",
+      "src/debug/res",
+      "build/generated/res/resValues/debug",
+      "build/generated/res/extra"
+    )
     assertThat(config.moduleResourceDirs).containsExactly(
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
@@ -863,7 +868,12 @@ class PaparazziPluginTest {
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
     )
-    assertThat(config.projectResourceDirs).containsExactly("build/generated/res/extra", "src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly(
+      "src/main/res",
+      "src/debug/res",
+      "build/generated/res/resValues/debug",
+      "build/generated/res/extra"
+    )
     assertThat(config.moduleResourceDirs).containsExactly(
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
@@ -904,7 +914,11 @@ class PaparazziPluginTest {
     val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.json")
 
     var config = resourcesFile.loadConfig()
-    assertThat(config.projectResourceDirs).containsExactly("src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly(
+      "src/main/res",
+      "src/debug/res",
+      "build/generated/res/resValues/debug"
+    )
 
     buildDir.deleteRecursively()
 
@@ -926,7 +940,11 @@ class PaparazziPluginTest {
     }
 
     config = resourcesFile.loadConfig()
-    assertThat(config.projectResourceDirs).containsExactly("src/main/res", "src/debug/res", "build/generated/res/resValues/debug")
+    assertThat(config.projectResourceDirs).containsExactly(
+      "src/main/res",
+      "src/debug/res",
+      "build/generated/res/resValues/debug"
+    )
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/consumer/build.gradle
@@ -14,7 +14,7 @@ android {
     targetCompatibility = libs.versions.javaTarget.get()
   }
   libraryVariants.configureEach {
-    it.registerGeneratedResFolders(project.files("${project.buildDir.path}/generated/res/extra"))
+    it.registerGeneratedResFolders(project.layout.buildDirectory.files("generated/res/extra"))
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
@@ -15,7 +15,7 @@ android {
     targetCompatibility = libs.versions.javaTarget.get()
   }
   libraryVariants.configureEach {
-    it.registerGeneratedResFolders(project.files("${project.buildDir.path}/generated/res/extra"))
+    it.registerGeneratedResFolders(project.layout.buildDirectory.files("generated/res/extra"))
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/cashapp/paparazzi/pull/1136.

Moves the Android build stuff to the AndroidComponentsExtension#onVariants API.  Also, cleans up the boutique logic around querying resource folder locations and improves lazy task wiring.