### PR TITLE
Add `Paparazzi(withExpectedActualLabels: Boolean = true)`

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -34,7 +34,8 @@ public class Paparazzi @JvmOverloads constructor(
   private val renderingMode: RenderingMode = RenderingMode.NORMAL,
   private val appCompatEnabled: Boolean = true,
   private val maxPercentDifference: Double = detectMaxPercentDifferenceDefault(),
-  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
+  private val withExpectedActualLabels: Boolean = true,
+  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference, withExpectedActualLabels),
   private val renderExtensions: Set<RenderExtension> = setOf(),
   private val supportsRtl: Boolean = false,
   private val showSystemUi: Boolean = false,
@@ -148,9 +149,12 @@ public class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    private fun determineHandler(
+      maxPercentDifference: Double,
+      withExpectedActualLabels: Boolean,
+    ): SnapshotHandler =
       if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference)
+        SnapshotVerifier(maxPercentDifference, withExpectedActualLabels)
       } else {
         HtmlReportWriter()
       }

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -26,6 +26,7 @@ import javax.imageio.ImageIO
 
 public class SnapshotVerifier @JvmOverloads constructor(
   private val maxPercentDifference: Double,
+  private val withExpectedActualLabels: Boolean = true,
   rootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
 ) : SnapshotHandler {
   private val imagesDirectory: File = File(rootDirectory, "images")
@@ -73,7 +74,8 @@ public class SnapshotVerifier @JvmOverloads constructor(
           image = image,
           goldenImage = goldenImage,
           maxPercentDifferent = maxPercentDifference,
-          failureDir = failureDir
+          failureDir = failureDir,
+          withExpectedActualLabels = withExpectedActualLabels,
         )
       }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -50,7 +50,8 @@ internal object ImageUtils {
     goldenImage: BufferedImage,
     image: BufferedImage,
     maxPercentDifferent: Double,
-    failureDir: File
+    failureDir: File,
+    withExpectedActualLabels: Boolean = false,
   ) {
     val (deltaImage, percentDifference) = compareImages(goldenImage, image)
 
@@ -73,31 +74,33 @@ internal object ImageUtils {
     }
 
     if (error != null) {
-      val deltaWidth = max(goldenImageWidth, imageWidth)
-      if (deltaWidth > 80) {
-        /**
-         * AWT uses native text rendering under the hood, making it extremely difficult to get
-         * consistent cross-platform label text rendering, due to antialiasing, etc. This can
-         * result in false negatives when comparing delta images.
-         *
-         * As a workaround, we instead use text images pre-rendered on MacOSX 14 with the default
-         * font=Dialog, size=12 and composite them into the delta image here.
-         *
-         * We use that original font's ascent to offset the labels, which is determined by running
-         * the following on MacOSX 14:
-         *
-         * ```
-         * val z = BufferedImage(1, 1, TYPE_INT_ARGB)
-         * val MAC_OSX_FONT_DIALOG_SIZE_12_ASCENT = z.graphics.fontMetrics.ascent
-         * ```
-         */
-        val g = deltaImage.graphics
-        val yOffset = 20 - MAC_OSX_FONT_DIALOG_SIZE_12_ASCENT
-        val myClassLoader = ImageUtils::class.java.classLoader!!
-        val expectedLabel = ImageIO.read(myClassLoader.getResourceAsStream("expected_label.png"))
-        g.drawImage(expectedLabel, 10, yOffset, null)
-        val actualLabel = ImageIO.read(myClassLoader.getResourceAsStream("actual_label.png"))
-        g.drawImage(actualLabel, goldenImageWidth + deltaWidth + 10, yOffset, null)
+      if (withExpectedActualLabels) {
+        val deltaWidth = max(goldenImageWidth, imageWidth)
+        if (deltaWidth > 80) {
+          /**
+           * AWT uses native text rendering under the hood, making it extremely difficult to get
+           * consistent cross-platform label text rendering, due to antialiasing, etc. This can
+           * result in false negatives when comparing delta images.
+           *
+           * As a workaround, we instead use text images pre-rendered on MacOSX 14 with the default
+           * font=Dialog, size=12 and composite them into the delta image here.
+           *
+           * We use that original font's ascent to offset the labels, which is determined by running
+           * the following on MacOSX 14:
+           *
+           * ```
+           * val z = BufferedImage(1, 1, TYPE_INT_ARGB)
+           * val MAC_OSX_FONT_DIALOG_SIZE_12_ASCENT = z.graphics.fontMetrics.ascent
+           * ```
+           */
+          val g = deltaImage.graphics
+          val yOffset = 20 - MAC_OSX_FONT_DIALOG_SIZE_12_ASCENT
+          val myClassLoader = ImageUtils::class.java.classLoader!!
+          val expectedLabel = ImageIO.read(myClassLoader.getResourceAsStream("expected_label.png"))
+          g.drawImage(expectedLabel, 10, yOffset, null)
+          val actualLabel = ImageIO.read(myClassLoader.getResourceAsStream("actual_label.png"))
+          g.drawImage(actualLabel, goldenImageWidth + deltaWidth + 10, yOffset, null)
+        }
       }
 
       val deltaOutput = File(failureDir, "delta-$imageName")


### PR DESCRIPTION
to allow removal of `actual` & `expected` labels in delta images. Keeping the previous behavior as default value.

Closes #1691