### PR TITLE
Don't validate APIs for test projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,14 @@ buildscript {
 
 apply plugin: 'binary-compatibility-validator'
 
+def testProjectPath = 'paparazzi-gradle-plugin/src/test/projects'.replace('/', File.separator)
+// These projects are imported in IDEA but we don't want to run the API validation on them.
+def testProjectNames = allprojects.findAll {
+  it.projectDir.path.contains(testProjectPath)
+}.collect { it.name }
+
 apiValidation {
-  ignoredProjects += ['sample']
+  ignoredProjects += ['sample'] + testProjectNames
 }
 
 subprojects {


### PR DESCRIPTION
Fixes

```
> Task :test-projects:build-class:apiCheck FAILED
Execution failed for task ':test-projects:build-class:apiCheck'.
> Expected file with API declarations 'paparazzi-gradle-plugin/src/test/projects/build-class/api/build-class.api' does not exist.
  Please ensure that ':apiDump' was executed in order to get an API dump to compare the build against
```