### PR TITLE
Modernize Paparazzi API documentation webpages

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -9,27 +9,7 @@
 set -ex
 
 # Generate the API docs
-./gradlew dokkaGfm
-
-# Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
-# Assign metadata to the file's first Markdown heading.
-# https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
-title_markdown_file() {
-  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - Paparazzi/"
-  echo "---"                                                     > "$1.fixed"
-  cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
-  echo "---"                                                    >> "$1.fixed"
-  echo                                                          >> "$1.fixed"
-  cat $1                                                        >> "$1.fixed"
-  mv "$1.fixed" "$1"
-}
-
-set +x
-for MARKDOWN_FILE in $(find docs/1.x/ -name '*.md'); do
-  echo $MARKDOWN_FILE
-  title_markdown_file $MARKDOWN_FILE
-done
-set -x
+./gradlew dokkaHtml
 
 # Copy in special files that GitHub wants in the project root.
 cat README.md | grep -v 'project website' > docs/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ markdown_extensions:
 
 nav:
   - 'Overview': index.md
-  - '1.x API': 1.x/paparazzi/app.cash.paparazzi/index.md
+  - '1.x API': 1.x/paparazzi/app.cash.paparazzi/index.html
   - 'Accessibility Snapshots': accessibility.md
   - 'Change Log': changelog.md
   - 'Code of Conduct': code_of_conduct.md

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -73,7 +73,7 @@ dependencies {
   testImplementation libs.truth
 }
 
-tasks.named("dokkaGfm").configure {
+tasks.named("dokkaHtml").configure {
   outputDirectory = rootProject.file("docs/1.x")
 
   dokkaSourceSets.named("main") {
@@ -81,6 +81,20 @@ tasks.named("dokkaGfm").configure {
       reportUndocumented = false
       skipDeprecated = true
       jdkVersion = 8
+      includeNonPublic = false
+      skipEmptyPackages = true
+      platform = "jvm"
+
+      externalDocumentationLink {
+        url.set(java.net.URL("https://developer.android.com/reference/"))
+      }
+
+      sourceLink {
+        localDirectory.set(file("src/main/java"))
+        remoteUrl.set(java.net.URL("https://github.com/cashapp/paparazzi/tree/master/paparazzi/src/main/java"))
+        remoteLineSuffix.set("#L")
+      }
+
       perPackageOption {
         prefix = "app.cash.paparazzi.internal"
         suppress = true


### PR DESCRIPTION
Updates the Paparazzi API docs to use a more modern styling provided through dokka that is also used in other libraries such as [SQLDelight](https://sqldelight.github.io/sqldelight/2.0.2/2.x/extensions/coroutines-extensions/app.cash.sqldelight.coroutines/index.html). Dark / light mode is a configuration option that is selectable on the webpages.

| Before |  After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/82229664-e36d-4e36-853b-05f91dfbf3df) | ![Screenshot 2025-03-18 at 3 45 14 PM](https://github.com/user-attachments/assets/dd95cd86-97e8-4914-9879-2d9f9f0f9656) |