### PR TITLE
Fix missing differ parameter in Paparazzi secondary constructor

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -56,7 +56,7 @@ public class Paparazzi @JvmOverloads constructor(
     renderingMode: RenderingMode = RenderingMode.NORMAL,
     appCompatEnabled: Boolean = true,
     maxPercentDifference: Double = detectMaxPercentDifferenceDefault(),
-    snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
+    snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference, differ),
     renderExtensions: Set<RenderExtension> = setOf(),
     supportsRtl: Boolean = false,
     showSystemUi: Boolean = false,


### PR DESCRIPTION
Fixes a compilation issue on master when the secondary constructor was added in [this PR](https://github.com/cashapp/paparazzi/pull/1997).