### PR TITLE
Disable unnecessary `release` build type in `sample` module

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,13 @@ android {
   }
 }
 
+// Disable unnecessary release build type
+androidComponents {
+  beforeVariants(selector().all()) {
+    enabled = buildType == "debug"
+  }
+}
+
 dependencies {
   implementation libs.composeUi.material
   implementation libs.composeUi.material.icons
@@ -45,5 +52,5 @@ tasks.withType(com.diffplug.gradle.spotless.SpotlessTask).configureEach {
 
 // Verify screenshots as part of the standard check process
 tasks.named("check").configure {
-  dependsOn("verifyPaparazziDebug")
+  dependsOn("verifyPaparazzi")
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,9 +24,7 @@ android {
 
 // Disable unnecessary release build type
 androidComponents {
-  beforeVariants(selector().all()) {
-    enabled = buildType == "debug"
-  }
+  beforeVariants(selector().withBuildType("release")) { enable = false }
 }
 
 dependencies {


### PR DESCRIPTION
It will save around 2 minutes on each CI build (3 * OS + 3 * JDK).

Here is an example of a run on the master branch: https://scans.gradle.com/s/4oc5b3rznajmi/timeline?name=release&project=:sample&sort=longest