### PR TITLE
Fix Paparazzi publication with missing `gradle.properties`

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -7,7 +7,7 @@ Markdown<3.9
 MarkupSafe==3.0.2
 mkdocs==1.6.1
 mkdocs-macros-plugin==1.3.7
-mkdocs-material==9.6.11
+mkdocs-material==9.6.12
 mkdocs-material-extensions==1.3.1
 Pygments==2.19.1
 pymdown-extensions==10.14.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Change Log
 
 ## [Unreleased]
+
+## [2.0.0-alpha01] - 2025-04-15
+
+### New
 * Support for editable text in accessibility snapshots
 * Support for error description in accessibility snapshots
+* Support progress compose semantics in accessibility snapshots
+* Support custom actions and link annotations in Compose accessibility snapshots
+* Support additional accessibility properties on views
+* Support live regions in accessibility snapshots
+* Add support for compose views that are hidden or invisible
+* Add gradle property to control default max percent difference
+* LayoutLib v15
+* [Gradle Plugin] Android Gradle Plugin 8.7.1
+
+### Fixed
+* Fix default layout params for compose snapshots
+* Fix accessibility overlay drawing in root view instead of window manager
+* Fix issue where unmergedNode has 0 elements
+* Don't scale accessibility legend text when font scale is non-default
+* Use compileOnly for kotlin/agp plugins
+* Bypass font path prefix check in ResourcesCompat::loadFont
+
+Kudos to @geoff-powell, @colinmarsch, @darshanparajuli, @DSteve595, @adamalyyan and others for contributions this release!
 
 ## [1.3.5] - 2024-11-06
 
@@ -411,7 +433,8 @@ As of this release, consumers must build on Java 11 environments.
 
 
 
-[Unreleased]: https://github.com/cashapp/paparazzi/compare/1.3.5...HEAD
+[Unreleased]: https://github.com/cashapp/paparazzi/compare/2.0.0-alpha01...HEAD
+[2.0.0-alpha01]: https://github.com/cashapp/paparazzi/releases/tag/2.0.0-alpha01
 [1.3.5]: https://github.com/cashapp/paparazzi/releases/tag/1.3.5
 [1.3.4]: https://github.com/cashapp/paparazzi/releases/tag/1.3.4
 [1.3.3]: https://github.com/cashapp/paparazzi/releases/tag/1.3.3

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:1.3.5'
+    classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:2.0.0-alpha01'
   }
 }
 
@@ -160,7 +160,7 @@ apply plugin: 'app.cash.paparazzi'
 Using the plugins DSL:
 ```groovy
 plugins {
-  id 'app.cash.paparazzi' version '1.3.5'
+  id 'app.cash.paparazzi' version '2.0.0-alpha01'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.paparazzi
-VERSION_NAME=2.0.0-SNAPSHOT
+VERSION_NAME=2.0.0-alpha01
 
 POM_URL=https://github.com/cashapp/paparazzi/
 POM_SCM_URL=https://github.com/cashapp/paparazzi/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.paparazzi
-VERSION_NAME=2.0.0-alpha01
+VERSION_NAME=2.0.0-SNAPSHOT
 
 POM_URL=https://github.com/cashapp/paparazzi/
 POM_SCM_URL=https://github.com/cashapp/paparazzi/

--- a/paparazzi-preview-lints/gradle.properties
+++ b/paparazzi-preview-lints/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=paparazzi-preview-lints
+POM_NAME=Paparazzi Preview Lints
+POM_DESCRIPTION=Lints rules for Paparazzi previews
+POM_PACKAGING=jar


### PR DESCRIPTION
```
  Invalid POM: /app/cash/paparazzi/paparazzi-preview-lints/2.0.0-alpha01/paparazzi-preview-lints-2.0.0-alpha01.pom: Project name missing, Project description missing
```

cc @jrodbx the latest 2.0.0-alpha01 failed to publish because of this missing file.

- https://github.com/cashapp/paparazzi/actions/runs/14476256191/job/40602519715

It probably did not fail sooner because SNAPSHOT builds requirements are not as strict as proper release builds.