### PR TITLE
Fix UnsatisfiedLinkError on SystemProperties.native_get

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -16,6 +16,7 @@
 package app.cash.paparazzi.gradle
 
 import app.cash.paparazzi.gradle.instrumentation.ResourcesCompatVisitorFactory
+import app.cash.paparazzi.gradle.instrumentation.SystemPropertiesVisitorFactory
 import app.cash.paparazzi.gradle.reporting.DiffImage
 import app.cash.paparazzi.gradle.reporting.PaparazziTestReporter
 import app.cash.paparazzi.gradle.utils.artifactViewFor
@@ -175,6 +176,10 @@ public class PaparazziPlugin @Inject constructor(
         val testInstrumentation = testComponent.instrumentation
         testInstrumentation.transformClassesWith(
           ResourcesCompatVisitorFactory::class.java,
+          InstrumentationScope.ALL
+        ) { }
+        testInstrumentation.transformClassesWith(
+          SystemPropertiesVisitorFactory::class.java,
           InstrumentationScope.ALL
         ) { }
         testInstrumentation.setAsmFramesComputationMode(

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/instrumentation/SystemPropertiesVisitorFactory.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/instrumentation/SystemPropertiesVisitorFactory.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.gradle.instrumentation
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.ClassContext
+import com.android.build.api.instrumentation.ClassData
+import com.android.build.api.instrumentation.InstrumentationParameters
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Transforms `android.os.SystemProperties` from layoutlib to be compatible with both
+ * Robolectric's native runtime and plain JVM tests where no native runtime is loaded.
+ *
+ * Layoutlib's `SystemProperties` differs from the standard Android SDK in that
+ * `native_get(String)` is a non-native Java wrapper. Robolectric's native runtime calls
+ * `RegisterNatives` expecting ALL native methods from the standard SDK to exist. The missing
+ * binding causes `RegisterNatives` to fail atomically, leaving all native bindings unregistered.
+ *
+ * This transform:
+ * 1. Makes `native_get(String)` native, matching the standard SDK so RegisterNatives succeeds.
+ * 2. Rewrites `get(String)` to call `native_get(String, "")`, since the single-arg overload
+ *    has no standard native binding.
+ * 3. Wraps public methods with `UnsatisfiedLinkError` catch blocks so non-Paparazzi tests
+ *    (which don't load any native runtime) get safe defaults instead of crashes.
+ */
+internal abstract class SystemPropertiesVisitorFactory :
+  AsmClassVisitorFactory<InstrumentationParameters.None> {
+
+  override fun createClassVisitor(
+    classContext: ClassContext,
+    nextClassVisitor: ClassVisitor
+  ): ClassVisitor = SystemPropertiesTransform(nextClassVisitor)
+
+  override fun isInstrumentable(classData: ClassData): Boolean =
+    classData.className == "android.os.SystemProperties"
+
+  internal class SystemPropertiesTransform(delegate: ClassVisitor) :
+    ClassVisitor(Opcodes.ASM9, delegate) {
+
+    override fun visitMethod(
+      access: Int,
+      name: String,
+      descriptor: String,
+      signature: String?,
+      exceptions: Array<String>?
+    ): MethodVisitor {
+      // Make native_get(String) truly native — drop the Java body so it matches the SDK.
+      if (name == "native_get" && descriptor == "(Ljava/lang/String;)Ljava/lang/String;") {
+        val mv = super.visitMethod(
+          access or Opcodes.ACC_NATIVE, name, descriptor, signature, exceptions
+        )
+        mv.visitEnd()
+        return object : MethodVisitor(api, null) {}
+      }
+
+      // Replace get(String) body to call native_get(String, "") with UnsatisfiedLinkError guard.
+      if (name == "get" && descriptor == "(Ljava/lang/String;)Ljava/lang/String;") {
+        val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+        emitGetStringBody(mv)
+        return object : MethodVisitor(api, null) {}
+      }
+
+      // Wrap remaining public methods with UnsatisfiedLinkError guard returning defaults.
+      if (name == "get" && descriptor == GET_WITH_DEFAULT_DESC) {
+        return guardMethod(access, name, descriptor, signature, exceptions, 1, Opcodes.ALOAD, Opcodes.ARETURN)
+      }
+      if (name == "set" && descriptor == "(Ljava/lang/String;Ljava/lang/String;)V") {
+        return guardMethod(access, name, descriptor, signature, exceptions, -1, -1, Opcodes.RETURN)
+      }
+      if (name == "getInt" && descriptor == "(Ljava/lang/String;I)I") {
+        return guardMethod(access, name, descriptor, signature, exceptions, 1, Opcodes.ILOAD, Opcodes.IRETURN)
+      }
+      if (name == "getLong" && descriptor == "(Ljava/lang/String;J)J") {
+        return guardMethod(access, name, descriptor, signature, exceptions, 1, Opcodes.LLOAD, Opcodes.LRETURN)
+      }
+      if (name == "getBoolean" && descriptor == "(Ljava/lang/String;Z)Z") {
+        return guardMethod(access, name, descriptor, signature, exceptions, 1, Opcodes.ILOAD, Opcodes.IRETURN)
+      }
+
+      return super.visitMethod(access, name, descriptor, signature, exceptions)
+    }
+
+    private fun guardMethod(
+      access: Int,
+      name: String,
+      descriptor: String,
+      signature: String?,
+      exceptions: Array<String>?,
+      defaultSlot: Int,
+      loadOpcode: Int,
+      returnOpcode: Int
+    ): MethodVisitor {
+      val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+      return UnsatisfiedLinkErrorGuard(api, mv, defaultSlot, loadOpcode, returnOpcode)
+    }
+
+    /**
+     * Emits: try { return native_get(key, ""); } catch (UnsatisfiedLinkError) { return ""; }
+     */
+    private fun emitGetStringBody(mv: MethodVisitor) {
+      val tryStart = Label()
+      val tryEnd = Label()
+      val handler = Label()
+
+      mv.visitCode()
+      mv.visitTryCatchBlock(tryStart, tryEnd, handler, UNSATISFIED_LINK_ERROR)
+      mv.visitLabel(tryStart)
+      mv.visitVarInsn(Opcodes.ALOAD, 0)
+      mv.visitLdcInsn("")
+      mv.visitMethodInsn(
+        Opcodes.INVOKESTATIC,
+        SYSTEM_PROPERTIES_INTERNAL,
+        "native_get",
+        GET_WITH_DEFAULT_DESC,
+        false
+      )
+      mv.visitLabel(tryEnd)
+      mv.visitInsn(Opcodes.ARETURN)
+      mv.visitLabel(handler)
+      mv.visitInsn(Opcodes.POP)
+      mv.visitLdcInsn("")
+      mv.visitInsn(Opcodes.ARETURN)
+      mv.visitMaxs(2, 1)
+      mv.visitEnd()
+    }
+
+    /**
+     * Wraps the original method body in try { ... } catch (UnsatisfiedLinkError) { return default; }
+     * by passing all original instructions through to the delegate and only injecting the try-start
+     * in [visitCode] and the catch handler in [visitMaxs].
+     */
+    private class UnsatisfiedLinkErrorGuard(
+      api: Int,
+      delegate: MethodVisitor,
+      private val defaultSlot: Int,
+      private val loadOpcode: Int,
+      private val returnOpcode: Int
+    ) : MethodVisitor(api, delegate) {
+      private val tryStart = Label()
+      private val tryEnd = Label()
+      private val handler = Label()
+
+      override fun visitCode() {
+        super.visitCode()
+        super.visitTryCatchBlock(tryStart, tryEnd, handler, UNSATISFIED_LINK_ERROR)
+        super.visitLabel(tryStart)
+      }
+
+      override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+        super.visitLabel(tryEnd)
+        super.visitLabel(handler)
+        super.visitInsn(Opcodes.POP) // pop exception
+        if (defaultSlot == -1) {
+          super.visitInsn(returnOpcode)
+        } else {
+          super.visitVarInsn(loadOpcode, defaultSlot)
+          super.visitInsn(returnOpcode)
+        }
+        super.visitMaxs(maxStack.coerceAtLeast(2), maxLocals)
+      }
+    }
+  }
+
+  internal companion object {
+    private const val SYSTEM_PROPERTIES_INTERNAL = "android/os/SystemProperties"
+    private const val UNSATISFIED_LINK_ERROR = "java/lang/UnsatisfiedLinkError"
+    private const val GET_WITH_DEFAULT_DESC =
+      "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"
+  }
+}

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/instrumentation/SystemPropertiesVisitorFactory.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/instrumentation/SystemPropertiesVisitorFactory.kt
@@ -43,13 +43,10 @@ import org.objectweb.asm.Opcodes
 internal abstract class SystemPropertiesVisitorFactory :
   AsmClassVisitorFactory<InstrumentationParameters.None> {
 
-  override fun createClassVisitor(
-    classContext: ClassContext,
-    nextClassVisitor: ClassVisitor
-  ): ClassVisitor = SystemPropertiesTransform(nextClassVisitor)
+  override fun createClassVisitor(classContext: ClassContext, nextClassVisitor: ClassVisitor): ClassVisitor =
+    SystemPropertiesTransform(nextClassVisitor)
 
-  override fun isInstrumentable(classData: ClassData): Boolean =
-    classData.className == "android.os.SystemProperties"
+  override fun isInstrumentable(classData: ClassData): Boolean = classData.className == "android.os.SystemProperties"
 
   internal class SystemPropertiesTransform(delegate: ClassVisitor) :
     ClassVisitor(Opcodes.ASM9, delegate) {

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1703,6 +1703,16 @@ class PaparazziPluginTest {
       .runFixture(fixtureRoot) { build() }
   }
 
+  // https://github.com/cashapp/paparazzi/issues/1922
+  @Test
+  fun systemPropertiesNativeLink() {
+    val fixtureRoot = File("src/test/projects/system-properties-native-link")
+
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
   @Test
   fun composeLaunchedEffectExceptionPropagates() {
     val fixtureRoot = File("src/test/projects/compose-launched-effect-exception")

--- a/paparazzi-gradle-plugin/src/test/projects/system-properties-native-link/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/system-properties-native-link/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'kotlin-android'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace = 'app.cash.paparazzi.plugin.test'
+  compileSdk = libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk = libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/projects/system-properties-native-link/src/test/java/app/cash/paparazzi/plugin/test/SystemPropertiesNativeLinkTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/system-properties-native-link/src/test/java/app/cash/paparazzi/plugin/test/SystemPropertiesNativeLinkTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import org.junit.Test
+
+/**
+ * Regression test for https://github.com/cashapp/paparazzi/issues/1922
+ *
+ * Verifies that non-Paparazzi tests in a module with Paparazzi applied can
+ * access android.os.SystemProperties without hitting an UnsatisfiedLinkError
+ * on native_get. This previously failed because layoutlib's SystemProperties
+ * has native_get as a non-native method, causing JNI RegisterNatives mismatches.
+ */
+class SystemPropertiesNativeLinkTest {
+  @Test
+  fun systemPropertiesGetDoesNotThrow() {
+    // Directly trigger the code path from issue #1922.
+    // ContentResolver.<clinit> -> Build.getString -> SystemProperties.get -> native_get
+    val result = android.os.SystemProperties.get("test.property", "default")
+    assert(result == "default") { "Expected 'default' but got '$result'" }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1922, this issue also popped up internally at Cash App when integrating the latest Paparazzi in as an internal version bump.

Layoutlib's `SystemProperties.native_get(String)` is a non-native Java wrapper, but the standard Android SDK declares it `native`. When Robolectric's native runtime calls `RegisterNatives`, this signature mismatch causes **atomic failure for ALL native bindings** on `SystemProperties` — any test in a Paparazzi-enabled module that touches `SystemProperties` (directly or via `ContentResolver`, `Build`, etc.) crashes with `UnsatisfiedLinkError`, even if the test has nothing to do with Paparazzi.

This adds an AGP ASM transform (`SystemPropertiesVisitorFactory`) that:
- Makes `native_get(String)` truly `native` to match the SDK, so Robolectric's `RegisterNatives` succeeds
- Rewrites `get(String)` to call `native_get(String, "")`, since the single-arg overload has no standard native binding
- Wraps public methods (`get`, `set`, `getInt`, `getLong`, `getBoolean`) with `UnsatisfiedLinkError` catch blocks so non-Paparazzi tests (which don't load any native runtime) get safe defaults instead of crashes

## Test plan

- [x] New integration test `systemPropertiesNativeLink` — calls `SystemProperties.get()` from a plain JUnit test in a Paparazzi-enabled module
- [x] Verified the test **fails with `UnsatisfiedLinkError`** when the transform is disabled
- [x] Verified the test **passes** with the transform enabled
- [x] Existing `robolectric` integration test still passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)