### PR TITLE
Add ability to avoid recording if difference threshold not exceeded

### DIFF
--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -95,7 +95,8 @@ public final class app/cash/paparazzi/HtmlReportWriter : app/cash/paparazzi/Snap
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;Ljava/io/File;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
 }
@@ -115,13 +116,14 @@ public final class app/cash/paparazzi/Paparazzi : org/junit/rules/TestRule {
 	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;)V
 	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;Z)V
 	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZD)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;Z)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZ)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZ)V
-	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZ)V
-	public synthetic fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZ)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;Z)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZ)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZ)V
+	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZ)V
+	public synthetic fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDZLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public final fun close ()V
 	public final fun getContext ()Landroid/content/Context;

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   layoutlibRuntime variantOf(libs.tools.layoutlib.runtime) { classifier(osLabel) }
   layoutlibResources libs.tools.layoutlib.resources
 
+  testImplementation libs.testParameterInjector
   testImplementation libs.truth
 }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -17,6 +17,7 @@ package app.cash.paparazzi
 
 import app.cash.paparazzi.SnapshotHandler.FrameHandler
 import app.cash.paparazzi.internal.PaparazziJson
+import app.cash.paparazzi.internal.RecordOverwritePolicy.shouldOverwriteGoldenFile
 import app.cash.paparazzi.internal.apng.ApngWriter
 import com.google.common.base.CharMatcher
 import com.google.common.io.Files
@@ -61,7 +62,8 @@ import java.util.UUID
 public class HtmlReportWriter @JvmOverloads constructor(
   private val runName: String = defaultRunName(),
   private val rootDirectory: File = File(System.getProperty("paparazzi.report.dir")),
-  snapshotRootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
+  snapshotRootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir")),
+  private val maxPercentDifference: Double? = null
 ) : SnapshotHandler {
   private val runsDirectory: File = File(rootDirectory, "runs")
   private val imagesDirectory: File = File(rootDirectory, "images")
@@ -106,7 +108,9 @@ public class HtmlReportWriter @JvmOverloads constructor(
 
         if (isRecording) {
           val goldenFile = File(goldenDir, snapshot.toFileName("_", "png"))
-          snapshotFile.copyTo(target = goldenFile, overwrite = true)
+          if (shouldOverwriteGoldenFile(goldenFile, snapshotFile, fps, maxPercentDifference)) {
+            snapshotFile.copyTo(target = goldenFile, overwrite = true)
+          }
         }
 
         shots += snapshot.copy(file = snapshotFile.toJsonPath())

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -34,7 +34,11 @@ public class Paparazzi @JvmOverloads constructor(
   private val renderingMode: RenderingMode = RenderingMode.NORMAL,
   private val appCompatEnabled: Boolean = true,
   private val maxPercentDifference: Double = detectMaxPercentDifferenceDefault(),
-  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
+  private val useMaxPercentDifferenceForRecord: Boolean = false,
+  private val snapshotHandler: SnapshotHandler = determineHandler(
+    maxPercentDifference,
+    useMaxPercentDifferenceForRecord
+  ),
   private val renderExtensions: Set<RenderExtension> = setOf(),
   private val supportsRtl: Boolean = false,
   private val showSystemUi: Boolean = false,
@@ -148,11 +152,16 @@ public class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    private fun determineHandler(
+      maxPercentDifference: Double,
+      useMaxPercentDifferenceForRecord: Boolean
+    ): SnapshotHandler =
       if (isVerifying) {
         SnapshotVerifier(maxPercentDifference)
       } else {
-        HtmlReportWriter()
+        HtmlReportWriter(
+          maxPercentDifference = maxPercentDifference.takeIf { useMaxPercentDifferenceForRecord }
+        )
       }
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/RecordOverwritePolicy.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/RecordOverwritePolicy.kt
@@ -1,0 +1,84 @@
+package app.cash.paparazzi.internal
+
+import app.cash.paparazzi.internal.apng.ApngReader
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.io.File
+import javax.imageio.ImageIO
+
+internal object RecordOverwritePolicy {
+
+  internal fun shouldOverwriteGoldenFile(
+    goldenFile: File,
+    snapshotFile: File,
+    fps: Int,
+    maxPercentDifference: Double?,
+    fileSystem: FileSystem = FileSystem.SYSTEM
+  ): Boolean {
+    return if (maxPercentDifference != null && goldenFile.exists()) {
+      if (fps == -1) {
+        shouldOverwriteGoldenImageFile(goldenFile, snapshotFile, maxPercentDifference)
+      } else {
+        shouldOverwriteGoldenVideoFile(goldenFile, snapshotFile, maxPercentDifference, fileSystem)
+      }
+    } else {
+      true
+    }
+  }
+
+  private fun shouldOverwriteGoldenImageFile(
+    goldenFile: File,
+    snapshotFile: File,
+    maxPercentDifference: Double
+  ): Boolean {
+    val goldenImage = ImageIO.read(goldenFile)
+    val snapshotImage = ImageIO.read(snapshotFile)
+    val (_, percentDifference) = ImageUtils.compareImages(
+      goldenImage = goldenImage,
+      image = snapshotImage
+    )
+    return percentDifference > maxPercentDifference
+  }
+
+  private fun shouldOverwriteGoldenVideoFile(
+    goldenFile: File,
+    snapshotFile: File,
+    maxPercentDifference: Double,
+    fileSystem: FileSystem
+  ): Boolean {
+    ApngReader(fileSystem.openReadOnly(goldenFile.path.toPath())).use { goldenApngReader ->
+      ApngReader(fileSystem.openReadOnly(snapshotFile.path.toPath())).use { snapshotApngReader ->
+        return anyFrameDifferenceExceedsThreshold(
+          goldenApngReader = goldenApngReader,
+          snapshotApngReader = snapshotApngReader,
+          maxPercentDifference = maxPercentDifference
+        )
+      }
+    }
+  }
+
+  private fun anyFrameDifferenceExceedsThreshold(
+    goldenApngReader: ApngReader,
+    snapshotApngReader: ApngReader,
+    maxPercentDifference: Double
+  ): Boolean {
+    if (goldenApngReader.frameCount != snapshotApngReader.frameCount) {
+      return true
+    }
+    while (!goldenApngReader.isFinished() || !snapshotApngReader.isFinished()) {
+      val goldenFrame = goldenApngReader.readNextFrame()
+      val snapshotFrame = snapshotApngReader.readNextFrame()
+      if (goldenFrame == null || snapshotFrame == null) {
+        return true
+      }
+      val (_, percentDifference) = ImageUtils.compareImages(
+        goldenImage = goldenFrame,
+        image = snapshotFrame
+      )
+      if (percentDifference > maxPercentDifference) {
+        return true
+      }
+    }
+    return false
+  }
+}


### PR DESCRIPTION
Added a boolean flag to use `maxPercentDifference` for `recordPaparazzi` command.
Not sure if it should be a boolean flag or a separate double type to set a different `maxPercentDifference` for record only.

Also, uncertain about API compatibility with the changes I introduced.

The problem with different operating systems that I described [here](https://github.com/cashapp/paparazzi/issues/1951#issuecomment-2976978049) is no longer reproducible in either direction (Mac/Windows). For AGP updates or other things that could have caused problems, this fix should work as well.

Closes #1951 