### PR TITLE
Register missing task inputs for Develocity test distribution

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -243,6 +243,12 @@ public class PaparazziPlugin @Inject constructor(
         test.inputs.files(layoutlibNativeRuntimeFileCollection)
           .withPropertyName("paparazzi.nativeRuntime")
           .withPathSensitivity(PathSensitivity.NONE)
+        test.inputs.files(layoutlibResourcesFileCollection)
+          .withPropertyName("paparazzi.resources")
+          .withPathSensitivity(PathSensitivity.NONE)
+        test.inputs.files(writeResourcesTask.flatMap { it.paparazziResources.asFile })
+          .withPropertyName("paparazzi.test.resources")
+          .withPathSensitivity(PathSensitivity.NONE)
 
         test.inputs.dir(
           isVerifyRun.flatMap {


### PR DESCRIPTION
## Summary
Fixes #1790

This PR registers two missing task inputs that were causing failures when using Develocity's test distribution feature:

1. **paparazzi.test.resources** - The output file from `writeResourcesTask` that's used as a system property
2. **paparazzi.resources** - The `layoutlibResourcesFileCollection` used in system properties

Both are now properly registered as task inputs with `PathSensitivity.NONE`, ensuring these files are uploaded when using Develocity test distribution.