### PR TITLE
Fix perceptual differs

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/DeltaE2000.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/DeltaE2000.kt
@@ -15,6 +15,9 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 internal object DeltaE2000 : Differ {
+
+  private const val THRESHOLD = 2.3 // JND threshold for perceptible difference
+
   override fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult {
     require(expected.width == actual.width && expected.height == actual.height)
 
@@ -31,17 +34,17 @@ internal object DeltaE2000 : Differ {
         val rgb1 = Color(expected.getRGB(x, y))
         val rgb2 = Color(actual.getRGB(x, y))
 
-        val lab1 = rgbToLab(rgb1)
-        val lab2 = rgbToLab(rgb2)
-
-        val deltaE = deltaE2000(lab1, lab2)
-
-        val isDifferent = deltaE > 2.3 // JND (just noticeable difference) threshold
-
-        if (isDifferent) {
-          numDifferent++
+        val deltaE = if (rgb1 != rgb2) {
+          val lab1 = rgbToLab(rgb1)
+          val lab2 = rgbToLab(rgb2)
+          deltaE2000(lab1, lab2)
         } else {
-          numSimilar++
+          0.0
+        }
+
+        when {
+          deltaE > THRESHOLD -> numDifferent++
+          deltaE > 0.0 -> numSimilar++ // Imperceptibly different but not identical
         }
 
         // Encode delta visually as grayscale based on magnitude
@@ -57,9 +60,13 @@ internal object DeltaE2000 : Differ {
     val percentDifference = numDifferent.toFloat() / totalPixels * 100f
 
     return when {
-      percentDifference == 0f -> DiffResult.Identical(deltaImage)
-      percentDifference < 5f -> DiffResult.Similar(deltaImage, numSimilar)
-      else -> DiffResult.Different(deltaImage, percentDifference, numDifferent)
+      numDifferent + numSimilar == 0L -> DiffResult.Identical(delta = deltaImage)
+      numDifferent == 0L -> DiffResult.Similar(delta = deltaImage, numSimilarPixels = numSimilar)
+      else -> DiffResult.Different(
+        delta = deltaImage,
+        percentDifference = percentDifference,
+        numDifferentPixels = numDifferent
+      )
     }
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/Flip.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/Flip.kt
@@ -10,6 +10,9 @@ import kotlin.math.pow
 import kotlin.math.sqrt
 
 internal object Flip : Differ {
+
+  private const val THRESHOLD = 0.02f
+
   override fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult {
     require(expected.width == actual.width && expected.height == actual.height)
 
@@ -23,56 +26,70 @@ internal object Flip : Differ {
 
     var weightedSum = 0.0
     var weightTotal = 0.0
-    var diffCount = 0L
+    var numDifferent = 0L
+    var numSimilar = 0L
 
     for (y in 0 until h) {
       for (x in 0 until w) {
         val c1 = Color(expected.getRGB(x, y))
         val c2 = Color(actual.getRGB(x, y))
-        val lin1 = srgbToLinear(c1)
-        val lin2 = srgbToLinear(c2)
+        val diffMag = if (c1 != c2) {
+          val lin1 = srgbToLinear(c1)
+          val lin2 = srgbToLinear(c2)
 
-        val fc1 = toFloatArray(lin1)
-        val fc2 = toFloatArray(lin2)
-        val ycxcz1 = toYCxCz(fc1)
-        val ycxcz2 = toYCxCz(fc2)
+          val fc1 = toFloatArray(lin1)
+          val fc2 = toFloatArray(lin2)
+          val ycxcz1 = toYCxCz(fc1)
+          val ycxcz2 = toYCxCz(fc2)
 
-        // Contrast sensitivity filter
-        val csfAttn = contrastSensitivity(ycxcz1, pixelsPerDegree, maxFrequency)
+          // Contrast sensitivity filter
+          val csfAttn = contrastSensitivity(ycxcz1, pixelsPerDegree, maxFrequency)
 
-        val diffVec = doubleArrayOf(
-          ycxcz1[0] - ycxcz2[0],
-          ycxcz1[1] - ycxcz2[1],
-          ycxcz1[2] - ycxcz2[2]
-        )
-        val diffMag = sqrt(diffVec.mapIndexed { i, dv -> dv * dv * csfAttn[i] }.sum())
+          val diffVec = doubleArrayOf(
+            ycxcz1[0] - ycxcz2[0],
+            ycxcz1[1] - ycxcz2[1],
+            ycxcz1[2] - ycxcz2[2]
+          )
+          sqrt(diffVec.mapIndexed { i, dv -> dv * dv * csfAttn[i] }.sum())
+        } else {
+          0.0
+        }
+
         weightedSum += diffMag
         weightTotal += 1.0
 
-        if (diffMag > 0.02) diffCount++
+        when {
+          diffMag > THRESHOLD -> numDifferent++
+          diffMag > 0.0 -> numSimilar++
+        }
 
         val gray = (min(1.0, diffMag) * 255).toInt()
         deltaImage.setRGB(x, y, Color(gray, gray, gray).rgb)
       }
     }
 
-    val avgError = (weightedSum / weightTotal).toFloat()
-    val percentDiff = diffCount.toFloat() / (w * h) * 100f
+    val percentDiff = numDifferent.toFloat() / (w * h) * 100f
 
     return when {
-      avgError < 0.005f -> DiffResult.Identical(deltaImage)
-      avgError < 0.02f -> DiffResult.Similar(deltaImage, (w * h - diffCount))
-      else -> DiffResult.Different(deltaImage, percentDiff, diffCount)
+      numDifferent + numSimilar == 0L -> DiffResult.Identical(delta = deltaImage)
+      numDifferent == 0L -> DiffResult.Similar(delta = deltaImage, numSimilarPixels = numSimilar)
+      else -> DiffResult.Different(
+        delta = deltaImage,
+        percentDifference = percentDiff,
+        numDifferentPixels = numDifferent
+      )
     }
   }
 
   private data class LinearRGB(val r: Double, val g: Double, val b: Double)
+
   private fun srgbToLinear(c: Color) =
     LinearRGB(
       gammaExpand(c.red / 255.0),
       gammaExpand(c.green / 255.0),
       gammaExpand(c.blue / 255.0)
     )
+
   private fun gammaExpand(c: Double) = if (c <= 0.04045) c / 12.92 else ((c + 0.055) / 1.055).pow(2.4)
 
   private fun toFloatArray(rgb: LinearRGB) = doubleArrayOf(rgb.r, rgb.g, rgb.b)

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/Mssim.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/differs/Mssim.kt
@@ -1,6 +1,5 @@
 package app.cash.paparazzi.internal.differs
 
-import androidx.compose.ui.util.fastCoerceAtLeast
 import app.cash.paparazzi.Differ
 import app.cash.paparazzi.Differ.DiffResult
 import java.awt.Color
@@ -10,6 +9,9 @@ import kotlin.math.min
 import kotlin.math.pow
 
 internal object Mssim : Differ {
+
+  private const val THRESHOLD = 0.99
+
   override fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult {
     require(expected.width == actual.width && expected.height == actual.height)
 
@@ -47,12 +49,17 @@ internal object Mssim : Differ {
     val percentDifference = ((1.0 - mssim) * 100).toFloat()
 
     return when {
-      percentDifference == 0f -> DiffResult.Identical(deltaImage)
+      mssim == 1.0 -> DiffResult.Identical(deltaImage)
+      mssim > THRESHOLD -> DiffResult.Similar(
+        delta = deltaImage,
+        numSimilarPixels = (mssim * width * height).toLong()
+      )
 
-      percentDifference < 5f ->
-        DiffResult.Similar(deltaImage, ((1.0 - percentDifference / 100f) * width * height).toLong())
-
-      else -> DiffResult.Different(deltaImage, percentDifference, (percentDifference / 100f * width * height).toLong())
+      else -> DiffResult.Different(
+        delta = deltaImage,
+        percentDifference = percentDifference,
+        numDifferentPixels = ((1.0 - mssim) * width * height).toLong()
+      )
     }
   }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/DeltaE2000Test.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/DeltaE2000Test.kt
@@ -19,7 +19,7 @@ class DeltaE2000Test {
     val expected = createImage(width = 1, height = 1, rgb = 0xFFFFFFFE)
     val actual = createImage(width = 1, height = 1)
     val result = DeltaE2000.compare(expected, actual)
-    assertThat(result).isInstanceOf(Differ.DiffResult.Identical::class.java)
+    assertThat(result).isInstanceOf(Differ.DiffResult.Similar::class.java)
   }
 
   @Test

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/DiffersTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/DiffersTest.kt
@@ -34,7 +34,7 @@ class DiffersTest {
     }
 
     val flipResult1 = Flip.compare(linuxWidget, macosxWidget)
-    assertThat(flipResult1).isInstanceOf(DiffResult.Identical::class.java)
+    assertThat(flipResult1).isInstanceOf(DiffResult.Similar::class.java)
 
     val siftResult1 = Sift.compare(linuxWidget, macosxWidget)
     with(siftResult1) {
@@ -44,7 +44,7 @@ class DiffersTest {
     }
 
     val de2000Result1 = DeltaE2000.compare(linuxWidget, macosxWidget)
-    assertThat(de2000Result1).isInstanceOf(DiffResult.Identical::class.java)
+    assertThat(de2000Result1).isInstanceOf(DiffResult.Similar::class.java)
   }
 
   @Test
@@ -73,7 +73,7 @@ class DiffersTest {
     }
 
     val flipResult2 = Flip.compare(linuxFullScreen, macosxFullScreen)
-    assertThat(flipResult2).isInstanceOf(DiffResult.Identical::class.java)
+    assertThat(flipResult2).isInstanceOf(DiffResult.Similar::class.java)
 
     //  Java heap space error (OOM)
 
@@ -85,6 +85,6 @@ class DiffersTest {
 //    }
 
     val de2000Result2 = DeltaE2000.compare(linuxFullScreen, macosxFullScreen)
-    assertThat(de2000Result2).isInstanceOf(DiffResult.Identical::class.java)
+    assertThat(de2000Result2).isInstanceOf(DiffResult.Similar::class.java)
   }
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/FlipTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/FlipTest.kt
@@ -19,7 +19,7 @@ class FlipTest {
     val expected = createImage(width = 1, height = 1, rgb = 0xFFFFFFFE)
     val actual = createImage(width = 1, height = 1)
     val result = Flip.compare(expected, actual)
-    assertThat(result).isInstanceOf(Differ.DiffResult.Identical::class.java)
+    assertThat(result).isInstanceOf(Differ.DiffResult.Similar::class.java)
   }
 
   @Test

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/MssimTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/differs/MssimTest.kt
@@ -38,5 +38,8 @@ class MssimTest {
     val actual = createImage(width = 1, height = 1)
     val result = Mssim.compare(expected, actual)
     assertThat(result).isInstanceOf(Differ.DiffResult.Different::class.java)
+    with(result as Differ.DiffResult.Different) {
+      assertThat(percentDifference).isEqualTo(99.99f)
+    }
   }
 }


### PR DESCRIPTION
Fixes #2314

The new differs added in #2009 return `Similar` (a passing result) when the images have some degree of difference. They should only do that when some *pixels* are similar. If even one pixel is sufficiently different, we should return `Different`.