### PR TITLE
Revert IDE compile hooks workaround

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -787,7 +787,7 @@ class PaparazziPluginTest {
     val fixtureRoot = File("src/test/projects/verify-resources-java")
 
     val result = gradleRunner
-      .withArguments(":consumer:compileDebugUnitTestJavaWithJavac", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
     assertThat(result.task(":consumer:preparePaparazziDebugResources")).isNotNull()
@@ -823,7 +823,7 @@ class PaparazziPluginTest {
     val fixtureRoot = File("src/test/projects/verify-resources-kotlin")
 
     val result = gradleRunner
-      .withArguments(":consumer:compileDebugUnitTestKotlin", "--stacktrace")
+      .withArguments(":consumer:testDebug", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
     assertThat(result.task(":consumer:preparePaparazziDebugResources")).isNotNull()


### PR DESCRIPTION
Since #125, Android Studio now uses Gradle directly to run tests (vs its previous custom test runner).  So let's remove the workaround and clean some stuff up.