### PR TITLE
Make paparazzi aware or unit test dependencies

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/AndroidVariantSources.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/AndroidVariantSources.kt
@@ -14,7 +14,7 @@ import org.gradle.api.provider.Provider
  */
 internal class AndroidVariantSources(
   private val variant: Variant,
-  private val testVariant: Component,
+  private val testVariant: Component
 ) {
   val localResourceDirs: Provider<List<Directory>>? by lazy {
     variant.sources.res?.all?.map { layers -> layers.flatten() }?.map { it.asReversed() }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -23,13 +23,11 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.DynamicFeatureAndroidComponentsExtension
 import com.android.build.api.variant.HasUnitTest
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.api.variant.UnitTest
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
@@ -117,10 +115,7 @@ public class PaparazziPlugin : Plugin<Project> {
 
       // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
 
-      val runtimeConfiguration: Configuration = variant
-        .nestedComponents
-        .filterIsInstance<UnitTest>()
-        .firstOrNull()?.runtimeConfiguration ?: variant.runtimeConfiguration
+      val runtimeConfiguration = testVariant.runtimeConfiguration
 
       val moduleResourceDirs = runtimeConfiguration
         .artifactsFor(ArtifactType.ANDROID_RES.type) { it is ProjectComponentIdentifier }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -23,11 +23,13 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.DynamicFeatureAndroidComponentsExtension
 import com.android.build.api.variant.HasUnitTest
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.UnitTest
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
@@ -115,11 +117,16 @@ public class PaparazziPlugin : Plugin<Project> {
 
       // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
 
-      val moduleResourceDirs = variant.runtimeConfiguration
+      val runtimeConfiguration: Configuration = variant
+        .nestedComponents
+        .filterIsInstance<UnitTest>()
+        .firstOrNull()?.runtimeConfiguration ?: variant.runtimeConfiguration
+
+      val moduleResourceDirs = runtimeConfiguration
         .artifactsFor(ArtifactType.ANDROID_RES.type) { it is ProjectComponentIdentifier }
         .artifactFiles
 
-      val aarExplodedDirs = variant.runtimeConfiguration
+      val aarExplodedDirs = runtimeConfiguration
         .artifactsFor(ArtifactType.ANDROID_RES.type) { it !is ProjectComponentIdentifier }
         .artifactFiles
 
@@ -127,15 +134,15 @@ public class PaparazziPlugin : Plugin<Project> {
 
       // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
 
-      val moduleAssetDirs = variant.runtimeConfiguration
+      val moduleAssetDirs = runtimeConfiguration
         .artifactsFor(ArtifactType.ASSETS.type) { it is ProjectComponentIdentifier }
         .artifactFiles
 
-      val aarAssetDirs = variant.runtimeConfiguration
+      val aarAssetDirs = runtimeConfiguration
         .artifactsFor(ArtifactType.ASSETS.type) { it !is ProjectComponentIdentifier }
         .artifactFiles
 
-      val packageAwareArtifactFiles = variant.runtimeConfiguration
+      val packageAwareArtifactFiles = runtimeConfiguration
         .artifactsFor(ArtifactType.SYMBOL_LIST_WITH_PACKAGE_NAME.type)
         .artifactFiles
 

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -70,12 +70,12 @@ public abstract class PrepareResourcesTask : DefaultTask() {
 
     val mainPackage = packageName.get()
     val resourcePackageNames = if (nonTransitiveRClassEnabled.get()) {
-      buildSet {
+      buildList {
         add(mainPackage)
         artifactFiles.files.forEach { file ->
           add(file.useLines { lines -> lines.first() })
         }
-      }.toList()
+      }.distinct()
     } else {
       listOf(mainPackage)
     }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -70,12 +70,12 @@ public abstract class PrepareResourcesTask : DefaultTask() {
 
     val mainPackage = packageName.get()
     val resourcePackageNames = if (nonTransitiveRClassEnabled.get()) {
-      buildList {
+      buildSet {
         add(mainPackage)
         artifactFiles.files.forEach { file ->
           add(file.useLines { lines -> lines.first() })
         }
-      }
+      }.toList()
     } else {
       listOf(mainPackage)
     }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -810,6 +810,7 @@ class PaparazziPluginTest {
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
@@ -846,6 +847,7 @@ class PaparazziPluginTest {
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
@@ -952,7 +954,10 @@ class PaparazziPluginTest {
     val resourcesFile = File(consumerModuleRoot, "build/intermediates/paparazzi/debug/resources.json")
 
     var config = resourcesFile.loadConfig()
-    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
+    assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
+      "../producer/build/intermediates/packaged_res/debug/packageDebugResources"
+    )
 
     buildDir.deleteRecursively()
 
@@ -974,7 +979,10 @@ class PaparazziPluginTest {
     }
 
     config = resourcesFile.loadConfig()
-    assertThat(config.moduleResourceDirs).containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
+    assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
+      "../producer/build/intermediates/packaged_res/debug/packageDebugResources"
+    )
   }
 
   @Test
@@ -1064,7 +1072,11 @@ class PaparazziPluginTest {
     val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.json")
 
     var config = resourcesFile.loadConfig()
-    assertThat(config.projectAssetDirs).containsExactly("src/main/assets", "src/debug/assets")
+    assertThat(config.projectAssetDirs).containsExactly(
+      "src/main/assets",
+      "src/debug/assets",
+      "build/intermediates/library_assets/debug/packageDebugAssets/out"
+    )
 
     buildDir.deleteRecursively()
 
@@ -1087,7 +1099,11 @@ class PaparazziPluginTest {
     }
 
     config = resourcesFile.loadConfig()
-    assertThat(config.projectAssetDirs).containsExactly("src/main/assets", "src/debug/assets")
+    assertThat(config.projectAssetDirs).containsExactly(
+      "src/main/assets",
+      "src/debug/assets",
+      "build/intermediates/library_assets/debug/packageDebugAssets/out"
+    )
   }
 
   @Test
@@ -1128,6 +1144,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
+      "build/intermediates/library_assets/debug/packageDebugAssets/out",
       "../producer/build/intermediates/library_assets/debug/packageDebugAssets/out"
     )
 
@@ -1155,6 +1172,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
+      "build/intermediates/library_assets/debug/packageDebugAssets/out",
       "../producer/build/intermediates/library_assets/debug/packageDebugAssets/out"
     )
   }

--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true
+android.useAndroidX=true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/consumer/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  libraryVariants.configureEach {
+    it.registerGeneratedResFolders(project.layout.buildDirectory.files("generated/res/extra"))
+  }
+}
+
+dependencies {
+  testImplementation projects.testModule
+  testRuntimeOnly projects.runtimeTestModule
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/consumer/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/consumer/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/runtime-test-module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/runtime-test-module/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test.runtimetestmodule'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/runtime-test-module/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/runtime-test-module/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/settings.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/settings.gradle
@@ -1,0 +1,5 @@
+apply from: '../test.settings.gradle'
+
+include ':consumer'
+include ':test-module'
+include ':runtime-test-module'

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/test-module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/test-module/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace 'app.cash.paparazzi.plugin.test.testmodule'
+  compileSdk libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/test-module/src/main/res/values/strings.xml
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-test-resources/test-module/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>


### PR DESCRIPTION
I'm having a problem on a project where I have a module that contains composables, those composables depend on a `IconProvider` interface, this interface outputs `@DrawableRes Int`. We do not want the UI module to depend on the implementation of this interface. But we do want this implementation available on unit tests.

We currently add a `testRuntimeOnly`  (could also be a `testImplementation`) on this interface implementation and get running espresso tests. But we get weird errors with Paparazzi. Looking into the code, it looks like the dependencies added on the test source set are not added in the `Config` class by `PaparazziPlugin`.

This PR is my attempt of making Paparazzi aware of resources of local modules and external libraries that are only visible to the test source set.

I have a [proof of concept](https://github.com/alyssoncs/paparazzi/tree/poc) of a composable depending on an interface, and this interface being provided only on the unit tests (it is also provided on the debug variant to make `@Preview`s work). Running `./gradlew :poc:ui:testReleaseUnitTest` should fail.

I also have the same [proof of concept + the code in this PR](https://github.com/alyssoncs/paparazzi/tree/use-test-resources-poc), and the same task succeeds.

This is my first time contributing to this project, let me know what you think of this. Also, does this deserve a new unit test? I could use some help on this. What would be important testing here?