### PR TITLE
Replace all accessing of gradle properties

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -125,7 +125,7 @@ public class PaparazziPlugin @Inject constructor(
       ) { task ->
         val android = project.extensions.getByType(BaseExtension::class.java)
         val nonTransitiveRClassEnabled =
-          (project.findProperty("android.nonTransitiveRClass") as? String)?.toBoolean() ?: true
+          project.providers.gradleProperty("android.nonTransitiveRClass").orNull?.toBoolean() ?: true
         val gradleHomeDir = projectDirectory.dir(project.gradle.gradleUserHomeDir.path)
 
         task.packageName.set(android.packageName())
@@ -290,7 +290,7 @@ public class PaparazziPlugin @Inject constructor(
   }
 
   private fun Project.isInternal(): Boolean =
-    properties["app.cash.paparazzi.internal"].toString() == "true"
+    providers.gradleProperty("app.cash.paparazzi.internal").orNull == "true"
 
   private fun BaseExtension.packageName(): String = namespace ?: ""
 


### PR DESCRIPTION
The old usage (`findProperty` or `properties`) is not compatible with project isolation. The new `providers.gradleProperty` is, however.