### PR TITLE
Decouple KSP Renovate updates from KGP

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,6 @@
       automerge: false,
       matchPackageNames: [
         'org.jetbrains.kotlin:{/,}**',
-        'com.google.devtools.ksp{/,}**',
         'dev.drewhamilton.poko{/,}**',
       ],
     },


### PR DESCRIPTION
Since KSP 2.3 it is no longer released together with KGP. They can be independently updated.