### PR TITLE
Add dark/light mode toggle in the documentation website

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -25,7 +25,7 @@ body, input {
     font-family: cash-market-rounded,"Helvetica Neue",helvetica,sans-serif;
     line-height: normal;
     font-weight: bold;
-    color: #353535;
+    color: var(--md-default-fg-color);
 }
 
 button.dl {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,23 @@ theme:
   favicon: images/icon-square.png
   logo: images/icon-square.png
   palette:
-    primary: 'light blue'
-    accent: 'blue'
+    # Palette toggle for light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: 'light blue'
+      accent: 'blue'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: 'light blue'
+      accent: 'blue'
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 extra_css:
   - 'css/app.css'


### PR DESCRIPTION
This change enables the light mode / dark mode toggle button on the top right of the documentation website.

| Light |  Dark |
| --- | --- |
| <img width="1340" alt="image" src="https://github.com/user-attachments/assets/5f7ea752-673b-4ece-8a0d-6b201a40b2bd" /> | <img width="1352" alt="image" src="https://github.com/user-attachments/assets/087e7473-9b80-46e5-9e34-83659979ca66" /> |