### PR TITLE
Reference java.nio.file.NoSuchFileException vs kotlin.io.NoSuchFileException in exception logic for missing public.txt

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AarSourceResourceRepository.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/resources/AarSourceResourceRepository.kt
@@ -21,6 +21,7 @@ import java.io.IOException
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.util.logging.Logger
 import java.util.stream.Collectors


### PR DESCRIPTION
Closes #1258.

See comment here: https://github.com/cashapp/paparazzi/issues/1258#issuecomment-2129588246