### PR TITLE
Replace byte-buddy with ASM for runtime method interception

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 androidTools = "31.13.2" # == 23.0.0 + agp version
-bytebuddy = "1.18.7"
+asm = "9.7.1"
 compose = "1.10.5"
 coroutines = "1.10.2"
 javaTarget = "21"
@@ -25,8 +25,7 @@ androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version
 autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
 autoService-kspCompiler = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
 
-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
-bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 composeUi-material = { module = "androidx.compose.material:material", version.ref = "compose" }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -256,6 +256,8 @@ public class PaparazziPlugin @Inject constructor(
           )
         )
 
+        test.jvmArgs("-Djdk.attach.allowAttachSelf=true", "-XX:+EnableDynamicAgentLoading")
+
         test.systemProperties["paparazzi.test.resources"] =
           writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
         test.systemProperties["paparazzi.project.dir"] = projectDirectory.toString()

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -37,8 +37,7 @@ dependencies {
   compileOnlyAarAsJar libs.androidx.lifecycle.runtime // Needed for setViewTreeLifecycleOwner
   compileOnlyAarAsJar libs.androidx.savedstate // Needed for setViewTreeSavedStateRegistryOwner
 
-  implementation libs.bytebuddy.agent
-  implementation libs.bytebuddy.core
+  implementation libs.asm
   implementation libs.trove4j
   api libs.tools.common
   api libs.tools.layoutlib
@@ -128,6 +127,7 @@ def generateTestConfig = tasks.register("generateTestConfig") {
 }
 
 tasks.withType(Test).configureEach {
+  jvmArgs '-Djdk.attach.allowAttachSelf=true', '-XX:+EnableDynamicAgentLoading'
   dependsOn(generateTestConfig)
   systemProperty(
     "paparazzi.test.resources",

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -74,7 +74,6 @@ import com.android.tools.idea.validator.LayoutValidator
 import com.android.tools.idea.validator.ValidatorData.Level
 import com.android.tools.idea.validator.ValidatorData.Policy
 import com.android.tools.idea.validator.ValidatorData.Type
-import net.bytebuddy.agent.ByteBuddyAgent
 import java.awt.geom.Ellipse2D
 import java.awt.image.BufferedImage
 import java.util.EnumSet
@@ -144,7 +143,6 @@ public class PaparazziSdk @JvmOverloads constructor(
     if (!isInitialized) {
       registerViewEditModeInterception()
 
-      ByteBuddyAgent.install()
       InterceptorRegistrar.registerMethodInterceptors()
     }
   }

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/AgentInstaller.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/AgentInstaller.kt
@@ -1,0 +1,54 @@
+package app.cash.paparazzi.agent
+
+import com.sun.tools.attach.VirtualMachine
+import java.lang.instrument.Instrumentation
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import kotlin.io.path.createTempFile
+import kotlin.io.path.outputStream
+
+internal object AgentInstaller {
+  @Volatile
+  private var instrumentation: Instrumentation? = null
+
+  @JvmStatic
+  fun agentmain(
+    @Suppress("unused") args: String?,
+    inst: Instrumentation
+  ) {
+    instrumentation = inst
+  }
+
+  fun install(): Instrumentation {
+    instrumentation?.let { return it }
+
+    val pid = ProcessHandle.current().pid().toString()
+    val agentJar = createAgentJar()
+    try {
+      val vm = VirtualMachine.attach(pid)
+      try {
+        vm.loadAgent(agentJar.toString())
+      } finally {
+        vm.detach()
+      }
+    } finally {
+      agentJar.toFile().delete()
+    }
+
+    return instrumentation
+      ?: error("Failed to install agent — Instrumentation not available")
+  }
+
+  private fun createAgentJar(): java.nio.file.Path {
+    val manifest = Manifest().apply {
+      mainAttributes.putValue("Manifest-Version", "1.0")
+      mainAttributes.putValue("Agent-Class", "app.cash.paparazzi.agent.AgentInstaller")
+      mainAttributes.putValue("Can-Redefine-Classes", "true")
+      mainAttributes.putValue("Can-Retransform-Classes", "true")
+    }
+
+    val jarPath = createTempFile("paparazzi-agent", ".jar")
+    JarOutputStream(jarPath.outputStream(), manifest).close()
+    return jarPath
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/AgentInstaller.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/AgentInstaller.kt
@@ -12,10 +12,7 @@ internal object AgentInstaller {
   private var instrumentation: Instrumentation? = null
 
   @JvmStatic
-  fun agentmain(
-    @Suppress("unused") args: String?,
-    inst: Instrumentation
-  ) {
+  fun agentmain(@Suppress("unused") args: String?, inst: Instrumentation) {
     instrumentation = inst
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -1,48 +1,105 @@
 package app.cash.paparazzi.agent
 
-import net.bytebuddy.ByteBuddy
-import net.bytebuddy.dynamic.ClassFileLocator
-import net.bytebuddy.dynamic.loading.ClassReloadingStrategy
-import net.bytebuddy.implementation.MethodDelegation
-import net.bytebuddy.matcher.ElementMatchers
-import net.bytebuddy.pool.TypePool
+import java.lang.instrument.ClassFileTransformer
+import java.security.ProtectionDomain
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
 
 internal object InterceptorRegistrar {
-  private val byteBuddy = ByteBuddy()
-  private val systemClassFileLocator = ClassFileLocator.ForClassLoader.ofSystemLoader()
-  private val systemTypePool = TypePool.Default.ofSystemLoader()
-  private val systemClassLoader = ClassLoader.getSystemClassLoader()
-
-  private val methodInterceptors = mutableListOf<() -> Unit>()
+  private val pendingInterceptors = mutableMapOf<String, MutableSet<Pair<String, Class<*>>>>()
 
   fun addMethodInterceptor(receiverClass: String, methodName: String, interceptor: Class<*>) =
     addMethodInterceptors(receiverClass, setOf(methodName to interceptor))
 
   fun addMethodInterceptors(receiverClass: String, methodNamesToInterceptors: Set<Pair<String, Class<*>>>) {
-    val typeResolution = systemTypePool.describe(receiverClass)
-    if (!typeResolution.isResolved) return
-
-    methodInterceptors += {
-      var builder = byteBuddy
-        .redefine<Any>(typeResolution.resolve(), systemClassFileLocator)
-
-      methodNamesToInterceptors.forEach {
-        builder = builder
-          .method(ElementMatchers.named(it.first))
-          .intercept(MethodDelegation.to(it.second))
-      }
-
-      builder
-        .make()
-        .load(systemClassLoader, ClassReloadingStrategy.fromInstalledAgent())
-    }
+    pendingInterceptors.getOrPut(receiverClass) { mutableSetOf() } += methodNamesToInterceptors
   }
 
   fun registerMethodInterceptors() {
-    methodInterceptors.forEach { it.invoke() }
+    val instrumentation = AgentInstaller.install()
+
+    for ((className, methodNamesToInterceptors) in pendingInterceptors) {
+      val interceptorMap = methodNamesToInterceptors.associate { (name, clazz) -> name to clazz }
+      val transformer = object : ClassFileTransformer {
+        override fun transform(
+          loader: ClassLoader?,
+          internalName: String?,
+          classBeingRedefined: Class<*>?,
+          protectionDomain: ProtectionDomain?,
+          classfileBuffer: ByteArray
+        ): ByteArray? {
+          if (classBeingRedefined == null) return null
+          return transformClass(classfileBuffer, interceptorMap)
+        }
+      }
+
+      instrumentation.addTransformer(transformer, true)
+      try {
+        val targetClass = ClassLoader.getSystemClassLoader().loadClass(className)
+        instrumentation.retransformClasses(targetClass)
+      } finally {
+        instrumentation.removeTransformer(transformer)
+      }
+    }
   }
 
   fun clearMethodInterceptors() {
-    methodInterceptors.clear()
+    pendingInterceptors.clear()
+  }
+
+  private fun transformClass(
+    classBytes: ByteArray,
+    interceptorMap: Map<String, Class<*>>
+  ): ByteArray {
+    val reader = ClassReader(classBytes)
+    val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS)
+
+    reader.accept(
+      object : ClassVisitor(Opcodes.ASM9, writer) {
+        override fun visitMethod(
+          access: Int,
+          name: String,
+          descriptor: String,
+          signature: String?,
+          exceptions: Array<String>?
+        ): MethodVisitor {
+          val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+          val interceptor = interceptorMap[name] ?: return mv
+
+          // Write replacement body that delegates to the interceptor's static intercept method
+          val returnType = Type.getReturnType(descriptor)
+          mv.visitCode()
+          mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            Type.getType(interceptor).internalName,
+            "intercept",
+            Type.getMethodDescriptor(returnType),
+            false
+          )
+          mv.visitInsn(returnOpcode(returnType))
+          mv.visitMaxs(0, 0) // COMPUTE_MAXS recalculates
+          mv.visitEnd()
+
+          // Return a no-op visitor to discard the original method bytecode
+          return object : MethodVisitor(Opcodes.ASM9) {}
+        }
+      },
+      0
+    )
+
+    return writer.toByteArray()
+  }
+
+  private fun returnOpcode(type: Type): Int = when (type.sort) {
+    Type.VOID -> Opcodes.RETURN
+    Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT, Type.INT -> Opcodes.IRETURN
+    Type.LONG -> Opcodes.LRETURN
+    Type.FLOAT -> Opcodes.FRETURN
+    Type.DOUBLE -> Opcodes.DRETURN
+    else -> Opcodes.ARETURN
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -1,13 +1,13 @@
 package app.cash.paparazzi.agent
 
-import java.lang.instrument.ClassFileTransformer
-import java.security.ProtectionDomain
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
+import java.lang.instrument.ClassFileTransformer
+import java.security.ProtectionDomain
 
 internal object InterceptorRegistrar {
   private val pendingInterceptors = mutableMapOf<String, MutableSet<Pair<String, Class<*>>>>()
@@ -51,10 +51,7 @@ internal object InterceptorRegistrar {
     pendingInterceptors.clear()
   }
 
-  private fun transformClass(
-    classBytes: ByteArray,
-    interceptorMap: Map<String, Class<*>>
-  ): ByteArray {
+  private fun transformClass(classBytes: ByteArray, interceptorMap: Map<String, Class<*>>): ByteArray {
     val reader = ClassReader(classBytes)
     val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS)
 
@@ -94,12 +91,13 @@ internal object InterceptorRegistrar {
     return writer.toByteArray()
   }
 
-  private fun returnOpcode(type: Type): Int = when (type.sort) {
-    Type.VOID -> Opcodes.RETURN
-    Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT, Type.INT -> Opcodes.IRETURN
-    Type.LONG -> Opcodes.LRETURN
-    Type.FLOAT -> Opcodes.FRETURN
-    Type.DOUBLE -> Opcodes.DRETURN
-    else -> Opcodes.ARETURN
-  }
+  private fun returnOpcode(type: Type): Int =
+    when (type.sort) {
+      Type.VOID -> Opcodes.RETURN
+      Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT, Type.INT -> Opcodes.IRETURN
+      Type.LONG -> Opcodes.LRETURN
+      Type.FLOAT -> Opcodes.FRETURN
+      Type.DOUBLE -> Opcodes.DRETURN
+      else -> Opcodes.ARETURN
+    }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
@@ -1,7 +1,6 @@
 package app.cash.paparazzi.agent
 
 import com.google.common.truth.Truth.assertThat
-import net.bytebuddy.agent.ByteBuddyAgent
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +16,6 @@ class InterceptorRegistrarTest {
       )
     )
 
-    ByteBuddyAgent.install()
     InterceptorRegistrar.registerMethodInterceptors()
   }
 


### PR DESCRIPTION
## Summary

Byte-buddy (`byte-buddy` + `byte-buddy-agent`, ~3.5 MB) was used solely for one thing: redefining `View.isInEditMode()` at runtime via `InterceptorRegistrar`. This replaces both dependencies with direct ASM bytecode transformation and the JDK Attach/Instrumentation APIs.

**Why:** byte-buddy is a large, general-purpose bytecode library. Paparazzi's interception needs are minimal (replace a method body with a static delegate call), so ASM's lower-level API is a better fit — smaller dependency footprint, fewer transitive deps, and more transparent bytecode manipulation.

### What changed

- **`AgentInstaller.kt`** (new) — self-attaches to the current JVM via `VirtualMachine.attach()` to obtain a `java.lang.instrument.Instrumentation` instance. Replaces `ByteBuddyAgent.install()`.
- **`InterceptorRegistrar.kt`** (rewritten) — uses ASM `ClassReader`/`ClassWriter`/`ClassVisitor` to rewrite target method bodies with `INVOKESTATIC` calls to interceptor classes. Uses `Instrumentation.retransformClasses()` (not `redefineClasses`) to apply transforms, which ensures compatibility with classes already modified by build-time ASM transforms.
- **`PaparazziSdk.kt`** — removed `ByteBuddyAgent.install()` call; agent installation is now handled internally by `InterceptorRegistrar.registerMethodInterceptors()`.
- **`PaparazziPlugin.kt`** — adds `-Djdk.attach.allowAttachSelf=true` and `-XX:+EnableDynamicAgentLoading` JVM flags to consumer test tasks (required for the JDK Attach API).
- **`libs.versions.toml` / `build.gradle`** — replaced `bytebuddy-agent` + `bytebuddy-core` with `org.ow2.asm:asm:9.7.1`.

## Test plan

- [x] `InterceptorRegistrarTest` passes — verifies ASM-based method interception and class retransformation
- [x] All `:paparazzi:test` tests pass
- [x] `:sample:testDebug` passes — full end-to-end: agent install → ASM transform of `android.view.View.isInEditMode()` → layoutlib rendering → snapshot comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)