### PR TITLE
Couple Poko to Kotlin for Renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,11 +11,12 @@
       "automerge": true,
     },
     {
-      "description": "Compose compiler is tightly coupled to Kotlin version.",
-      "groupName": "Kotlin and Compose",
+      "description": "Compiler plugins are tightly coupled to Kotlin version.",
+      "groupName": "Kotlin",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin:",
-        "com.google.devtools.ksp"
+        "com.google.devtools.ksp",
+        "dev.drewhamilton.poko",
       ],
       "automerge": false,
     },


### PR DESCRIPTION
Poko versions are often tightly coupled to Kotlin versions since the compiler plugin APIs are not stable. This makes it easier to update those together.

Also removed "Compose" mentions from the Kotlin group since Compose is no longer included in that group.