### PR TITLE
Fix java.lang.NoClassDefFoundError: org/gradle/reporting/HtmlWriterTools

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/ClassPageRenderer.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/ClassPageRenderer.kt
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.testing.TestOutputEvent
 import org.gradle.internal.html.SimpleHtmlWriter
 import org.gradle.internal.xml.SimpleMarkupWriter
 import org.gradle.reporting.CodePanelRenderer
-import org.gradle.reporting.HtmlWriterTools.addClipboardCopyButton
 import java.io.IOException
 
 internal class ClassPageRenderer(
@@ -175,7 +174,7 @@ internal class ClassPageRenderer(
               .characters("")
             resultsProvider.writeAllOutput(classId, TestOutputEvent.Destination.StdOut, htmlWriter)
             htmlWriter.endElement()
-            addClipboardCopyButton(htmlWriter, codeId)
+            addClipboardCopyButtonIfSupported(htmlWriter, codeId)
             htmlWriter.endElement()
           }
         }
@@ -196,11 +195,26 @@ internal class ClassPageRenderer(
               .characters("")
             resultsProvider.writeAllOutput(classId, TestOutputEvent.Destination.StdErr, htmlWriter)
             htmlWriter.endElement()
-            addClipboardCopyButton(htmlWriter, codeId)
+            addClipboardCopyButtonIfSupported(htmlWriter, codeId)
             htmlWriter.endElement()
           }
         }
       )
     }
+  }
+
+  private fun addClipboardCopyButtonIfSupported(htmlWriter: SimpleHtmlWriter, codeId: String) {
+    addClipboardCopyButtonMethod?.invoke(null, htmlWriter, codeId)
+  }
+
+  private companion object {
+    // Gradle 8 does not expose HtmlWriterTools, so copy buttons are best-effort.
+    val addClipboardCopyButtonMethod = runCatching {
+      Class.forName("org.gradle.reporting.HtmlWriterTools").getMethod(
+        "addClipboardCopyButton",
+        SimpleHtmlWriter::class.java,
+        String::class.java
+      )
+    }.getOrNull()
   }
 }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/ClassPageRenderer.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/reporting/ClassPageRenderer.kt
@@ -207,6 +207,7 @@ internal class ClassPageRenderer(
     addClipboardCopyButtonMethod?.invoke(null, htmlWriter, codeId)
   }
 
+  // Workaround for Gradle 8.x users: remove once ported to the new testing infra
   private companion object {
     // Gradle 8 does not expose HtmlWriterTools, so copy buttons are best-effort.
     val addClipboardCopyButtonMethod = runCatching {


### PR DESCRIPTION
Fix java.lang.NoClassDefFoundError: org/gradle/reporting/HtmlWriterTools when using latest Paparazzi with Gradle 8.x

This PR makes Paparazzi compatible with Gradle 8.x again so that projects can upgrade to Paparazzi 2.0.0 independenly of upgrading to Gradle 9.x

Fixes #2251

## Summary
- avoid a hard runtime dependency on Gradle 9's `HtmlWriterTools` when rendering Paparazzi class reports
- keep clipboard copy buttons on newer Gradle versions, but gracefully skip them when the helper API is unavailable

## Testing
- I verified that this fixes the NoClassDefFoundError we were encountering with Paparazzi 2.0.0 previously