### PR TITLE
Fail faster on ksp codegen, add custom lint checks for user experience

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     classpath libs.plugin.kotlin
     classpath libs.plugin.kotlin.compose
     classpath libs.plugin.kotlinApiDump
+    classpath libs.plugin.ksp
     classpath libs.plugin.android
     classpath libs.plugin.mavenPublish
     classpath libs.plugin.dokka

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,9 @@ androidx-compose-ui-android = { module = "androidx.compose.ui:ui-android", versi
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-android", version = "2.8.7" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.3.2" }
 
+autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
+autoService-kspCompiler = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
+
 bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
@@ -42,6 +45,9 @@ ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = 
 ktlint-core = "com.pinterest.ktlint:ktlint-cli:1.4.1"
 
 kxml2 = { module = "kxml2:kxml2", version = "2.3.0" }
+
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "androidTools" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "androidTools" }
 
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
@@ -71,7 +77,7 @@ plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-kotlin-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 plugin-kotlinApiDump = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = '0.16.3' }
-plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+plugin-ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.30.0" }
 plugin-poko = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.17.2" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }

--- a/paparazzi-preview-lints/api/paparazzi-preview-lints.api
+++ b/paparazzi-preview-lints/api/paparazzi-preview-lints.api
@@ -1,0 +1,15 @@
+public final class app/cash/paparazzi/preview/lints/PaparazziPreviewDetector : com/android/tools/lint/detector/api/Detector, com/android/tools/lint/detector/api/SourceCodeScanner {
+	public fun <init> ()V
+	public fun applicableAnnotations ()Ljava/util/List;
+	public fun inheritAnnotation (Ljava/lang/String;)Z
+	public fun isApplicableAnnotationUsage (Lcom/android/tools/lint/detector/api/AnnotationUsageType;)Z
+	public fun visitAnnotationUsage (Lcom/android/tools/lint/detector/api/JavaContext;Lorg/jetbrains/uast/UElement;Lcom/android/tools/lint/detector/api/AnnotationInfo;Lcom/android/tools/lint/detector/api/AnnotationUsageInfo;)V
+}
+
+public final class app/cash/paparazzi/preview/lints/PaparazziPreviewIssueRegistry : com/android/tools/lint/client/api/IssueRegistry {
+	public fun <init> ()V
+	public fun getApi ()I
+	public fun getIssues ()Ljava/util/List;
+	public fun getVendor ()Lcom/android/tools/lint/client/api/Vendor;
+}
+

--- a/paparazzi-preview-lints/build.gradle
+++ b/paparazzi-preview-lints/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'com.android.lint'
+apply plugin: 'com.google.devtools.ksp'
+
+dependencies {
+  compileOnly libs.lint.api
+  compileOnly libs.autoService.annotations
+
+  ksp libs.autoService.kspCompiler
+
+  testCompileOnly libs.lint.api
+  testImplementation libs.lint.tests
+  testImplementation libs.junit
+  testImplementation libs.truth
+}

--- a/paparazzi-preview-lints/src/main/java/app/cash/paparazzi/preview/lints/PaparazziPreviewDetector.kt
+++ b/paparazzi-preview-lints/src/main/java/app/cash/paparazzi/preview/lints/PaparazziPreviewDetector.kt
@@ -1,0 +1,145 @@
+package app.cash.paparazzi.preview.lints
+
+import com.android.tools.lint.detector.api.AnnotationInfo
+import com.android.tools.lint.detector.api.AnnotationUsageInfo
+import com.android.tools.lint.detector.api.AnnotationUsageType
+import com.android.tools.lint.detector.api.AnnotationUsageType.DEFINITION
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UastVisibility
+
+public class PaparazziPreviewDetector : Detector(), SourceCodeScanner {
+  override fun applicableAnnotations(): List<String> = listOf(PAPARAZZI_ANNOTATION)
+
+  override fun isApplicableAnnotationUsage(type: AnnotationUsageType): Boolean =
+    type == DEFINITION || super.isApplicableAnnotationUsage(type)
+
+  override fun inheritAnnotation(annotation: String): Boolean = false
+
+  @Suppress("UnstableApiUsage")
+  override fun visitAnnotationUsage(
+    context: JavaContext,
+    element: UElement,
+    annotationInfo: AnnotationInfo,
+    usageInfo: AnnotationUsageInfo
+  ) {
+    val qualifiedName = annotationInfo.qualifiedName
+    if (qualifiedName != PAPARAZZI_ANNOTATION) return
+
+    val annotatedMethod = annotationInfo.annotation.uastParent as? UMethod
+      ?: throw IllegalStateException("Expected annotated method given declared target type")
+
+    val annotatedMethodName = annotatedMethod.name
+    val hasComposable = annotatedMethod.annotations.any { it.qualifiedName == COMPOSABLE_ANNOTATION }
+    if (!hasComposable) {
+      context.report(
+        issue = COMPOSABLE_NOT_DETECTED,
+        scope = element,
+        location = context.getLocation(element),
+        message = "$annotatedMethodName is not annotated with @Composable."
+      )
+    }
+
+    val hasPreview = annotatedMethod.annotations.any { it.qualifiedName == PREVIEW_ANNOTATION }
+    if (!hasPreview) {
+      context.report(
+        issue = PREVIEW_NOT_DETECTED,
+        scope = element,
+        location = context.getLocation(element),
+        message = "$annotatedMethodName is not annotated with @Preview."
+      )
+    }
+
+    if (annotatedMethod.visibility == UastVisibility.PRIVATE) {
+      context.report(
+        issue = PRIVATE_PREVIEW_DETECTED,
+        scope = element,
+        location = context.getLocation(element),
+        message = "$annotatedMethodName is private. Make it internal or public to generate a snapshot."
+      )
+    }
+
+    val hasPreviewParameter = annotatedMethod.parameters.any {
+      it.annotations.any { it.qualifiedName == PREVIEW_PARAMETER_ANNOTATION }
+    }
+    if (hasPreviewParameter) {
+      context.report(
+        issue = PREVIEW_PARAMETERS_NOT_SUPPORTED,
+        scope = element,
+        location = context.getLocation(element),
+        message = "@Preview of $annotatedMethodName uses PreviewParameters which aren't currently supported."
+      )
+    }
+  }
+
+  internal companion object {
+    private const val PAPARAZZI_ANNOTATION = "app.cash.paparazzi.annotations.Paparazzi"
+    private const val COMPOSABLE_ANNOTATION = "androidx.compose.runtime.Composable"
+    private const val PREVIEW_ANNOTATION = "androidx.compose.ui.tooling.preview.Preview"
+    private const val PREVIEW_PARAMETER_ANNOTATION = "androidx.compose.ui.tooling.preview.PreviewParameter"
+
+    val COMPOSABLE_NOT_DETECTED: Issue = Issue.create(
+      id = "ComposableAnnotationNotFound",
+      briefDescription = "Composable Annotation not found",
+      explanation = "Paparazzi Previews require a @Composable annotation to be applied.",
+      category = Category.CUSTOM_LINT_CHECKS,
+      priority = 10,
+      severity = Severity.ERROR,
+      implementation = Implementation(
+        PaparazziPreviewDetector::class.java,
+        Scope.JAVA_FILE_SCOPE,
+        Scope.JAVA_FILE_SCOPE
+      )
+    )
+
+    val PREVIEW_NOT_DETECTED: Issue = Issue.create(
+      id = "PreviewAnnotationNotFound",
+      briefDescription = "Preview Annotation not found",
+      explanation = "Paparazzi Previews require a @Preview annotation to be applied.",
+      category = Category.CUSTOM_LINT_CHECKS,
+      priority = 10,
+      severity = Severity.ERROR,
+      implementation = Implementation(
+        PaparazziPreviewDetector::class.java,
+        Scope.JAVA_FILE_SCOPE,
+        Scope.JAVA_FILE_SCOPE
+      )
+    )
+
+    val PRIVATE_PREVIEW_DETECTED: Issue = Issue.create(
+      id = "PrivatePreviewDetected",
+      briefDescription = "@Preview of private Composable detected",
+      explanation = "Paparazzi Previews does not support private Composables.",
+      category = Category.CUSTOM_LINT_CHECKS,
+      priority = 10,
+      severity = Severity.ERROR,
+      implementation = Implementation(
+        PaparazziPreviewDetector::class.java,
+        Scope.JAVA_FILE_SCOPE,
+        Scope.JAVA_FILE_SCOPE
+      )
+    )
+
+    val PREVIEW_PARAMETERS_NOT_SUPPORTED: Issue = Issue.create(
+      id = "PreviewParametersNotSupported",
+      briefDescription = "Preview Parameters not supported",
+      explanation = "Paparazzi Previews does not support Preview Parameters.",
+      category = Category.CUSTOM_LINT_CHECKS,
+      priority = 10,
+      severity = Severity.ERROR,
+      implementation = Implementation(
+        PaparazziPreviewDetector::class.java,
+        Scope.JAVA_FILE_SCOPE,
+        Scope.JAVA_FILE_SCOPE
+      )
+    )
+  }
+}

--- a/paparazzi-preview-lints/src/main/java/app/cash/paparazzi/preview/lints/PaparazziPreviewIssueRegistry.kt
+++ b/paparazzi-preview-lints/src/main/java/app/cash/paparazzi/preview/lints/PaparazziPreviewIssueRegistry.kt
@@ -1,0 +1,25 @@
+package app.cash.paparazzi.preview.lints
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+import com.google.auto.service.AutoService
+
+@AutoService(value = [IssueRegistry::class])
+public class PaparazziPreviewIssueRegistry : IssueRegistry() {
+  override val issues: List<Issue> = listOf(
+    PaparazziPreviewDetector.COMPOSABLE_NOT_DETECTED,
+    PaparazziPreviewDetector.PREVIEW_NOT_DETECTED,
+    PaparazziPreviewDetector.PRIVATE_PREVIEW_DETECTED,
+    PaparazziPreviewDetector.PREVIEW_PARAMETERS_NOT_SUPPORTED
+  )
+
+  override val api: Int = CURRENT_API
+
+  override val vendor: Vendor = Vendor(
+    vendorName = "cashapp/paparazzi",
+    identifier = "app.cash.paparazzi",
+    feedbackUrl = "https://github.com/cashapp/paparazzi/issues"
+  )
+}

--- a/paparazzi-preview-lints/src/test/java/app/cash/paparazzi/preview/lints/PaparazziPreviewDetectorTest.kt
+++ b/paparazzi-preview-lints/src/test/java/app/cash/paparazzi/preview/lints/PaparazziPreviewDetectorTest.kt
@@ -1,0 +1,283 @@
+package app.cash.paparazzi.preview.lints
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+
+class PaparazziPreviewDetectorTest {
+  @Test
+  fun simplePreview() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.tooling.preview.Preview
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Preview
+          @Composable
+          fun SamplePreview() {}
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .detector(PaparazziPreviewDetector())
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun multiplePreviews() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.tooling.preview.Preview
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Preview
+          @Preview(
+             name = "Night Pixel 4",
+             uiMode = 0x20, // uiMode maps to android.content.res.Configuration.UI_MODE_NIGHT_YES
+             device = "id:pixel_4"
+          )
+          @Composable
+          fun SamplePreview() {}
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .detector(PaparazziPreviewDetector())
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun notComposable() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.ui.tooling.preview.Preview
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Preview
+          fun SamplePreview() {}
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .issues(PaparazziPreviewDetector.COMPOSABLE_NOT_DETECTED)
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expect(
+        """
+        src/test/test.kt:6: Error: SamplePreview is not annotated with @Composable. [ComposableAnnotationNotFound]
+        @Paparazzi
+        ~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun notPreview() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.runtime.Composable
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Composable
+          fun SamplePreview() {}
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .issues(PaparazziPreviewDetector.PREVIEW_NOT_DETECTED)
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expect(
+        """
+        src/test/test.kt:6: Error: SamplePreview is not annotated with @Preview. [PreviewAnnotationNotFound]
+        @Paparazzi
+        ~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun privatePreview() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.tooling.preview.Preview
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Preview
+          @Composable
+          private fun SamplePreview() {}
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .issues(PaparazziPreviewDetector.PRIVATE_PREVIEW_DETECTED)
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expect(
+        """
+        src/test/test.kt:7: Error: SamplePreview is private. Make it internal or public to generate a snapshot. [PrivatePreviewDetected]
+        @Paparazzi
+        ~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun previewParameters() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package test
+
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.tooling.preview.Preview
+          import androidx.compose.ui.tooling.preview.PreviewParameter
+          import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+          import app.cash.paparazzi.annotations.Paparazzi
+
+          @Paparazzi
+          @Preview
+          @Composable
+          fun SamplePreview(
+            @PreviewParameter(SamplePreviewParameter::class) text: String,
+          ) {}
+
+          object SamplePreviewParameter: PreviewParameterProvider<String> {
+            override val values: Sequence<String> = sequenceOf("test")
+          }
+          """
+        ).indented(),
+        *COMPOSE_SOURCES.toTypedArray(),
+        PAPARAZZI_ANNOTATION
+      )
+      .issues(PaparazziPreviewDetector.PREVIEW_PARAMETERS_NOT_SUPPORTED)
+      .skipTestModes(TestMode.SUPPRESSIBLE)
+      .run()
+      .expect(
+        """
+        src/test/SamplePreviewParameter.kt:9: Error: @Preview of SamplePreview uses PreviewParameters which aren't currently supported. [PreviewParametersNotSupported]
+        @Paparazzi
+        ~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  private companion object {
+    private val COMPOSE_SOURCES =
+      listOf(
+        kotlin(
+          """
+          package androidx.compose.runtime
+
+          @Retention(AnnotationRetention.BINARY)
+          @Target(
+              AnnotationTarget.FUNCTION,
+              AnnotationTarget.TYPE,
+              AnnotationTarget.TYPE_PARAMETER,
+              AnnotationTarget.PROPERTY_GETTER
+          )
+          annotation class Composable
+          """
+        ).indented(),
+        kotlin(
+          """
+          package androidx.compose.ui.tooling.preview
+
+          @Retention(AnnotationRetention.BINARY)
+          @Target(
+              AnnotationTarget.ANNOTATION_CLASS,
+              AnnotationTarget.FUNCTION
+          )
+          @Repeatable
+          annotation class Preview(
+            val name: String = "",
+            val group: String = "",
+            val apiLevel: Int = -1,
+            val widthDp: Int = -1,
+            val heightDp: Int = -1,
+            val locale: String = "",
+            val fontScale: Float = 1f,
+            val showSystemUi: Boolean = false,
+            val showBackground: Boolean = false,
+            val backgroundColor: Long = 0,
+            val uiMode: Int = 0,
+            val device: String = "",
+            val wallpaper: Int = 0,
+          )
+          """
+        ).indented(),
+        kotlin(
+          """
+          package androidx.compose.ui.tooling.preview
+
+          import kotlin.jvm.JvmDefaultWithCompatibility
+          import kotlin.reflect.KClass
+
+          @JvmDefaultWithCompatibility
+          interface PreviewParameterProvider<T> {
+              val values: Sequence<T>
+              val count get() = values.count()
+          }
+
+          annotation class PreviewParameter(
+              val provider: KClass<out PreviewParameterProvider<*>>,
+              val limit: Int = Int.MAX_VALUE
+          )
+          """
+        ).indented()
+      )
+
+    val PAPARAZZI_ANNOTATION = kotlin(
+      """
+      package app.cash.paparazzi.annotations
+
+      @Target(AnnotationTarget.FUNCTION)
+      @Retention(AnnotationRetention.BINARY)
+      annotation class Paparazzi
+      """
+    ).indented()
+  }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,6 +31,10 @@ dependencies {
   // deliberately not in versions.toml as a one-off
   implementation 'com.airbnb.android:lottie:6.6.0'
 
+  // TODO: wire via plugin
+  implementation projects.paparazziAnnotations
+  lintChecks projects.paparazziPreviewLints
+
   testImplementation libs.testParameterInjector
 }
 

--- a/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemo.kt
+++ b/sample/src/main/java/app/cash/paparazzi/sample/ResourcesDemo.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import app.cash.paparazzi.annotations.Paparazzi
 import app.cash.paparazzi.sample.ResourcesDemoView.Companion.plurals
 
 const val IMAGE_SIZE = 120f
 
+@Paparazzi
 @Preview
 @Composable
 fun ResourcesDemo() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ rootProject.name = 'paparazzi-root'
 include ':paparazzi'
 include ':paparazzi-annotations'
 include ':paparazzi-preview-processor'
+include ':paparazzi-preview-lints'
 include ':paparazzi-gradle-plugin'
 
 include ':sample'


### PR DESCRIPTION
Currently, the ksp plugin propagates error and empty state to the generated code, to be surfaced as test failures.  This PR proposes failing faster on ksp processing and adding custom lint checks as signals to the test author on how to properly use the annotation.