### PR TITLE
Introduce OffByTwo differ to relax image comparisons

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Differ.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Differ.kt
@@ -10,9 +10,15 @@ internal interface Differ {
       val delta: BufferedImage
     ) : DiffResult
 
+    data class Similar(
+      val delta: BufferedImage,
+      val numSimilarPixels: Long
+    ) : DiffResult
+
     data class Different(
       val delta: BufferedImage,
-      val percentDifference: Float
+      val percentDifference: Float,
+      val numDifferentPixels: Long
     ) : DiffResult
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -16,7 +16,9 @@
 
 package app.cash.paparazzi.internal
 
-import app.cash.paparazzi.internal.Differ.DiffResult
+import app.cash.paparazzi.internal.Differ.DiffResult.Different
+import app.cash.paparazzi.internal.Differ.DiffResult.Identical
+import app.cash.paparazzi.internal.Differ.DiffResult.Similar
 import java.awt.AlphaComposite
 import java.awt.Color
 import java.awt.Graphics2D
@@ -138,11 +140,12 @@ internal object ImageUtils {
       throw IllegalStateException("expected:<$TYPE_INT_ARGB> but was:<${goldenImage.type}>")
     }
 
-    val differ: Differ = PixelPerfect
+    val differ: Differ = OffByTwo
     differ.compare(goldenImage, image).let { result ->
       return when (result) {
-        is DiffResult.Identical -> result.delta to 0f
-        is DiffResult.Different -> result.delta to result.percentDifference
+        is Identical -> result.delta to 0f
+        is Similar -> result.delta to 0f
+        is Different -> result.delta to result.percentDifference
       }
     }
   }


### PR DESCRIPTION
Details discussed here: https://github.com/cashapp/paparazzi/issues/1465#issuecomment-2214901484

This will allow rgb components that differ by <= 2 to be considered similar. In the current set of tests, this appears to overcome cross-platform rendering differences due to antialiasing (for text) and dithering (for gradients).

In a follow-up, remaining tests will be migrated to use this differ, enabling us to get rid of `maxPercentDifference`!

Closes https://github.com/cashapp/paparazzi/issues/1465.