### PR TITLE
Allow differ to be configured

### DIFF
--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -213,9 +213,9 @@ public final class app/cash/paparazzi/SnapshotHandlerKt {
 
 public final class app/cash/paparazzi/SnapshotVerifier : app/cash/paparazzi/SnapshotHandler {
 	public static final field $stable I
-	public fun <init> (D)V
-	public fun <init> (DLjava/io/File;)V
-	public synthetic fun <init> (DLjava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (DLapp/cash/paparazzi/internal/Differ;)V
+	public fun <init> (DLjava/io/File;Lapp/cash/paparazzi/internal/Differ;)V
+	public synthetic fun <init> (DLjava/io/File;Lapp/cash/paparazzi/internal/Differ;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
 }
@@ -237,5 +237,33 @@ public final class app/cash/paparazzi/accessibility/AccessibilityRenderExtension
 	public static final field $stable I
 	public fun <init> ()V
 	public fun renderView (Landroid/view/View;)Landroid/view/View;
+}
+
+public abstract interface class app/cash/paparazzi/internal/Differ {
+	public abstract fun compare (Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;)Lapp/cash/paparazzi/internal/Differ$DiffResult;
+}
+
+public abstract interface class app/cash/paparazzi/internal/Differ$DiffResult {
+}
+
+public final class app/cash/paparazzi/internal/Differ$DiffResult$Different : app/cash/paparazzi/internal/Differ$DiffResult {
+	public static final field $stable I
+	public fun <init> (Ljava/awt/image/BufferedImage;FJ)V
+	public final fun getDelta ()Ljava/awt/image/BufferedImage;
+	public final fun getNumDifferentPixels ()J
+	public final fun getPercentDifference ()F
+}
+
+public final class app/cash/paparazzi/internal/Differ$DiffResult$Identical : app/cash/paparazzi/internal/Differ$DiffResult {
+	public static final field $stable I
+	public fun <init> (Ljava/awt/image/BufferedImage;)V
+	public final fun getDelta ()Ljava/awt/image/BufferedImage;
+}
+
+public final class app/cash/paparazzi/internal/Differ$DiffResult$Similar : app/cash/paparazzi/internal/Differ$DiffResult {
+	public static final field $stable I
+	public fun <init> (Ljava/awt/image/BufferedImage;J)V
+	public final fun getDelta ()Ljava/awt/image/BufferedImage;
+	public final fun getNumSimilarPixels ()J
 }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -16,6 +16,7 @@
 package app.cash.paparazzi
 
 import app.cash.paparazzi.SnapshotHandler.FrameHandler
+import app.cash.paparazzi.internal.Differ
 import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.apng.ApngVerifier
 import okio.Path.Companion.toOkioPath
@@ -26,7 +27,8 @@ import javax.imageio.ImageIO
 
 public class SnapshotVerifier @JvmOverloads constructor(
   private val maxPercentDifference: Double,
-  rootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
+  rootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir")),
+  private val differ: Differ
 ) : SnapshotHandler {
   private val imagesDirectory: File = File(rootDirectory, "images")
   private val videosDirectory: File = File(rootDirectory, "videos")
@@ -42,7 +44,7 @@ public class SnapshotVerifier @JvmOverloads constructor(
       val expected = File(snapshotDir, snapshot.toFileName(extension = "png"))
       val failurePath = File(failureDir, "delta-${expected.name}").toOkioPath()
       val pngVerifier: ApngVerifier? = if (fps != -1) {
-        ApngVerifier(expected.toOkioPath(), failurePath, fps, frameCount, maxPercentDifference)
+        ApngVerifier(expected.toOkioPath(), failurePath, fps, frameCount, maxPercentDifference, differ = differ)
       } else {
         null
       }
@@ -73,7 +75,8 @@ public class SnapshotVerifier @JvmOverloads constructor(
           image = image,
           goldenImage = goldenImage,
           maxPercentDifferent = maxPercentDifference,
-          failureDir = failureDir
+          failureDir = failureDir,
+          differ = differ
         )
       }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/Differ.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/Differ.kt
@@ -2,23 +2,23 @@ package app.cash.paparazzi.internal
 
 import java.awt.image.BufferedImage
 
-internal interface Differ {
-  fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult
+public sealed interface Differ {
+  public fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult
 
-  sealed interface DiffResult {
-    data class Identical(
-      val delta: BufferedImage
+  public sealed interface DiffResult {
+    public class Identical(
+      public val delta: BufferedImage
     ) : DiffResult
 
-    data class Similar(
-      val delta: BufferedImage,
-      val numSimilarPixels: Long
+    public class Similar(
+      public val delta: BufferedImage,
+      public val numSimilarPixels: Long
     ) : DiffResult
 
-    data class Different(
-      val delta: BufferedImage,
-      val percentDifference: Float,
-      val numDifferentPixels: Long
+    public class Different(
+      public val delta: BufferedImage,
+      public val percentDifference: Float,
+      public val numDifferentPixels: Long
     ) : DiffResult
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -50,9 +50,10 @@ internal object ImageUtils {
     goldenImage: BufferedImage,
     image: BufferedImage,
     maxPercentDifferent: Double,
-    failureDir: File
+    failureDir: File,
+    differ: Differ
   ) {
-    val (deltaImage, percentDifference) = compareImages(goldenImage, image)
+    val (deltaImage, percentDifference) = compareImages(goldenImage, image, differ)
 
     val goldenImageWidth = goldenImage.width
     val goldenImageHeight = goldenImage.height
@@ -126,7 +127,7 @@ internal object ImageUtils {
   }
 
   @Throws(IOException::class)
-  fun compareImages(goldenImage: BufferedImage, image: BufferedImage): Pair<BufferedImage, Float> {
+  fun compareImages(goldenImage: BufferedImage, image: BufferedImage, differ: Differ): Pair<BufferedImage, Float> {
     var goldenImage = goldenImage
     if (goldenImage.type != TYPE_INT_ARGB) {
       val temp = BufferedImage(goldenImage.width, goldenImage.height, TYPE_INT_ARGB)
@@ -137,7 +138,6 @@ internal object ImageUtils {
       throw IllegalStateException("expected:<$TYPE_INT_ARGB> but was:<${goldenImage.type}>")
     }
 
-    val differ: Differ = OffByTwo
     differ.compare(goldenImage, image).let { result ->
       return when (result) {
         is Identical -> result.delta to 0f

--- a/paparazzi/src/test/java/app/cash/paparazzi/RenderExtensionTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/RenderExtensionTest.kt
@@ -9,6 +9,7 @@ import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
+import app.cash.paparazzi.internal.OffByTwo
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,7 +17,7 @@ class RenderExtensionTest {
   @get:Rule
   val paparazzi = Paparazzi(
     deviceConfig = DeviceConfig.NEXUS_5,
-    snapshotHandler = SnapshotVerifier(maxPercentDifference = 0.01),
+    snapshotHandler = SnapshotVerifier(maxPercentDifference = 0.01, differ = OffByTwo),
     renderExtensions = setOf(
       WrappedRenderExtension(Color.DKGRAY),
       WrappedRenderExtension(Color.RED),

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtensionTest.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.SnapshotVerifier
+import app.cash.paparazzi.internal.OffByTwo
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,7 +22,7 @@ class AccessibilityRenderExtensionTest {
   @get:Rule
   val paparazzi = Paparazzi(
     deviceConfig = DeviceConfig.NEXUS_5,
-    snapshotHandler = SnapshotVerifier(maxPercentDifference = 0.01),
+    snapshotHandler = SnapshotVerifier(maxPercentDifference = 0.01, differ = OffByTwo),
     renderExtensions = setOf(AccessibilityRenderExtension())
   )
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
@@ -17,6 +17,7 @@
 package app.cash.paparazzi.internal.apng
 
 import app.cash.paparazzi.internal.ImageUtils
+import app.cash.paparazzi.internal.OffByTwo
 import com.google.common.truth.Truth.assertThat
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -46,7 +47,8 @@ class ApngReaderTest {
         goldenImage = expectedImage,
         image = actualImage,
         maxPercentDifferent = 0.0,
-        failureDir = tempDir.newFolder()
+        failureDir = tempDir.newFolder(),
+        differ = OffByTwo
       )
     }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
@@ -1,6 +1,7 @@
 package app.cash.paparazzi.internal.apng
 
 import app.cash.paparazzi.internal.ImageUtils.compareImages
+import app.cash.paparazzi.internal.OffByTwo
 import app.cash.paparazzi.internal.apng.PngTestUtils.createImage
 import com.google.common.truth.Truth.assertThat
 import okio.FileSystem
@@ -51,7 +52,8 @@ class ApngVerifierTest {
       fps = 1,
       frameCount = 3,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(secondFrame)
@@ -75,7 +77,8 @@ class ApngVerifierTest {
       fps = 3,
       frameCount = 3,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(secondFrame)
@@ -110,7 +113,8 @@ class ApngVerifierTest {
       fps = 3,
       frameCount = 3,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(secondFrame)
@@ -144,7 +148,8 @@ class ApngVerifierTest {
       fps = 3,
       frameCount = 3,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(firstFrame)
@@ -182,7 +187,8 @@ class ApngVerifierTest {
       fps = 1,
       frameCount = 3,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(thirdFrame)
       it.verifyFrame(secondFrame)
@@ -216,7 +222,8 @@ class ApngVerifierTest {
       fps = 1,
       frameCount = 5,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(secondFrame)
@@ -253,7 +260,8 @@ class ApngVerifierTest {
       fps = 1,
       frameCount = 2,
       maxPercentDifference = 0.01,
-      withErrorText = false
+      withErrorText = false,
+      differ = OffByTwo
     ).use {
       it.verifyFrame(firstFrame)
       it.verifyFrame(secondFrame)
@@ -278,7 +286,7 @@ class ApngVerifierTest {
     ApngReader(FileSystem.SYSTEM.openReadOnly(actualPath)).use { actual ->
       ApngReader(FileSystem.SYSTEM.openReadOnly(expectedPath)).use { expected ->
         while (!expected.isFinished()) {
-          val (_, percentDiff) = compareImages(expected.readNextFrame()!!, actual.readNextFrame()!!)
+          val (_, percentDiff) = compareImages(expected.readNextFrame()!!, actual.readNextFrame()!!, OffByTwo)
           assertThat(percentDiff).isEqualTo(0F)
         }
         assertThat(actual.isFinished()).isTrue()


### PR DESCRIPTION
Highlights
* Differ becomes a sealed interface
* Test rule checks for new gradle property ("app.cash.paparazzi.differ") defaulting to OffByTwo