### PR TITLE
Fix publish java version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5


### PR DESCRIPTION
After update to layoutlib 16.0.x, it requires java 21 and publish workflow wasn't updated