### PR TITLE
Add accessibility traversal neighbor metadata

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElement.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElement.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.text.LinkAnnotation
 internal data class AccessibilityElement(
   val id: String,
   val displayBounds: Rect,
+  val beforeElementId: String? = null,
+  val afterElementId: String? = null,
   val stateDescription: String? = null,
   val selected: String? = null,
   val toggleableState: String? = null,

--- a/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElementCollector.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElementCollector.kt
@@ -51,7 +51,26 @@ internal class AccessibilityElementCollector {
   }
 
   internal fun withTraversalNeighbors(elements: Collection<AccessibilityElement>): Set<AccessibilityElement> {
-    val orderedElements = elements.toList()
+    val duplicateIds = elements
+      .groupingBy { it.id }
+      .eachCount()
+      .filterValues { it > 1 }
+      .keys
+    val usedIds = elements.mapTo(mutableSetOf()) { it.id }
+    val nextSuffixById = mutableMapOf<String, Int>()
+    val orderedElements = elements.map { element ->
+      if (element.id !in duplicateIds) {
+        element
+      } else {
+        var suffix = nextSuffixById.getOrDefault(element.id, 1)
+        var uniqueId: String
+        do {
+          uniqueId = "${element.id}#${suffix++}"
+        } while (!usedIds.add(uniqueId))
+        nextSuffixById[element.id] = suffix
+        element.copy(id = uniqueId)
+      }
+    }
 
     return orderedElements
       .mapIndexed { index, element ->

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorSnapshotTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorSnapshotTest.kt
@@ -1,0 +1,102 @@
+package app.cash.paparazzi.accessibility
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver.OnPreDrawListener
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.RenderExtension
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class AccessibilityElementCollectorSnapshotTest {
+  private var collectedElements: List<AccessibilityElement> = emptyList()
+  private val collectingRenderExtension = CollectingAccessibilityRenderExtension { elements ->
+    collectedElements = elements
+  }
+
+  @get:Rule
+  val paparazzi = Paparazzi(
+    renderExtensions = setOf(collectingRenderExtension)
+  )
+
+  @Test
+  fun `collect orders view traversal elements during snapshot processing`() {
+    val view = LinearLayout(paparazzi.context).apply {
+      orientation = LinearLayout.VERTICAL
+
+      val thirdTextView = TextView(context).apply {
+        id = View.generateViewId()
+        text = "Third"
+      }
+
+      val firstTextView = TextView(context).apply {
+        id = View.generateViewId()
+        text = "First"
+        accessibilityTraversalBefore = thirdTextView.id
+      }
+
+      val secondTextView = TextView(context).apply {
+        id = View.generateViewId()
+        text = "Second"
+        accessibilityTraversalBefore = thirdTextView.id
+      }
+
+      addView(thirdTextView)
+      addView(firstTextView)
+      addView(secondTextView)
+    }
+
+    paparazzi.snapshot(view)
+
+    val orderedElements = collectedElements
+      .filter { it.mainAccessibilityText in setOf("First", "Second", "Third") }
+
+    assertThat(orderedElements).hasSize(3)
+    assertThat(orderedElements.map { it.mainAccessibilityText })
+      .containsExactly("First", "Second", "Third")
+      .inOrder()
+
+    val firstElement = orderedElements[0]
+    val secondElement = orderedElements[1]
+    val thirdElement = orderedElements[2]
+
+    assertThat(firstElement.beforeElementId).isNull()
+    assertThat(firstElement.afterElementId).isEqualTo(secondElement.id)
+    assertThat(secondElement.beforeElementId).isEqualTo(firstElement.id)
+    assertThat(secondElement.afterElementId).isEqualTo(thirdElement.id)
+    assertThat(thirdElement.beforeElementId).isEqualTo(secondElement.id)
+    assertThat(thirdElement.afterElementId).isNull()
+  }
+}
+
+private class CollectingAccessibilityRenderExtension(
+  private val onElementsCollected: (List<AccessibilityElement>) -> Unit
+) : RenderExtension {
+  private val collector = AccessibilityElementCollector()
+
+  override fun renderView(contentView: View): View =
+    FrameLayout(contentView.context).apply {
+      layoutParams = ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT
+      )
+      addView(contentView)
+
+      viewTreeObserver.addOnPreDrawListener(object : OnPreDrawListener {
+        override fun onPreDraw(): Boolean {
+          viewTreeObserver.removeOnPreDrawListener(this)
+          onElementsCollected(
+            collector.collect(
+              rootView = this@apply,
+              windowManagerRootView = null
+            ).toList()
+          )
+          return true
+        }
+      })
+    }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorTest.kt
@@ -1,0 +1,40 @@
+package app.cash.paparazzi.accessibility
+
+import android.graphics.Rect
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AccessibilityElementCollectorTest {
+  private val collector = AccessibilityElementCollector()
+
+  @Test
+  fun `withTraversalNeighbors assigns before and after ids`() {
+    val first = AccessibilityElement(
+      id = "first",
+      displayBounds = Rect(),
+      mainAccessibilityText = "First"
+    )
+    val second = AccessibilityElement(
+      id = "second",
+      displayBounds = Rect(),
+      mainAccessibilityText = "Second"
+    )
+    val third = AccessibilityElement(
+      id = "third",
+      displayBounds = Rect(),
+      mainAccessibilityText = "Third"
+    )
+
+    val withNeighbors = collector
+      .withTraversalNeighbors(linkedSetOf(first, second, third))
+      .toList()
+
+    assertThat(withNeighbors.map { it.id }).containsExactly("first", "second", "third").inOrder()
+    assertThat(withNeighbors[0].beforeElementId).isNull()
+    assertThat(withNeighbors[0].afterElementId).isEqualTo("second")
+    assertThat(withNeighbors[1].beforeElementId).isEqualTo("first")
+    assertThat(withNeighbors[1].afterElementId).isEqualTo("third")
+    assertThat(withNeighbors[2].beforeElementId).isEqualTo("second")
+    assertThat(withNeighbors[2].afterElementId).isNull()
+  }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/accessibility/AccessibilityElementCollectorTest.kt
@@ -37,4 +37,26 @@ class AccessibilityElementCollectorTest {
     assertThat(withNeighbors[2].beforeElementId).isEqualTo("second")
     assertThat(withNeighbors[2].afterElementId).isNull()
   }
+
+  @Test
+  fun `withTraversalNeighbors assigns unique ids to elements with duplicate labels`() {
+    val first = AccessibilityElement(
+      id = "button",
+      displayBounds = Rect(0, 0, 10, 10),
+      mainAccessibilityText = "OK"
+    )
+    val second = AccessibilityElement(
+      id = "button",
+      displayBounds = Rect(0, 10, 10, 20),
+      mainAccessibilityText = "OK"
+    )
+
+    val withNeighbors = collector
+      .withTraversalNeighbors(listOf(first, second))
+      .toList()
+
+    assertThat(withNeighbors.map { it.id }).containsExactly("button#1", "button#2").inOrder()
+    assertThat(withNeighbors[0].afterElementId).isEqualTo("button#2")
+    assertThat(withNeighbors[1].beforeElementId).isEqualTo("button#1")
+  }
 }


### PR DESCRIPTION
This change adds before/after metadata to the `AccessibilityElement` for verifying the ordering of the accessibility hierarchy via the metadata of the elements. This is part of the work to contribute to the implementation of https://github.com/cashapp/paparazzi/issues/2239