### PR TITLE
Pull diff image metadata logic out of reporting renderer

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/DiffImage.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/DiffImage.kt
@@ -2,9 +2,7 @@ package app.cash.paparazzi.gradle.reporting
 
 internal data class DiffImage(
   val path: String, // TODO relative path
-  val base64EncodedImage: String,
-  val testClass: String,
-  val testMethod: String
+  val base64EncodedImage: String
 ) {
   val text: String
     get() = "Error displaying image for $path"

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/PaparazziTestReporter.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/PaparazziTestReporter.kt
@@ -1,12 +1,10 @@
 package app.cash.paparazzi.gradle.reporting
 
 import org.gradle.api.GradleException
-import org.gradle.api.file.Directory
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.api.internal.tasks.testing.report.TestReporter
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.internal.html.SimpleHtmlWriter
 import org.gradle.internal.operations.BuildOperationContext
@@ -24,8 +22,7 @@ import kotlin.time.measureTime
 internal class PaparazziTestReporter(
   private val buildOperationRunner: BuildOperationRunner,
   private val buildOperationExecutor: BuildOperationExecutor,
-  private val isVerifyRun: Provider<Boolean>,
-  private val failureSnapshotDir: Provider<Directory>
+  private val diffRegistryFactory: () -> Map<Pair<String, String>, DiffImage>
 ) : TestReporter {
   init {
     // Rather than copy SimpleHtmlWriter, let's append our desired tags to the allowlist
@@ -105,8 +102,7 @@ internal class PaparazziTestReporter(
                       classResults,
                       ClassPageRenderer(
                         resultsProvider,
-                        isVerifyRun.get(),
-                        failureSnapshotDir.get().asFile
+                        diffRegistryFactory
                       ),
                       output
                     )


### PR DESCRIPTION
Full context here: https://github.com/gradle/gradle/pull/32672#discussion_r2151320515

Gradle 8.13 introduced a new TestEventReporting API and in poking around, I wondered whether there might be an opportunity for a lighter API to inject test result metadata.

Regardless of whether Gradle considers the suggestion or not, it looks like breaking changes will come "soon", so this PR opportunistically pulls out the logic we currently use to decide + provide the image diff metadata to the rendering logic.