### PR TITLE
Always sanitize the snapshot filename

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -92,7 +92,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
       val snapshotDir = if (fps == -1) imagesDirectory else videosDirectory
       val goldenDir = if (fps == -1) goldenImagesDirectory else goldenVideosDirectory
       val hashes = mutableListOf<String>()
-      val snapshotTmpFile = File(snapshotDir, snapshot.toFileName(extension = "temp.png").sanitizeForFilename(lowercase = false)!!)
+      val snapshotTmpFile = File(snapshotDir, snapshot.toFileName(extension = "temp.png"))
       val writer = ApngWriter(snapshotTmpFile.path.toPath(), fps)
 
       override fun handle(image: BufferedImage) {
@@ -108,7 +108,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
         snapshotTmpFile.delete()
 
         if (isRecording) {
-          val goldenFile = File(goldenDir, snapshot.toFileName("_", "png").sanitizeForFilename(lowercase = false)!!)
+          val goldenFile = File(goldenDir, snapshot.toFileName("_", "png"))
           snapshotFile.copyTo(target = goldenFile, overwrite = true)
         }
 
@@ -233,16 +233,3 @@ internal fun defaultRunName(): String {
   return "${timestamp}_$token"
 }
 
-internal val filenameSafeChars = CharMatcher.inRange('a', 'z')
-  .or(CharMatcher.inRange('A', 'Z'))
-  .or(CharMatcher.inRange('0', '9'))
-  .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
-
-internal val filenameLowerCaseSafeChars = CharMatcher.inRange('a', 'z')
-  .or(CharMatcher.inRange('0', '9'))
-  .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
-
-internal fun String.sanitizeForFilename(lowercase: Boolean = true): String? {
-  val safeChars = if (lowercase) filenameLowerCaseSafeChars else filenameSafeChars
-  return safeChars.negate().replaceFrom(if (lowercase) toLowerCase(Locale.US) else this, '_')
-}

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -18,7 +18,6 @@ package app.cash.paparazzi
 import app.cash.paparazzi.SnapshotHandler.FrameHandler
 import app.cash.paparazzi.internal.PaparazziJson
 import app.cash.paparazzi.internal.apng.ApngWriter
-import com.google.common.base.CharMatcher
 import okio.BufferedSink
 import okio.HashingSink
 import okio.Path.Companion.toPath
@@ -232,4 +231,3 @@ internal fun defaultRunName(): String {
   val token = UUID.randomUUID().toString().substring(0, 6)
   return "${timestamp}_$token"
 }
-

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -49,12 +49,12 @@ internal fun Snapshot.toFileName(
   return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension".sanitizeForFilename(lowercase = false)!!
 }
 
-internal val filenameSafeChars = CharMatcher.inRange('a', 'z')
+private val filenameSafeChars = CharMatcher.inRange('a', 'z')
   .or(CharMatcher.inRange('A', 'Z'))
   .or(CharMatcher.inRange('0', '9'))
   .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
 
-internal val filenameLowerCaseSafeChars = CharMatcher.inRange('a', 'z')
+private val filenameLowerCaseSafeChars = CharMatcher.inRange('a', 'z')
   .or(CharMatcher.inRange('0', '9'))
   .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -46,7 +46,7 @@ internal fun Snapshot.toFileName(
   } else {
     ""
   }
-  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension".sanitizeForFilename(lowercase = true)!!
+  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension".sanitizeForFilename(lowercase = false)!!
 }
 
 internal val filenameSafeChars = CharMatcher.inRange('a', 'z')

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paparazzi
 
+import com.google.common.base.CharMatcher
 import dev.drewhamilton.poko.Poko
 import java.util.Date
 import java.util.Locale
@@ -45,5 +46,19 @@ internal fun Snapshot.toFileName(
   } else {
     ""
   }
-  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension"
+  return "${testName.packageName}${delimiter}${testName.className}${delimiter}${testName.methodName}$formattedLabel.$extension".sanitizeForFilename(lowercase = true)!!
+}
+
+internal val filenameSafeChars = CharMatcher.inRange('a', 'z')
+  .or(CharMatcher.inRange('A', 'Z'))
+  .or(CharMatcher.inRange('0', '9'))
+  .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
+
+internal val filenameLowerCaseSafeChars = CharMatcher.inRange('a', 'z')
+  .or(CharMatcher.inRange('0', '9'))
+  .or(CharMatcher.anyOf("_-.~@^()[]{}:;,"))
+
+internal fun String.sanitizeForFilename(lowercase: Boolean = true): String? {
+  val safeChars = if (lowercase) filenameLowerCaseSafeChars else filenameSafeChars
+  return safeChars.negate().replaceFrom(if (lowercase) toLowerCase(Locale.US) else this, '_')
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
@@ -312,9 +312,9 @@ class HtmlReportWriterTest {
     }
   }
 
-  private fun Instant.toDate() = Date(toEpochMilli())
-
   private fun File.lastModifiedTime(): FileTime {
     return Files.readAttributes(this.toPath(), BasicFileAttributes::class.java).lastModifiedTime()
   }
 }
+
+internal fun Instant.toDate() = Date(toEpochMilli())

--- a/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
@@ -1,0 +1,67 @@
+package app.cash.paparazzi
+
+import app.cash.paparazzi.FileSubject.Companion.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.awt.image.BufferedImage
+import java.io.File
+import java.time.Instant
+
+class SnapshotVerifierTest {
+  // Verify that the snapshot verifier reads the correct file name output from HtmlReportWriter
+  @get:Rule
+  val reportRoot: TemporaryFolder = TemporaryFolder()
+
+  @get:Rule
+  val snapshotRoot: TemporaryFolder = TemporaryFolder()
+
+  private val anyImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+
+  @Test
+  fun verifyImageFilename() {
+    try {
+      // set record mode
+      System.setProperty("paparazzi.test.record", "true")
+      val imageSnapshot = Snapshot(
+        name = "image name with spaces",
+        testName = TestName("app.cash.paparazzi", "CelebrityTest", "test name with spaces"),
+        timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate(),
+        tags = listOf("redesign")
+      )
+      val htmlReportWriter = HtmlReportWriter("run_one", reportRoot.root, snapshotRoot.root)
+      htmlReportWriter.use {
+        val golden =
+          File("${snapshotRoot.root}/images/app.cash.paparazzi_CelebrityTest_test_name_with_spaces_image_name_with_spaces.png")
+
+        // precondition
+        assertThat(golden).doesNotExist()
+
+        val recordFrameHandler = htmlReportWriter.newFrameHandler(
+          snapshot = imageSnapshot,
+          frameCount = 1,
+          fps = -1
+        )
+        recordFrameHandler.use { recordFrameHandler.handle(anyImage) }
+        assertThat(golden).exists()
+      }
+
+      val snapshotVerifier = SnapshotVerifier(0.0, snapshotRoot.root)
+      snapshotVerifier.use {
+        val verifyFrameHandler = snapshotVerifier.newFrameHandler(
+          snapshot = imageSnapshot,
+          frameCount = 1,
+          fps = -1,
+        )
+        verifyFrameHandler.use { verifyFrameHandler.handle(anyImage) }
+      }
+    } finally {
+      System.clearProperty("paparazzi.test.record")
+    }
+  }
+
+  @Test
+  fun verifyVideoFilename() {
+
+  }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
@@ -51,7 +51,7 @@ class SnapshotVerifierTest {
         val verifyFrameHandler = snapshotVerifier.newFrameHandler(
           snapshot = imageSnapshot,
           frameCount = 1,
-          fps = -1,
+          fps = -1
         )
         verifyFrameHandler.use { verifyFrameHandler.handle(anyImage) }
       }
@@ -62,6 +62,5 @@ class SnapshotVerifierTest {
 
   @Test
   fun verifyVideoFilename() {
-
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/SnapshotVerifierTest.kt
@@ -62,5 +62,49 @@ class SnapshotVerifierTest {
 
   @Test
   fun verifyVideoFilename() {
+    try {
+      // set record mode
+      System.setProperty("paparazzi.test.record", "true")
+      val imageSnapshot = Snapshot(
+        name = "video name with spaces",
+        testName = TestName("app.cash.paparazzi", "CelebrityTest", "test name with spaces"),
+        timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate(),
+        tags = listOf("redesign")
+      )
+      val htmlReportWriter = HtmlReportWriter("record_one", reportRoot.root, snapshotRoot.root)
+      htmlReportWriter.use {
+        val golden =
+          File("${snapshotRoot.root}/videos/app.cash.paparazzi_CelebrityTest_test_name_with_spaces_video_name_with_spaces.png")
+
+        // precondition
+        assertThat(golden).doesNotExist()
+
+        val recordFrameHandler = htmlReportWriter.newFrameHandler(
+          snapshot = imageSnapshot,
+          frameCount = 2,
+          fps = 1
+        )
+        recordFrameHandler.use {
+          recordFrameHandler.handle(anyImage)
+          recordFrameHandler.handle(anyImage)
+        }
+        assertThat(golden).exists()
+      }
+
+      val snapshotVerifier = SnapshotVerifier(0.0, snapshotRoot.root)
+      snapshotVerifier.use {
+        val verifyFrameHandler = snapshotVerifier.newFrameHandler(
+          snapshot = imageSnapshot,
+          frameCount = 2,
+          fps = 1
+        )
+        verifyFrameHandler.use {
+          verifyFrameHandler.handle(anyImage)
+          verifyFrameHandler.handle(anyImage)
+        }
+      }
+    } finally {
+      System.clearProperty("paparazzi.test.record")
+    }
   }
 }


### PR DESCRIPTION
With the recent fix omitting invalid filename characters when recording snapshots, the verification step would fail because it did not apply the same sanitization. This PR makes the snapshot filename always sanitize to resolve this issue. 