### PR TITLE
Update macOS 14 to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [
           # Check https://github.com/actions/runner-images?tab=readme-ov-file#available-images for actual versions for latest
-          macOS-latest
+          macOS-latest,
           windows-latest,
           ubuntu-latest
         ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [
           # Check https://github.com/actions/runner-images?tab=readme-ov-file#available-images for actual versions for latest
-          macOS-latest, # arm64
+          macOS-latest
           windows-latest,
           ubuntu-latest
         ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          # Migrate back to macOS-latest once 'latest' workflow label is updated (April – June 2024)
-          # https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-          macOS-14,
+          # Check https://github.com/actions/runner-images?tab=readme-ov-file#available-images for actual versions for latest
+          macOS-latest, # arm64
           windows-latest,
           ubuntu-latest
         ]


### PR DESCRIPTION
macOS-latest is [now](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) macOS 14 arm64 so we no longer need to target a direct version.

Add support for macOS 14 x64 to cover more end user scenarios.