### PR TITLE
Do not cache paparazzi-gradle-plugin:test

### DIFF
--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -63,6 +63,7 @@ buildConfig {
 
 tasks.withType(Test).configureEach {
   dependsOn(':paparazzi:publishMavenPublicationToProjectLocalMavenRepository')
+  outputs.cacheIf { false }
 }
 
 // When cleaning this project, we also want to clean the test projects.


### PR DESCRIPTION
I noticed that `paparazzi-gradle-plugin:test` was always being pulled `FROM_CACHE` and never actually run in CI, no matter what files were updated. This change causes it to always be run and never cached. If anyone has ideas for a better fix here to resolve the root cause that might have been resulting in that task not being cached I'm open to changing this!