### PR TITLE
Add missing `gradle/actions/setup-gradle` in GHA workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
 
       - name: Run All Tests
         run: ./gradlew check
@@ -70,6 +68,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Publish Artifacts
         run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Publish Artifacts
         run: ./gradlew publishMavenPublicationToMavenCentralRepository paparazzi-gradle-plugin:publishAllPublicationsToMavenCentralRepository
         env:


### PR DESCRIPTION
to optimize CI build times (gradle download/unzip, and overall build cache) See this job for instance: https://github.com/cashapp/paparazzi/actions/runs/15979693741/job/45071335392


And remove `validate-wrappers: true` option that is already the default value:
https://github.com/gradle/actions/blob/ac638b010cf58a27ee6c972d7336334ccaf61c96/setup-gradle/action.yml#L192-L197