### PR TITLE
Add error message if SHRINK rendering mode is used with AccessibilityRenderExtension

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/test/java/app/cash/paparazzi/plugin/test/ComposeA11yTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-a11y/src/test/java/app/cash/paparazzi/plugin/test/ComposeA11yTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import org.junit.Rule
 import org.junit.Test
 
@@ -151,6 +152,16 @@ class ComposeA11yTest {
     paparazzi.snapshot {
       Column(Modifier.background(Color.LightGray)) {
         androidx.compose.material.Text("Some text that will appear scaled in the UI, but not scaled in the legend")
+      }
+    }
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun renderingModeSHRINKThrowsException() {
+    paparazzi.unsafeUpdateConfig(renderingMode = RenderingMode.SHRINK)
+    paparazzi.snapshot {
+      Column(Modifier.background(Color.LightGray)) {
+        Text("SHRINK and AccessibilityRenderExtension are not supported together")
       }
     }
   }

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -232,7 +232,15 @@ public class PaparazziSdk @JvmOverloads constructor(
   private fun takeSnapshots(view: View, startNanos: Long, fps: Int, frameCount: Int) {
     val viewGroup = bridgeRenderSession.rootViews[0].viewObject as ViewGroup
     val modifiedView = renderExtensions.fold(view) { currentView, renderExtension ->
-      renderExtension.renderView(currentView)
+      val currentSessionRenderingMode = sessionParamsBuilder.build().renderingMode
+      if (currentSessionRenderingMode == RenderingMode.SHRINK && renderExtension is AccessibilityRenderExtension) {
+        throw IllegalStateException(
+          "AccessibilityRenderExtension cannot be used with the SHRINK rendering mode. " +
+            "See https://github.com/cashapp/paparazzi/issues/1350 for more context."
+        )
+      } else {
+        renderExtension.renderView(currentView)
+      }
     }
 
     System_Delegate.setNanosTime(0L)


### PR DESCRIPTION
From a conversation with @geoff-powell we decided returning an error message to disallow `SHRINK` rendering mode usage with the `AccessibilityRenderExtension` is likely the best approach for https://github.com/cashapp/paparazzi/issues/1350 until Paparazzi 2.0.0 is released which should unlock more flexibility around how the accessibility legend can be drawn. 