### PR TITLE
Configure default differ when none is specified

### DIFF
--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -119,8 +119,9 @@ public final class app/cash/paparazzi/Flags {
 
 public final class app/cash/paparazzi/HtmlReportWriter : app/cash/paparazzi/SnapshotHandler {
 	public static final field $stable I
-	public fun <init> (DLapp/cash/paparazzi/Differ;)V
-	public fun <init> (Ljava/lang/String;DLapp/cash/paparazzi/Differ;)V
+	public fun <init> (D)V
+	public fun <init> (Ljava/lang/String;D)V
+	public fun <init> (Ljava/lang/String;Ljava/io/File;D)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -64,7 +64,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
   private val runName: String = defaultRunName(),
   private val rootDirectory: File = File(System.getProperty("paparazzi.report.dir")),
   private val maxPercentDifference: Double,
-  private val differ: Differ,
+  private val differ: Differ = determineDiffer(),
   snapshotRootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
 ) : SnapshotHandler {
   private val runsDirectory: File = File(rootDirectory, "runs")

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -21,13 +21,6 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.compose.runtime.Composable
-import app.cash.paparazzi.Differ
-import app.cash.paparazzi.internal.differs.DeltaE2000
-import app.cash.paparazzi.internal.differs.Flip
-import app.cash.paparazzi.internal.differs.Mssim
-import app.cash.paparazzi.internal.differs.OffByTwo
-import app.cash.paparazzi.internal.differs.PixelPerfect
-import app.cash.paparazzi.internal.differs.Sift
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -41,7 +34,7 @@ public class Paparazzi @JvmOverloads constructor(
   private val renderingMode: RenderingMode = RenderingMode.NORMAL,
   private val appCompatEnabled: Boolean = true,
   private val maxPercentDifference: Double = detectMaxPercentDifferenceDefault(),
-  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference, differ),
+  private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
   private val renderExtensions: Set<RenderExtension> = setOf(),
   private val supportsRtl: Boolean = false,
   private val showSystemUi: Boolean = false,
@@ -60,7 +53,7 @@ public class Paparazzi @JvmOverloads constructor(
     renderingMode: RenderingMode = RenderingMode.NORMAL,
     appCompatEnabled: Boolean = true,
     maxPercentDifference: Double = detectMaxPercentDifferenceDefault(),
-    snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference, differ),
+    snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference),
     renderExtensions: Set<RenderExtension> = setOf(),
     supportsRtl: Boolean = false,
     showSystemUi: Boolean = false,
@@ -188,25 +181,11 @@ public class Paparazzi @JvmOverloads constructor(
     private val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private val differ: Differ =
-      System.getProperty("app.cash.paparazzi.differ")?.lowercase().let { differ ->
-        when (differ) {
-          "offbytwo" -> OffByTwo
-          "pixelperfect" -> PixelPerfect
-          "mssim" -> Mssim
-          "sift" -> Sift
-          "flip" -> Flip
-          "de2000" -> DeltaE2000
-          null, "", "default" -> OffByTwo
-          else -> error("Unknown differ type '$differ'.")
-        }
-      }
-
-    private fun determineHandler(maxPercentDifference: Double, differ: Differ): SnapshotHandler =
+    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
       if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference, differ = differ)
+        SnapshotVerifier(maxPercentDifference)
       } else {
-        HtmlReportWriter(maxPercentDifference = maxPercentDifference, differ = differ)
+        HtmlReportWriter(maxPercentDifference = maxPercentDifference)
       }
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -19,8 +19,12 @@ import app.cash.paparazzi.Differ
 import app.cash.paparazzi.SnapshotHandler.FrameHandler
 import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.apng.ApngVerifier
+import app.cash.paparazzi.internal.differs.DeltaE2000
+import app.cash.paparazzi.internal.differs.Flip
+import app.cash.paparazzi.internal.differs.Mssim
 import app.cash.paparazzi.internal.differs.OffByTwo
 import app.cash.paparazzi.internal.differs.PixelPerfect
+import app.cash.paparazzi.internal.differs.Sift
 import okio.Path.Companion.toOkioPath
 import java.awt.image.BufferedImage
 import java.awt.image.BufferedImage.TYPE_INT_ARGB
@@ -106,15 +110,15 @@ public class SnapshotVerifier @JvmOverloads constructor(
   }
 }
 
-/**
- * Convenience method to select a built-in differ via system property.
- * This allows selection of built-in differs without requiring direct access to internal implementations.
- */
-private fun determineDiffer() =
+internal fun determineDiffer() =
   System.getProperty("app.cash.paparazzi.differ")?.lowercase().let { differ ->
     when (differ) {
       "offbytwo" -> OffByTwo
       "pixelperfect" -> PixelPerfect
+      "mssim" -> Mssim
+      "sift" -> Sift
+      "flip" -> Flip
+      "de2000" -> DeltaE2000
       null, "", "default" -> OffByTwo
       else -> error("Unknown differ type '$differ'.")
     }


### PR DESCRIPTION
Differs are internal classes, but copying them to provide one for the expected argument of public SnapshotVerifier isn't ideal. 
Instead, read a system property and select from default if no argument is present for differ. 