### PR TITLE
Add plugin cleanup and integration coverage for artifact goldens

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -137,6 +137,7 @@ public class PaparazziPlugin @Inject constructor(
           val files = project.fileTree(snapshotOutputDir) { tree ->
             tree.include("**/*.png")
             tree.include("**/*.mov")
+            tree.include("artifacts/**")
           }
           it.delete(files)
         }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1595,6 +1595,41 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun accessibilityHierarchyArtifactsOptIn() {
+    val fixtureRoot = File("src/test/projects/accessibility-hierarchy-artifact")
+    val snapshotsDir = File(fixtureRoot, "src/test/snapshots").registerForDeletionOnExit()
+    val accessibilitySnapshot = File(
+      snapshotsDir,
+      "artifacts/accessibility-hierarchy/app.cash.paparazzi.plugin.test_AccessibilityHierarchyArtifactTest_record_accessibility.json"
+    )
+
+    val recordResult = gradleRunner
+      .withArguments("recordPaparazziDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+    with(recordResult.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+    assertThat(accessibilitySnapshot.exists()).isTrue()
+    assertThat(accessibilitySnapshot.readText()).contains("\"legendText\": \"Dialog overlay\"")
+    assertThat(accessibilitySnapshot.readText()).contains("\"legendText\": \"First\"")
+    assertThat(accessibilitySnapshot.readText()).contains("\"legendText\": \"Second\"")
+
+    val verifyResult = gradleRunner
+      .withArguments("verifyPaparazziDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+    with(verifyResult.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(SUCCESS)
+    }
+
+    gradleRunner
+      .withArguments("deletePaparazziSnapshots", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+    assertThat(accessibilitySnapshot.exists()).isFalse()
+  }
+
+  @Test
   fun snapshotReport() {
     val fixtureRoot = File("src/test/projects/report-snapshots")
     val testReportDir = File(fixtureRoot, "build/reports/tests/testDebugUnitTest/classes")

--- a/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'com.android.library'
+  id 'org.jetbrains.kotlin.plugin.compose'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace = 'app.cash.paparazzi.plugin.test'
+  compileSdk = libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk = libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  buildFeatures {
+    compose = true
+  }
+}
+
+dependencies {
+  implementation libs.composeUi.material3.android
+  implementation libs.composeUi.material
+  implementation libs.composeUi.material.icons
+  implementation libs.androidx.appcompat
+}

--- a/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+android.dependencyResolutionAtConfigurationTime.disallow=true
+app.cash.paparazzi.accessibility.hierarchy.artifacts.enabled=true

--- a/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/src/test/java/app/cash/paparazzi/plugin/test/AccessibilityHierarchyArtifactTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/accessibility-hierarchy-artifact/src/test/java/app/cash/paparazzi/plugin/test/AccessibilityHierarchyArtifactTest.kt
@@ -1,0 +1,32 @@
+package app.cash.paparazzi.plugin.test
+
+import android.app.Dialog
+import android.widget.LinearLayout
+import android.widget.TextView
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class AccessibilityHierarchyArtifactTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun record() {
+    val view = LinearLayout(paparazzi.context).apply {
+      orientation = LinearLayout.VERTICAL
+      addView(TextView(context).apply { text = "First" })
+      addView(TextView(context).apply { text = "Second" })
+    }
+
+    val dialog = Dialog(paparazzi.context).apply {
+      setContentView(TextView(context).apply { text = "Dialog overlay" })
+      show()
+    }
+    try {
+      paparazzi.snapshot(view, name = "accessibility")
+    } finally {
+      dialog.dismiss()
+    }
+  }
+}


### PR DESCRIPTION
Adds some plugin clean up and test code on top of https://github.com/cashapp/paparazzi/pull/2278

## Update (2026-08-04)

The plugin fixture exercises explicit property opt-in across record and verify, and snapshot cleanup includes generated artifacts. The focused integration test currently stops in `preparePaparazziDebugResources` because of an existing dependency-resolution NPE; the pre-existing `accessibilityRendering` control fixture fails at the same task with the same error before accessibility code runs. Plugin formatting passes.


## Update (2026-08-12)

Restacked on #2278. The plugin fixture now uses `Paparazzi()` directly, without `AccessibilityRenderExtension`, and records primary content together with a native dialog overlay. The integration test asserts that all three accessibility elements are present in the artifact. Plugin formatting passes; nested fixture execution remains blocked before the test runs by the previously documented `preparePaparazziDebugResources` dependency-resolution NPE.