### PR TITLE
Fix aar2jar output file paths to resolve missing compose dependencies

### DIFF
--- a/build-logic/aar2jar/src/main/java/app/cash/paparazzi/gradle/ExtractClassesJarTransform.kt
+++ b/build-logic/aar2jar/src/main/java/app/cash/paparazzi/gradle/ExtractClassesJarTransform.kt
@@ -35,13 +35,13 @@ abstract class ExtractClassesJarTransform : TransformAction<TransformParameters.
 
   override fun transform(outputs: TransformOutputs) {
     val inputFile = primaryInput.get().asFile
-    val outputFile = outputs.file(inputFile.nameWithoutExtension)
+    val aarFileName = inputFile.nameWithoutExtension
 
     ZipInputStream(inputFile.inputStream().buffered()).use { input ->
       while(true) {
         val entry = input.nextEntry ?: break
         if (entry.name != "classes.jar") continue
-        Files.copy(input, outputFile.toPath())
+        Files.copy(input, outputs.file("$aarFileName-${entry.name}").toPath())
         break
       }
     }


### PR DESCRIPTION
Previously the `outputFile` path was something like the following for each input: `/Users/cmarsch/.gradle/caches/8.8/transforms/f148f675e43cbd2a21221ba4f5df0fa0-749cc3c4-82fb-4932-a240-115b2a884778/transformed/lifecycle-livedata-core-2.6.2`, now it's more simply: `lifecycle-livedata-core-2.6.2-classes.jar`.

This resolves an issue where all `androidx.compose` dependencies in the `paparazzi` module were appearing as `Unresolved references` in the IDE.

This change is based on [the previous logic](https://github.com/cashapp/paparazzi/blob/18e71964fad9de91002b91a5c100a7a49915b15f/paparazzi/build.gradle#L228) that was used in this transfromation.