### PR TITLE
Revert "Update dependency dev.drewhamilton.poko:poko-gradle-plugin to…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,5 +67,5 @@ plugin-kotlin-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle
 plugin-kotlinApiDump = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = '0.16.3' }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.29.0" }
-plugin-poko = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.17.0" }
+plugin-poko = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.16.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }


### PR DESCRIPTION
… v0.17.0 (#1550)"

This reverts commit 6a0d266de2b78fdfcd4d367fdbd6edb134f3407d.

This version bump caused an internal kotlin compilation error on master. Reverting this for now in order to get us back to green