### PR TITLE
Fix tests dependent on locale

### DIFF
--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
@@ -8,12 +8,14 @@ import okio.Path
 import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.awt.Point
 import java.io.File
 import java.lang.AssertionError
+import java.util.Locale
 
 class ApngVerifierTest {
   @get:Rule
@@ -22,6 +24,12 @@ class ApngVerifierTest {
   private val firstFrame = createImage(squareOffset = Point(5, 5))
   private val secondFrame = createImage(squareOffset = Point(25, 25))
   private val thirdFrame = createImage(squareOffset = Point(45, 45))
+
+  @Before
+  fun setup () {
+    // set locale to US to avoid issues with different locales
+    Locale.setDefault(Locale.US)
+  }
 
   @Test
   fun validatesSuccessfully() {

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
@@ -7,6 +7,7 @@ import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
+import org.junit.After
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -24,11 +25,17 @@ class ApngVerifierTest {
   private val firstFrame = createImage(squareOffset = Point(5, 5))
   private val secondFrame = createImage(squareOffset = Point(25, 25))
   private val thirdFrame = createImage(squareOffset = Point(45, 45))
+  private val defaultLocale = Locale.getDefault()
 
   @Before
   fun setup() {
     // set locale to US to avoid issues with different locales
     Locale.setDefault(Locale.US)
+  }
+
+  @After
+  fun tearDown() {
+    Locale.setDefault(defaultLocale)
   }
 
   @Test

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
@@ -26,7 +26,7 @@ class ApngVerifierTest {
   private val thirdFrame = createImage(squareOffset = Point(45, 45))
 
   @Before
-  fun setup () {
+  fun setup() {
     // set locale to US to avoid issues with different locales
     Locale.setDefault(Locale.US)
   }


### PR DESCRIPTION
Fix tests dependant on locale that are expecting the decimal output in a specific (US) locale.