### PR TITLE
Add paparazzi-junit4-reporting for Gradle test report image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New
+* New `paparazzi-junit4-reporting` artifact: a JUnit Platform engine wrapper (`paparazzi-vintage`) that enables Gradle test report image attachments for JUnit 4 tests (requires Gradle 9.4+; use `excludeEngines("junit-vintage")` alongside it)
+* New `FrameHandler.outputFile` property exposing the output file produced by each snapshot or gif
+
 ## [2.0.0-alpha04] - 2026-01-20
 
 As of this release, consumers must build on Java 21+ environments.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ class LaunchViewTest {
 }
 ```
 
+### Gradle test report attachments (Gradle 9.4+)
+
+Snapshot images are automatically attached to the Gradle HTML test report with no extra
+configuration required. The plugin adds the necessary dependencies and routes JUnit 4 tests
+through the `paparazzi-vintage` engine, which publishes each snapshot as a file attachment
+via `PaparazziReportingBridge`. Run the generated report task to view the results:
+
+```bash
+./gradlew :sample:testDebugUnitTestReport
+```
+
 See the [project website][paparazzi] for documentation and APIs.
 
 Supporting Multiple Test Frameworks

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,11 @@ trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version = "1.0.20200
 
 # Test libraries
 junit = { module = "junit:junit", version = "4.13.2" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.12.2" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.12.2" }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version = "1.12.2" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.12.2" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version = "5.12.2" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.21" }
 truth = { module = "com.google.truth:truth", version = "1.4.5" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -55,6 +55,9 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.options.Option
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestReport
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
+import org.gradle.api.tasks.testing.testng.TestNGOptions
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.os.OperatingSystem
@@ -245,6 +248,19 @@ public class PaparazziPlugin @Inject constructor(
       val failureDir = buildDirectory.dir("paparazzi/failures")
       val testTaskProvider = testTasks.withType(Test::class.java)
       testTaskProvider.configureEach { test ->
+        // configureEach fires after all build-script configuration actions have run, so
+        // test.options reflects whatever framework the user configured (if any).
+        // - TestNG: leave it alone; the JUnit Platform runner would override useTestNG()
+        // - JUnit Platform already configured: just add the engine exclusion so that
+        //   junit-vintage doesn't run alongside paparazzi-vintage and double-execute tests
+        // - Default (JUnit 4 / nothing): switch to JUnit Platform with the exclusion so
+        //   paparazzi-vintage can attach snapshot images to the Gradle HTML test report
+        when (val opts = test.options) {
+          is TestNGOptions -> { /* Don't override TestNG test runner */ }
+          is JUnitPlatformOptions -> opts.excludeEngines("junit-vintage")
+          else -> test.useJUnitPlatform { it.excludeEngines("junit-vintage") }
+        }
+
         val localResourceDirs = sources.localResourceDirs ?: providerFactory.provider { emptyList() }
         val localAssetDirs = sources.localAssetDirs ?: providerFactory.provider { emptyList() }
 
@@ -314,6 +330,29 @@ public class PaparazziPlugin @Inject constructor(
           val uri = reportOutputDir.get().asFile.toPath().resolve("index.html").toUri()
           test.logger.log(LIFECYCLE, "See the Paparazzi report at: $uri")
         }
+      }
+
+      // Register a TestReport task that uses Gradle's generic HTML renderer — the only one
+      // that shows the Attachments tab for snapshot images published via fileEntryPublished.
+      // The built-in Test task HTML report uses the legacy PageRenderer which does not
+      // support file attachments at all.
+      val attachmentReportTask = project.tasks.register(
+        "test${testVariantSlug}Report",
+        TestReport::class.java
+      ) { report ->
+        report.group = VERIFICATION_GROUP
+        report.description =
+          "Generate HTML test report with snapshot image attachments for variant '${variant.name}'"
+        report.testResults.from(
+          project.tasks.named("test$testVariantSlug", AbstractTestTask::class.java)
+            .flatMap { it.binaryResultsDirectory }
+        )
+        report.destinationDirectory.set(
+          buildDirectory.dir("reports/tests/test${testVariantSlug}Report")
+        )
+      }
+      testTaskProvider.configureEach { test ->
+        test.finalizedBy(attachmentReportTask)
       }
 
       recordTaskProvider.configure { it.dependsOn(testTaskProvider) }
@@ -416,6 +455,14 @@ public class PaparazziPlugin @Inject constructor(
     }
     val configurationName = if (isMultiplatformProject) "commonTestImplementation" else "testImplementation"
     project.configurations.getByName(configurationName).dependencies.add(dependency)
+
+    val reportingDependency = if (project.isInternal()) {
+      project.dependencies.project(mapOf("path" to ":paparazzi-junit4-reporting"))
+    } else {
+      project.dependencies.create("app.cash.paparazzi:paparazzi-junit4-reporting:$VERSION")
+    }
+    val runtimeConfigurationName = if (isMultiplatformProject) "commonTestRuntimeOnly" else "testRuntimeOnly"
+    project.configurations.getByName(runtimeConfigurationName).dependencies.add(reportingDependency)
   }
 
   private fun Project.provideOnEnabled(filterProvider: Provider<Boolean>, sourceProvider: Provider<*>): Provider<*> {

--- a/paparazzi-junit4-reporting/api/paparazzi-junit4-reporting.api
+++ b/paparazzi-junit4-reporting/api/paparazzi-junit4-reporting.api
@@ -1,0 +1,9 @@
+public final class app/cash/paparazzi/vintage/PaparazziVintageTestEngine : org/junit/platform/engine/TestEngine {
+	public fun <init> ()V
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
+	public fun getArtifactId ()Ljava/util/Optional;
+	public fun getGroupId ()Ljava/util/Optional;
+	public fun getId ()Ljava/lang/String;
+}
+

--- a/paparazzi-junit4-reporting/build.gradle
+++ b/paparazzi-junit4-reporting/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.vanniktech.maven.publish'
+
+dependencies {
+  implementation projects.paparazzi
+  implementation libs.junit.vintage.engine
+
+  testImplementation libs.junit
+  testImplementation libs.junit.jupiter.api
+  testImplementation libs.junit.platform.engine
+  testImplementation libs.junit.vintage.engine
+  testImplementation libs.truth
+  testRuntimeOnly libs.junit.jupiter.engine
+  testRuntimeOnly libs.junit.platform.launcher
+}
+
+tasks.withType(Test).configureEach {
+  useJUnitPlatform {
+    // paparazzi-vintage (our engine) handles JUnit 4; exclude the standard vintage engine
+    // so that any JUnit 4 classes on the test classpath don't run twice.
+    excludeEngines("junit-vintage")
+  }
+}

--- a/paparazzi-junit4-reporting/gradle.properties
+++ b/paparazzi-junit4-reporting/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=paparazzi-junit4-reporting
+POM_NAME=Paparazzi JUnit 4 Reporting
+POM_DESCRIPTION=JUnit Platform engine wrapper that attaches Paparazzi snapshots to Gradle HTML test reports for JUnit 4 tests
+POM_PACKAGING=jar

--- a/paparazzi-junit4-reporting/src/main/java/app/cash/paparazzi/vintage/PaparazziVintageTestEngine.kt
+++ b/paparazzi-junit4-reporting/src/main/java/app/cash/paparazzi/vintage/PaparazziVintageTestEngine.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.vintage
+
+import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.PaparazziReportingBridge
+import org.junit.platform.engine.EngineDiscoveryRequest
+import org.junit.platform.engine.EngineExecutionListener
+import org.junit.platform.engine.ExecutionRequest
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestEngine
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.reporting.FileEntry
+import org.junit.platform.engine.reporting.ReportEntry
+import org.junit.vintage.engine.VintageTestEngine
+import java.util.Optional
+
+/**
+ * A [TestEngine] that wraps [VintageTestEngine] and intercepts the
+ * [EngineExecutionListener] to publish snapshot images to Gradle's HTML test
+ * report via [EngineExecutionListener.fileEntryPublished].
+ *
+ * This engine uses the ID `"paparazzi-vintage"` (not `"junit-vintage"`) because
+ * the JUnit Platform reserves the `"junit-"` prefix for official engines.
+ * [VintageTestEngine] is excluded by the Paparazzi Gradle plugin so that JUnit 4
+ * tests only run once (through this engine rather than both engines).
+ *
+ * Requires Gradle 9.4+ for file attachments to appear in the HTML test report.
+ */
+public class PaparazziVintageTestEngine : TestEngine {
+  private val delegate = VintageTestEngine()
+
+  // Use a distinct ID rather than "junit-vintage"; the JUnit Platform's
+  // EngineIdValidator forbids third-party engines from using the "junit-" prefix
+  // with a well-known ID unless their class name matches exactly.
+  override fun getId(): String = "paparazzi-vintage"
+
+  override fun getGroupId(): Optional<String> = Optional.of("app.cash.paparazzi")
+
+  override fun getArtifactId(): Optional<String> = Optional.of("paparazzi-junit4-reporting")
+
+  override fun discover(request: EngineDiscoveryRequest, uniqueId: UniqueId): TestDescriptor =
+    delegate.discover(request, uniqueId)
+
+  @Suppress("DEPRECATION") // ExecutionRequest 3-arg constructor; loses CancellationToken
+  override fun execute(request: ExecutionRequest) {
+    val wrapped = FilePublishingEngineExecutionListener(request.engineExecutionListener)
+    delegate.execute(
+      ExecutionRequest(
+        request.rootTestDescriptor,
+        wrapped,
+        request.configurationParameters
+      )
+    )
+  }
+}
+
+/**
+ * Wraps an [EngineExecutionListener] to set/clear [PaparazziReportingBridge.currentPublisher]
+ * around each leaf test, so that [Paparazzi.reportOutputFile] can emit
+ * [EngineExecutionListener.fileEntryPublished] events for snapshot files.
+ */
+internal class FilePublishingEngineExecutionListener(
+  private val delegate: EngineExecutionListener
+) : EngineExecutionListener {
+
+  override fun executionStarted(descriptor: TestDescriptor) {
+    if (descriptor.isTest) {
+      PaparazziReportingBridge.currentPublisher.set { file ->
+        delegate.fileEntryPublished(descriptor, FileEntry.from(file.toPath(), "image/png"))
+      }
+    }
+    delegate.executionStarted(descriptor)
+  }
+
+  override fun executionFinished(descriptor: TestDescriptor, result: TestExecutionResult) {
+    delegate.executionFinished(descriptor, result)
+    if (descriptor.isTest) {
+      PaparazziReportingBridge.currentPublisher.remove()
+    }
+  }
+
+  override fun dynamicTestRegistered(descriptor: TestDescriptor) =
+    delegate.dynamicTestRegistered(descriptor)
+
+  override fun executionSkipped(descriptor: TestDescriptor, reason: String) =
+    delegate.executionSkipped(descriptor, reason)
+
+  override fun reportingEntryPublished(descriptor: TestDescriptor, entry: ReportEntry) =
+    delegate.reportingEntryPublished(descriptor, entry)
+
+  override fun fileEntryPublished(descriptor: TestDescriptor, file: FileEntry) =
+    delegate.fileEntryPublished(descriptor, file)
+}

--- a/paparazzi-junit4-reporting/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/paparazzi-junit4-reporting/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+app.cash.paparazzi.vintage.PaparazziVintageTestEngine

--- a/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/FilePublishingEngineExecutionListenerTest.kt
+++ b/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/FilePublishingEngineExecutionListenerTest.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.vintage
+
+import app.cash.paparazzi.PaparazziReportingBridge
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.EngineExecutionListener
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.TestSource
+import org.junit.platform.engine.TestTag
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.reporting.FileEntry
+import org.junit.platform.engine.reporting.ReportEntry
+import java.io.File
+import java.util.Optional
+
+class FilePublishingEngineExecutionListenerTest {
+  private val delegate = RecordingEngineExecutionListener()
+  private val listener = FilePublishingEngineExecutionListener(delegate)
+
+  @AfterEach
+  fun clearPublisher() {
+    PaparazziReportingBridge.currentPublisher.remove()
+  }
+
+  // ── Publisher lifecycle ───────────────────────────────────────────────────
+
+  @Test
+  fun publisherInstalled_whenLeafTestStarts() {
+    listener.executionStarted(leafDescriptor("test-1"))
+
+    assertThat(PaparazziReportingBridge.currentPublisher.get()).isNotNull()
+  }
+
+  @Test
+  fun publisherCleared_whenLeafTestFinishes() {
+    val descriptor = leafDescriptor("test-1")
+    listener.executionStarted(descriptor)
+    listener.executionFinished(descriptor, TestExecutionResult.successful())
+
+    assertThat(PaparazziReportingBridge.currentPublisher.get()).isNull()
+  }
+
+  @Test
+  fun publisherNotInstalled_forSuiteNode() {
+    listener.executionStarted(suiteDescriptor("suite-1"))
+
+    assertThat(PaparazziReportingBridge.currentPublisher.get()).isNull()
+  }
+
+  @Test
+  fun publisherNotCleared_whenSuiteNodeFinishes() {
+    // Install a publisher manually to verify suites don't clear it.
+    val sentinel: (File) -> Unit = {}
+    PaparazziReportingBridge.currentPublisher.set(sentinel)
+
+    val suite = suiteDescriptor("suite-1")
+    listener.executionStarted(suite)
+    listener.executionFinished(suite, TestExecutionResult.successful())
+
+    assertThat(PaparazziReportingBridge.currentPublisher.get()).isSameInstanceAs(sentinel)
+  }
+
+  // ── File publishing ───────────────────────────────────────────────────────
+
+  @Test
+  fun fileEntryPublished_onDelegate_whenBridgePublishesFile() {
+    listener.executionStarted(leafDescriptor("test-1"))
+
+    val file = File.createTempFile("snapshot", ".png")
+    PaparazziReportingBridge.publishFile(file)
+
+    assertThat(delegate.publishedFiles).hasSize(1)
+    assertThat(delegate.publishedFiles[0].path).isEqualTo(file.toPath())
+  }
+
+  @Test
+  fun fileEntryMediaType_isPng() {
+    listener.executionStarted(leafDescriptor("test-1"))
+
+    PaparazziReportingBridge.publishFile(File.createTempFile("snapshot", ".png"))
+
+    assertThat(delegate.publishedFiles[0].mediaType.orElse(null)).isEqualTo("image/png")
+  }
+
+  @Test
+  fun multipleFiles_publishedToDelegate() {
+    listener.executionStarted(leafDescriptor("test-1"))
+
+    val file1 = File.createTempFile("snap1", ".png")
+    val file2 = File.createTempFile("snap2", ".png")
+    PaparazziReportingBridge.publishFile(file1)
+    PaparazziReportingBridge.publishFile(file2)
+
+    assertThat(delegate.publishedFiles.map { it.path })
+      .containsExactly(file1.toPath(), file2.toPath())
+      .inOrder()
+  }
+
+  @Test
+  fun noFilesPublished_whenBridgeNotCalled() {
+    listener.executionStarted(leafDescriptor("test-1"))
+    listener.executionFinished(leafDescriptor("test-1"), TestExecutionResult.successful())
+
+    assertThat(delegate.publishedFiles).isEmpty()
+  }
+
+  // ── Delegation of all other events ───────────────────────────────────────
+
+  @Test
+  fun executionStarted_delegated() {
+    val descriptor = leafDescriptor("test-1")
+    listener.executionStarted(descriptor)
+
+    assertThat(delegate.startedDescriptors).containsExactly(descriptor)
+  }
+
+  @Test
+  fun executionFinished_delegated() {
+    val descriptor = leafDescriptor("test-1")
+    val result = TestExecutionResult.successful()
+    listener.executionStarted(descriptor)
+    listener.executionFinished(descriptor, result)
+
+    assertThat(delegate.finishedDescriptors).containsExactly(descriptor)
+    assertThat(delegate.finishedResults).containsExactly(result)
+  }
+
+  @Test
+  fun executionSkipped_delegated() {
+    val descriptor = leafDescriptor("test-1")
+    listener.executionSkipped(descriptor, "disabled")
+
+    assertThat(delegate.skippedDescriptors).containsExactly(descriptor)
+    assertThat(delegate.skippedReasons).containsExactly("disabled")
+  }
+
+  @Test
+  fun dynamicTestRegistered_delegated() {
+    val descriptor = leafDescriptor("dynamic-1")
+    listener.dynamicTestRegistered(descriptor)
+
+    assertThat(delegate.dynamicDescriptors).containsExactly(descriptor)
+  }
+
+  @Test
+  fun reportingEntryPublished_delegated() {
+    val descriptor = leafDescriptor("test-1")
+    val entry = ReportEntry.from("key", "value")
+    listener.reportingEntryPublished(descriptor, entry)
+
+    assertThat(delegate.reportEntries).containsExactly(entry)
+  }
+
+  @Test
+  fun fileEntryPublished_delegated_whenCalledDirectly() {
+    val descriptor = leafDescriptor("test-1")
+    val file = File.createTempFile("snapshot", ".png")
+    val entry = FileEntry.from(file.toPath(), "image/png")
+    listener.fileEntryPublished(descriptor, entry)
+
+    assertThat(delegate.publishedFiles).containsExactly(entry)
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private fun leafDescriptor(id: String): TestDescriptor = FakeTestDescriptor(id, isTest = true)
+  private fun suiteDescriptor(id: String): TestDescriptor = FakeTestDescriptor(id, isTest = false)
+}
+
+private class FakeTestDescriptor(
+  private val id: String,
+  private val isTest: Boolean
+) : TestDescriptor {
+  override fun getUniqueId(): UniqueId = UniqueId.root("test", id)
+  override fun getDisplayName(): String = id
+  override fun getType(): TestDescriptor.Type =
+    if (isTest) TestDescriptor.Type.TEST else TestDescriptor.Type.CONTAINER
+  override fun getSource(): Optional<TestSource> = Optional.empty()
+  override fun getChildren(): MutableSet<TestDescriptor> = mutableSetOf()
+  override fun getParent(): Optional<TestDescriptor> = Optional.empty()
+  override fun setParent(parent: TestDescriptor?) {}
+  override fun addChild(descriptor: TestDescriptor) {}
+  override fun removeChild(descriptor: TestDescriptor) {}
+  override fun removeFromHierarchy() {}
+  override fun findByUniqueId(uniqueId: UniqueId): Optional<TestDescriptor> = Optional.empty()
+  override fun getTags(): MutableSet<TestTag> = mutableSetOf()
+}
+
+private class RecordingEngineExecutionListener : EngineExecutionListener {
+  val startedDescriptors = mutableListOf<TestDescriptor>()
+  val finishedDescriptors = mutableListOf<TestDescriptor>()
+  val finishedResults = mutableListOf<TestExecutionResult>()
+  val skippedDescriptors = mutableListOf<TestDescriptor>()
+  val skippedReasons = mutableListOf<String>()
+  val dynamicDescriptors = mutableListOf<TestDescriptor>()
+  val reportEntries = mutableListOf<ReportEntry>()
+  val publishedFiles = mutableListOf<FileEntry>()
+
+  override fun executionStarted(descriptor: TestDescriptor) {
+    startedDescriptors += descriptor
+  }
+
+  override fun executionFinished(descriptor: TestDescriptor, result: TestExecutionResult) {
+    finishedDescriptors += descriptor
+    finishedResults += result
+  }
+
+  override fun executionSkipped(descriptor: TestDescriptor, reason: String) {
+    skippedDescriptors += descriptor
+    skippedReasons += reason
+  }
+
+  override fun dynamicTestRegistered(descriptor: TestDescriptor) {
+    dynamicDescriptors += descriptor
+  }
+
+  override fun reportingEntryPublished(descriptor: TestDescriptor, entry: ReportEntry) {
+    reportEntries += entry
+  }
+
+  override fun fileEntryPublished(descriptor: TestDescriptor, file: FileEntry) {
+    publishedFiles += file
+  }
+}

--- a/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/PaparazziReportingBridgeTest.kt
+++ b/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/PaparazziReportingBridgeTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.vintage
+
+import app.cash.paparazzi.PaparazziReportingBridge
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class PaparazziReportingBridgeTest {
+  @AfterEach
+  fun clearPublisher() {
+    PaparazziReportingBridge.currentPublisher.remove()
+  }
+
+  @Test
+  fun currentPublisher_isNullByDefault() {
+    assertThat(PaparazziReportingBridge.currentPublisher.get()).isNull()
+  }
+
+  @Test
+  fun publishFile_isNoOp_whenNoPublisherSet() {
+    val file = File.createTempFile("snapshot", ".png")
+    // Should not throw.
+    PaparazziReportingBridge.publishFile(file)
+  }
+
+  @Test
+  fun publishFile_invokesCurrentPublisher() {
+    val published = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> published += file }
+
+    val file = File.createTempFile("snapshot", ".png")
+    PaparazziReportingBridge.publishFile(file)
+
+    assertThat(published).containsExactly(file)
+  }
+
+  @Test
+  fun publishFile_invokesCurrentPublisher_multipleTimesForMultipleFiles() {
+    val published = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> published += file }
+
+    val file1 = File.createTempFile("snapshot1", ".png")
+    val file2 = File.createTempFile("snapshot2", ".png")
+    PaparazziReportingBridge.publishFile(file1)
+    PaparazziReportingBridge.publishFile(file2)
+
+    assertThat(published).containsExactly(file1, file2).inOrder()
+  }
+
+  @Test
+  fun publishFile_isNoOp_afterPublisherCleared() {
+    val published = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> published += file }
+    PaparazziReportingBridge.currentPublisher.remove()
+
+    PaparazziReportingBridge.publishFile(File.createTempFile("snapshot", ".png"))
+
+    assertThat(published).isEmpty()
+  }
+}

--- a/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/PaparazziVintageTestEngineTest.kt
+++ b/paparazzi-junit4-reporting/src/test/java/app/cash/paparazzi/vintage/PaparazziVintageTestEngineTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.vintage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class PaparazziVintageTestEngineTest {
+  private val engine = PaparazziVintageTestEngine()
+
+  @Test
+  fun engineId_isPaparazziVintage() {
+    assertThat(engine.id).isEqualTo("paparazzi-vintage")
+  }
+
+  @Test
+  fun groupId_isPaparazziGroup() {
+    assertThat(engine.groupId.orElse(null)).isEqualTo("app.cash.paparazzi")
+  }
+
+  @Test
+  fun artifactId_isPaparazziJunit4Reporting() {
+    assertThat(engine.artifactId.orElse(null)).isEqualTo("paparazzi-junit4-reporting")
+  }
+}

--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -191,6 +191,13 @@ public final class app/cash/paparazzi/Paparazzi : org/junit/rules/TestRule {
 	public static synthetic fun unsafeUpdateConfig$default (Lapp/cash/paparazzi/Paparazzi;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ILjava/lang/Object;)V
 }
 
+public final class app/cash/paparazzi/PaparazziReportingBridge {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/paparazzi/PaparazziReportingBridge;
+	public final fun getCurrentPublisher ()Ljava/lang/ThreadLocal;
+	public final fun publishFile (Ljava/io/File;)V
+}
+
 public final class app/cash/paparazzi/PaparazziSdk {
 	public static final field $stable I
 	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;Lkotlin/jvm/functions/Function1;)V
@@ -251,7 +258,12 @@ public abstract interface class app/cash/paparazzi/SnapshotHandler : java/io/Clo
 }
 
 public abstract interface class app/cash/paparazzi/SnapshotHandler$FrameHandler : java/io/Closeable {
+	public fun getOutputFile ()Ljava/io/File;
 	public abstract fun handle (Ljava/awt/image/BufferedImage;)V
+}
+
+public final class app/cash/paparazzi/SnapshotHandler$FrameHandler$DefaultImpls {
+	public static fun getOutputFile (Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;)Ljava/io/File;
 }
 
 public final class app/cash/paparazzi/SnapshotHandlerKt {

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -98,6 +98,9 @@ public class HtmlReportWriter @JvmOverloads constructor(
       val snapshotTmpFile = File(snapshotDir, snapshot.toFileName(extension = "temp.png"))
       val writer = ApngWriter(snapshotTmpFile.path.toPath(), fps)
 
+      override var outputFile: File? = null
+        private set
+
       override fun handle(image: BufferedImage) {
         writer.writeImage(image)
         hashes += hash(image)
@@ -126,6 +129,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
           }
         }
 
+        outputFile = snapshotFile
         shots += snapshot.copy(file = snapshotFile.toJsonPath())
       }
     }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -25,8 +25,26 @@ import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.io.File
 import java.util.Date
 
+/**
+ * A JUnit 4 [TestRule] for rendering Android views and Compose composables as snapshot images
+ * without a physical device or emulator.
+ *
+ * Usage:
+ * ```
+ * class MyTest {
+ *   @get:Rule
+ *   val paparazzi = Paparazzi()
+ *
+ *   @Test
+ *   fun test() {
+ *     paparazzi.snapshot { MyComposable() }
+ *   }
+ * }
+ * ```
+ */
 public class Paparazzi @JvmOverloads constructor(
   private val environment: Environment = detectEnvironment(),
   private val deviceConfig: DeviceConfig = DeviceConfig.NEXUS_5,
@@ -87,6 +105,23 @@ public class Paparazzi @JvmOverloads constructor(
   public val context: Context
     get() = sdk.context
 
+  private fun createSdk() {
+    sdk = PaparazziSdk(
+      environment = environment,
+      deviceConfig = deviceConfig,
+      theme = theme,
+      renderingMode = renderingMode,
+      appCompatEnabled = appCompatEnabled,
+      renderExtensions = renderExtensions,
+      supportsRtl = supportsRtl,
+      showSystemUi = showSystemUi,
+      validateAccessibility = validateAccessibility,
+      onNewFrame = { frameHandler.handle(it) },
+      useDeviceResolution = useDeviceResolution
+    )
+    sdk.setup()
+  }
+
   override fun apply(base: Statement, description: Description): Statement {
     return object : Statement() {
       override fun evaluate() {
@@ -106,20 +141,7 @@ public class Paparazzi @JvmOverloads constructor(
   }
 
   public fun setup(testName: TestName) {
-    sdk = PaparazziSdk(
-      environment = environment,
-      deviceConfig = deviceConfig,
-      theme = theme,
-      renderingMode = renderingMode,
-      appCompatEnabled = appCompatEnabled,
-      renderExtensions = renderExtensions,
-      supportsRtl = supportsRtl,
-      showSystemUi = showSystemUi,
-      validateAccessibility = validateAccessibility,
-      onNewFrame = { frameHandler.handle(it) },
-      useDeviceResolution = useDeviceResolution
-    )
-    sdk.setup()
+    createSdk()
     this.testName = testName
     sdk.prepare()
   }
@@ -144,6 +166,7 @@ public class Paparazzi @JvmOverloads constructor(
       frameHandler = handler
       sdk.snapshot(composable)
     }
+    reportOutputFile()
   }
 
   @JvmOverloads
@@ -152,6 +175,7 @@ public class Paparazzi @JvmOverloads constructor(
       frameHandler = handler
       sdk.snapshot(view, offsetMillis)
     }
+    reportOutputFile()
   }
 
   @JvmOverloads
@@ -165,6 +189,12 @@ public class Paparazzi @JvmOverloads constructor(
       frameHandler = handler
       sdk.gif(view, start, end, fps)
     }
+    reportOutputFile()
+  }
+
+  private fun reportOutputFile() {
+    val file = frameHandler.outputFile ?: return
+    PaparazziReportingBridge.publishFile(file)
   }
 
   public fun unsafeUpdateConfig(
@@ -189,11 +219,11 @@ public class Paparazzi @JvmOverloads constructor(
     return TestName(packageName, className, methodName)
   }
 
-  private companion object {
-    private val isVerifying: Boolean =
+  internal companion object {
+    internal val isVerifying: Boolean =
       System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
-    private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+    internal fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
       if (isVerifying) {
         SnapshotVerifier(maxPercentDifference)
       } else {

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziReportingBridge.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziReportingBridge.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import java.io.File
+
+/**
+ * Static thread-local bridge between [Paparazzi] (JUnit 4) and the
+ * `paparazzi-junit4-reporting` engine module.
+ *
+ * When `PaparazziVintageTestEngine` is on the classpath, it sets
+ * [currentPublisher] to a callback that emits a `fileEntryPublished` event on
+ * the JUnit Platform [EngineExecutionListener] for the currently-running test.
+ * [Paparazzi.reportOutputFile] calls [publishFile] after every snapshot or gif,
+ * so snapshots are automatically attached to Gradle's HTML test report.
+ *
+ * When the engine module is absent (JUnit 4 without the wrapper, or JUnit 5
+ * via [PaparazziExtension]), [currentPublisher] is null and this is a no-op.
+ */
+public object PaparazziReportingBridge {
+  /**
+   * A per-thread callback installed by `PaparazziVintageTestEngine` at the
+   * start of each leaf test and removed when the test finishes.
+   */
+  public val currentPublisher: ThreadLocal<((File) -> Unit)?> = ThreadLocal.withInitial { null }
+
+  public fun publishFile(file: File) {
+    currentPublisher.get()?.invoke(file)
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -142,10 +142,20 @@ public class PaparazziSdk @JvmOverloads constructor(
 
   public fun setup() {
     if (!isInitialized) {
-      registerViewEditModeInterception()
+      // Guard against re-running ByteBuddy retransformation after the first setup().
+      // When tests run under JUnit Platform (useJUnitPlatform), the JUnit Platform
+      // launcher loads all test classes during discovery before running any tests.
+      // This can cause Android framework classes (e.g. android.view.View) to be loaded
+      // from the test classpath before PaparazziSdk.setup() runs, putting the JVM's live
+      // class in a state that ByteBuddy's original-bytes redefine would reject. A
+      // JVM-global System property prevents double-invocation across classloader boundaries.
+      if (System.getProperty("paparazzi.bytebuddy.initialized") == null) {
+        System.setProperty("paparazzi.bytebuddy.initialized", "true")
+        registerViewEditModeInterception()
 
-      ByteBuddyAgent.install()
-      InterceptorRegistrar.registerMethodInterceptors()
+        ByteBuddyAgent.install()
+        InterceptorRegistrar.registerMethodInterceptors()
+      }
     }
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotHandler.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotHandler.kt
@@ -17,12 +17,32 @@ package app.cash.paparazzi
 
 import java.awt.image.BufferedImage
 import java.io.Closeable
+import java.io.File
 
+/**
+ * Handles writing snapshot output files. Implementations receive rendered frames via
+ * [FrameHandler.handle] and produce output files (e.g. PNG images or animated PNGs).
+ *
+ * @see HtmlReportWriter
+ * @see SnapshotVerifier
+ */
 public interface SnapshotHandler : Closeable {
+  /** Creates a new [FrameHandler] for the given [snapshot]. */
   public fun newFrameHandler(snapshot: Snapshot, frameCount: Int, fps: Int): FrameHandler
 
+  /**
+   * Receives rendered frames for a single snapshot or gif and produces an output file.
+   */
   public interface FrameHandler : Closeable {
+    /** Receives a single rendered frame. */
     public fun handle(image: BufferedImage)
+
+    /**
+     * The output file produced by this handler, available after [close].
+     * For single-frame snapshots this is the PNG image; for animations this is the animated PNG.
+     * Returns `null` if this handler does not produce an output file (e.g. during verification).
+     */
+    public val outputFile: File? get() = null
   }
 }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -9,7 +9,6 @@ import net.bytebuddy.pool.TypePool
 
 internal object InterceptorRegistrar {
   private val byteBuddy = ByteBuddy()
-  private val systemClassFileLocator = ClassFileLocator.ForClassLoader.ofSystemLoader()
   private val systemTypePool = TypePool.Default.ofSystemLoader()
   private val systemClassLoader = ClassLoader.getSystemClassLoader()
 
@@ -23,8 +22,15 @@ internal object InterceptorRegistrar {
     if (!typeResolution.isResolved) return
 
     methodInterceptors += {
+      // Use the bytes of the class as currently loaded in the JVM (via the instrumentation
+      // agent installed by ByteBuddyAgent.install()) rather than the original classfile
+      // bytes from the system classloader. This prevents "attempted to delete a method"
+      // errors when the class was loaded from a version with additional methods (e.g.
+      // from a mockable Android jar or after AGP ASM transforms caused it to be loaded
+      // early with extra stubs).
+      val classFileLocator = ClassFileLocator.ForInstrumentation.fromInstalledAgent(systemClassLoader)
       var builder = byteBuddy
-        .redefine<Any>(typeResolution.resolve(), systemClassFileLocator)
+        .redefine<Any>(typeResolution.resolve(), classFileLocator)
 
       methodNamesToInterceptors.forEach {
         builder = builder

--- a/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
@@ -94,6 +94,100 @@ class HtmlReportWriterTest {
   }
 
   @Test
+  fun outputFileSetForImages() {
+    val htmlReportWriter = HtmlReportWriter(
+      runName = "run_one",
+      rootDirectory = reportRoot.root,
+      maxPercentDifference = 0.0,
+      differ = PixelPerfect,
+      snapshotRootDirectory = snapshotRoot.root
+    )
+    htmlReportWriter.use {
+      val frameHandler = htmlReportWriter.newFrameHandler(
+        snapshot = Snapshot(
+          name = "loading",
+          testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+          timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+        ),
+        frameCount = 1,
+        fps = -1
+      )
+      // Before close, outputFile should be null
+      assertThat(frameHandler.outputFile).isNull()
+
+      frameHandler.use {
+        frameHandler.handle(anyImage)
+      }
+
+      // After close, outputFile should point to the written image
+      assertThat(frameHandler.outputFile).isNotNull()
+      assertThat(frameHandler.outputFile!!.exists()).isTrue()
+      assertThat(frameHandler.outputFile!!.name).endsWith(".png")
+      assertThat(frameHandler.outputFile!!.parentFile.name).isEqualTo("images")
+    }
+  }
+
+  @Test
+  fun outputFileSetForVideos() {
+    val htmlReportWriter = HtmlReportWriter(
+      runName = "run_one",
+      rootDirectory = reportRoot.root,
+      maxPercentDifference = 0.0,
+      differ = PixelPerfect,
+      snapshotRootDirectory = snapshotRoot.root
+    )
+    htmlReportWriter.use {
+      val frameHandler = htmlReportWriter.newFrameHandler(
+        snapshot = Snapshot(
+          name = "loading",
+          testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+          timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+        ),
+        frameCount = 2,
+        fps = 1
+      )
+      assertThat(frameHandler.outputFile).isNull()
+
+      frameHandler.use {
+        frameHandler.handle(anyImage)
+        frameHandler.handle(anyImage)
+      }
+
+      assertThat(frameHandler.outputFile).isNotNull()
+      assertThat(frameHandler.outputFile!!.exists()).isTrue()
+      assertThat(frameHandler.outputFile!!.name).endsWith(".png")
+      assertThat(frameHandler.outputFile!!.parentFile.name).isEqualTo("videos")
+    }
+  }
+
+  @Test
+  fun outputFileNullWhenNoFramesWritten() {
+    val htmlReportWriter = HtmlReportWriter(
+      runName = "run_one",
+      rootDirectory = reportRoot.root,
+      maxPercentDifference = 0.0,
+      differ = PixelPerfect,
+      snapshotRootDirectory = snapshotRoot.root
+    )
+    htmlReportWriter.use {
+      val frameHandler = htmlReportWriter.newFrameHandler(
+        snapshot = Snapshot(
+          name = "loading",
+          testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+          timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+        ),
+        frameCount = 1,
+        fps = -1
+      )
+      frameHandler.use {
+        // intentionally empty, no frames written
+      }
+
+      assertThat(frameHandler.outputFile).isNull()
+    }
+  }
+
+  @Test
   fun sanitizeForFilename() {
     assertThat("0 Dollars".sanitizeForFilename()).isEqualTo("0_dollars")
     assertThat("`!#$%&*+=|\\'\"<>?/".sanitizeForFilename()).isEqualTo("_________________")

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziTest.kt
@@ -30,10 +30,11 @@ import android.widget.Button
 import android.widget.TextView
 import com.android.internal.lang.System_Delegate
 import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.concurrent.TimeUnit
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 class PaparazziTest {
   @get:Rule
@@ -242,6 +243,67 @@ class PaparazziTest {
     paparazzi.gif(view, fps = 4)
 
     assertThat(log).isEqualTo(listOf("predraw", "draw", "draw", "predraw", "predraw", "predraw"))
+  }
+
+  @Test
+  fun reportingBridgeCalledAfterSnapshot() {
+    val capturedFiles = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> capturedFiles += file }
+    try {
+      val view = View(paparazzi.context)
+      paparazzi.snapshot(view)
+
+      assertThat(capturedFiles).hasSize(1)
+      assertThat(capturedFiles[0].exists()).isTrue()
+      assertThat(capturedFiles[0].name).endsWith(".png")
+    } finally {
+      PaparazziReportingBridge.currentPublisher.remove()
+    }
+  }
+
+  @Test
+  fun reportingBridgeCalledAfterGif() {
+    val capturedFiles = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> capturedFiles += file }
+    try {
+      val view = View(paparazzi.context)
+      paparazzi.gif(view, start = 0L, end = 500L, fps = 4)
+
+      assertThat(capturedFiles).hasSize(1)
+      assertThat(capturedFiles[0].exists()).isTrue()
+      assertThat(capturedFiles[0].name).endsWith(".png")
+    } finally {
+      PaparazziReportingBridge.currentPublisher.remove()
+    }
+  }
+
+  @Test
+  fun reportingBridgeNotCalledWhenPublisherIsNull() {
+    PaparazziReportingBridge.currentPublisher.remove()
+
+    val view = View(paparazzi.context)
+    // Should not throw
+    paparazzi.snapshot(view)
+  }
+
+  @Test
+  fun reportingBridgeCalledForMultipleSnapshots() {
+    val capturedFiles = mutableListOf<File>()
+    PaparazziReportingBridge.currentPublisher.set { file -> capturedFiles += file }
+    try {
+      val view1 = View(paparazzi.context)
+      val view2 = View(paparazzi.context).apply {
+        setBackgroundColor(Color.RED)
+      }
+      paparazzi.snapshot(view1, name = "first")
+      paparazzi.snapshot(view2, name = "second")
+
+      assertThat(capturedFiles).hasSize(2)
+      // Different views produce different content hashes and thus different files
+      assertThat(capturedFiles[0]).isNotEqualTo(capturedFiles[1])
+    } finally {
+      PaparazziReportingBridge.currentPublisher.remove()
+    }
   }
 
   private val time: Long

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ develocity {
 rootProject.name = 'paparazzi-root'
 
 include ':paparazzi'
+include ':paparazzi-junit4-reporting'
 include ':paparazzi-annotations'
 include ':paparazzi-gradle-plugin'
 include ':paparazzi-preview-lints'


### PR DESCRIPTION
Closes https://github.com/cashapp/paparazzi/issues/2263 

Introduces a new `paparazzi-junit4-reporting` artifact: a JUnit Platform engine wrapper (`paparazzi-vintage`) that intercepts `EngineExecutionListener` to call `fileEntryPublished()` for every snapshot PNG, surfacing images in Gradle 9.4+ test reports. The Paparazzi plugin auto-applies this new dependency and excludes the `junit-vintage` engine.
