### PR TITLE
Fix compose accessibility ordering

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityRenderExtension.kt
@@ -216,15 +216,6 @@ public class AccessibilityRenderExtension : RenderExtension {
         )
       )
     }
-
-    children.forEach {
-      it.processAccessibleChildren(
-        processElement = processElement,
-        locationOnScreen = locationOnScreen,
-        viewBounds = viewBounds,
-        unmergedNodes = unmergedNodes
-      )
-    }
   }
 
   private fun SemanticsNode.findAllUnmergedNodes(): List<SemanticsNode> {


### PR DESCRIPTION
It seems there was a bug introduced in https://github.com/cashapp/paparazzi/commit/29cfca907e2e23526a66cb378f804e3c54536ca1 that broke the compose accessibility ordering support. It was sadly not caught on CI as it looks like the `paparazzi-gradle-plugin:test` task was _always_ being pulled from the cache. As a follow up to this change I will post a PR to resolve that issue now that this change fixes the failing test case for `AccessibilityRenderingTest`.