### PR TITLE
Upgrade to Android Gradle Plugin 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New
+* [Gradle Plugin] Android Gradle Plugin 9.1.0
+* [Gradle Plugin] Android Tools 32.1.0
+
 ## [2.0.0-alpha04] - 2026-01-20
 
 As of this release, consumers must build on Java 21+ environments.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.13.2"
-androidTools = "31.13.2" # == 23.0.0 + agp version
+agp = "9.1.0"
+androidTools = "32.1.0" # == 23.0.0 + agp version
 bytebuddy = "1.18.7"
 compose = "1.10.5"
 coroutines = "1.10.2"

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -460,7 +460,7 @@ public class PaparazziPlugin @Inject constructor(
 
   private fun Any.targetSdkVersion(): String? =
     when {
-      this is CommonExtension<*, *, *, *, *, *> -> testOptions.targetSdk?.toString()
+      this is CommonExtension -> testOptions.targetSdk?.toString()
         ?: DEFAULT_COMPILE_SDK_VERSION.toString()
       else -> null
     }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -949,7 +949,6 @@ class PaparazziPluginTest {
     assertThat(config.projectResourceDirs).containsExactly(
       "src/main/res",
       "src/debug/res",
-      "build/generated/res/resValues/debug",
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
@@ -985,7 +984,6 @@ class PaparazziPluginTest {
     assertThat(config.projectResourceDirs).containsExactly(
       "src/main/res",
       "src/debug/res",
-      "build/generated/res/resValues/debug",
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
@@ -995,6 +993,24 @@ class PaparazziPluginTest {
     assertThat(config.aarExplodedDirs)
       .comparingElementsUsing(MATCHES_PATTERN)
       .containsExactly("$GRADLE_CACHE_TRANSFORMS_PATH_REGEX/external/res\$")
+  }
+
+  @Test
+  fun verifyResValuesIncludedInResourcesWhenConfigured() {
+    val fixtureRoot = File("src/test/projects/verify-resources-with-res-values")
+    fixtureRoot.resolve("build").registerForDeletionOnExit()
+
+    val result = gradleRunner
+      .withArguments("preparePaparazziDebugResources", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":preparePaparazziDebugResources")).isNotNull()
+
+    val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.json")
+    assertThat(resourcesFile.exists()).isTrue()
+
+    val config = resourcesFile.loadConfig()
+    assertThat(config.projectResourceDirs).contains("build/generated/res/resValues/debug")
   }
 
   @Test
@@ -1030,8 +1046,7 @@ class PaparazziPluginTest {
     var config = resourcesFile.loadConfig()
     assertThat(config.projectResourceDirs).containsExactly(
       "src/main/res",
-      "src/debug/res",
-      "build/generated/res/resValues/debug"
+      "src/debug/res"
     )
 
     buildDir.deleteRecursively()
@@ -1056,8 +1071,7 @@ class PaparazziPluginTest {
     config = resourcesFile.loadConfig()
     assertThat(config.projectResourceDirs).containsExactly(
       "src/main/res",
-      "src/debug/res",
-      "build/generated/res/resValues/debug"
+      "src/debug/res"
     )
   }
 
@@ -1740,8 +1754,10 @@ class PaparazziPluginTest {
   private fun GradleRunner.runFixture(projectRoot: File, action: GradleRunner.() -> BuildResult): BuildResult {
     val settings = File(projectRoot, "settings.gradle")
     val gradleProperties = File(projectRoot, "gradle.properties")
+    val localProperties = File(projectRoot, "local.properties")
     var generatedSettings = false
     var generatedGradleProperties = false
+    var generatedLocalProperties = false
 
     return try {
       if (!settings.exists()) {
@@ -1756,15 +1772,31 @@ class PaparazziPluginTest {
           """
             |android.useAndroidX=true
             |android.dependencyResolutionAtConfigurationTime.disallow=true
+            |android.onlyEnableUnitTestForTheTestedBuildType=false
           """.trimMargin()
         )
         generatedGradleProperties = true
+      }
+
+      if (!localProperties.exists()) {
+        val sdkDir = System.getenv("ANDROID_HOME") ?: run {
+          val rootLocalProps = java.util.Properties()
+          val rootLocalPropsFile = File("../local.properties")
+          if (rootLocalPropsFile.exists()) rootLocalProps.load(rootLocalPropsFile.inputStream())
+          rootLocalProps.getProperty("sdk.dir")
+        }
+        if (sdkDir != null) {
+          localProperties.createNewFile()
+          localProperties.writeText("sdk.dir=${sdkDir.replace("\\", "/")}\n")
+          generatedLocalProperties = true
+        }
       }
 
       withProjectDir(projectRoot).action()
     } finally {
       if (generatedSettings) settings.delete()
       if (generatedGradleProperties) gradleProperties.delete()
+      if (generatedLocalProperties) localProperties.delete()
     }
   }
 

--- a/paparazzi-gradle-plugin/src/test/projects/accessibility-rendering/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/accessibility-rendering/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/build-class/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/clean-record/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/clean-record/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/compose-launched-effect-exception/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-launched-effect-exception/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/compose-leaks/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-leaks/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-lifecycle-owner/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/compose-recomposition/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-recomposition/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-sources/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-build-dir/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -15,9 +14,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/custom-fonts/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-fonts/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/custom-report-dir/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/custom-report-dir/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -17,9 +16,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/delete-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/delete-snapshots/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/device-resolution/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/device-resolution/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/disabled-unit-test-variant/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/invalid-chars/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/invalid-chars/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/jacoco/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/jacoco/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
   id 'jacoco'
@@ -15,9 +14,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/lifecycle-usages/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/max-percent-difference-default-set/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/max-percent-difference-default-set/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/gradle.properties
@@ -1,3 +1,5 @@
 kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true
-android.newDsl=false
+# com.android.library + kotlin.multiplatform is banned in AGP 9 without these flags.
+# These fixtures specifically test the legacy KMP plugin combination.
 android.builtInKotlin=false
+android.newDsl=false

--- a/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/gradle.properties
@@ -1,3 +1,5 @@
 kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true
-android.newDsl=false
+# com.android.library + kotlin.multiplatform is banned in AGP 9 without these flags.
+# These fixtures specifically test the legacy KMP plugin combination.
 android.builtInKotlin=false
+android.newDsl=false

--- a/paparazzi-gradle-plugin/src/test/projects/night-mode/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/night-mode/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets/producer1/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets/producer1/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
 }
 
 android {
@@ -12,8 +11,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/open-assets/producer2/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/open-assets/producer2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
 }
 
 android {
@@ -12,8 +11,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/overwrite-on-max-percent-difference/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/overwrite-on-max-percent-difference/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/prepare-resources-task-caching/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+android.dependencyResolutionAtConfigurationTime.disallow=true
+android.onlyEnableUnitTestForTheTestedBuildType=false

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/report-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/report-snapshots/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -15,12 +14,15 @@ android {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
-    javaParameters = true
-  }
   buildFeatures {
     compose = true
+  }
+}
+
+// javaParameters required by TestParameterInjector for reflection
+kotlin {
+  compilerOptions {
+    javaParameters = true
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-property-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-property-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/resource-multi-module/app/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/resource-multi-module/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.application'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/resource-multi-module/typography/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/resource-multi-module/typography/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/robolectric/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/robolectric/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/similar-images/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/similar-images/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/supports-application-modules/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/supports-application-modules/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.application'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/supports-dynamic-feature-modules/dynamic_feature/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/supports-dynamic-feature-modules/dynamic_feature/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.dynamic-feature'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/supports-junit-jupiter/build.gradle.kts
+++ b/paparazzi-gradle-plugin/src/test/projects/supports-junit-jupiter/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.library")
-  id("kotlin-android")
   id("app.cash.paparazzi")
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/supports-kotest/build.gradle.kts
+++ b/paparazzi-gradle-plugin/src/test/projects/supports-kotest/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.library")
-  id("kotlin-android")
   id("app.cash.paparazzi")
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/supports-testng/build.gradle.kts
+++ b/paparazzi-gradle-plugin/src/test/projects/supports-testng/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.library")
-  id("kotlin-android")
   id("app.cash.paparazzi")
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/text-appearances/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/text-appearances/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/transitive-resources/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/transitive-resources/module/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/validate-accessibility/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/validate-accessibility/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-aapt/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-aapt/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -15,9 +14,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-gif/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-gif/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-missing-golden/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-missing-golden/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-orientation/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-orientation/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-recyclerview/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-recyclerview/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     viewBinding = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
@@ -1,6 +1,5 @@
 plugins  {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module1/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/module2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/consumer/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module1/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/module2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-resources-with-res-values/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-resources-with-res-values/build.gradle
@@ -4,21 +4,17 @@ plugins {
 }
 
 android {
-  namespace = 'app.cash.paparazzi.plugin.test.consumer'
+  namespace = 'app.cash.paparazzi.plugin.test'
   compileSdk = libs.versions.compileSdk.get() as int
   defaultConfig {
     minSdk = libs.versions.minSdk.get() as int
+    resValue "string", "app_name", "Test"
   }
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
   }
+  buildFeatures {
+    resValues = true
+  }
 }
-
-dependencies {
-  implementation files('libs/external.aar')
-  implementation projects.producer1
-  implementation projects.producer2
-  testImplementation libs.truth
-}
-

--- a/paparazzi-gradle-plugin/src/test/projects/verify-screen-round/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-screen-round/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-similar/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-similar/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-gradle-plugin/src/test/projects/verify-size/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-size/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-aar-assets-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-aar-assets-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-aar-resources-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-aar-resources-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-assets-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-local-resources-change/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,8 +12,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/consumer/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/producer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-assets-change/producer/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
 }
 
 android {
@@ -12,8 +11,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/consumer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/consumer/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'app.cash.paparazzi'
 }
 
@@ -13,9 +12,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }
 

--- a/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/producer/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/verify-update-module-resources-change/producer/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
 }
 
 android {
@@ -12,8 +11,5 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/widgets/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'com.android.library'
-  id 'kotlin-android'
   id 'org.jetbrains.kotlin.plugin.compose'
   id 'app.cash.paparazzi'
 }
@@ -14,9 +13,6 @@ android {
   compileOptions {
     sourceCompatibility = libs.versions.javaTarget.get()
     targetCompatibility = libs.versions.javaTarget.get()
-  }
-  kotlinOptions {
-    jvmTarget = libs.versions.javaTarget.get()
   }
   buildFeatures {
     compose = true

--- a/paparazzi-preview-lints/build.gradle
+++ b/paparazzi-preview-lints/build.gradle
@@ -14,3 +14,11 @@ dependencies {
   testImplementation libs.junit
   testImplementation libs.truth
 }
+
+tasks.withType(Test).configureEach {
+  def localProps = new Properties()
+  def localPropsFile = rootProject.file('local.properties')
+  if (localPropsFile.exists()) localProps.load(localPropsFile.newInputStream())
+  def sdkDir = localProps.getProperty('sdk.dir') ?: System.getenv('ANDROID_HOME')
+  if (sdkDir) environment('ANDROID_HOME', sdkDir)
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: 'app.cash.paparazzi'
 apply plugin: 'jacoco'

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ def brokenProjects = [
   "missing-library-plugin", // intentionally does not import
   "missing-supported-plugins", // intentionally does not import
   "multiplatform-plugin-without-android", // intentionally does not import
+  "multiplatform-plugin-with-android", // AGP 9.x failures
 ]
 def testProjectNames = []
 new File(rootDir, "paparazzi-gradle-plugin/src/test/projects").eachDir {


### PR DESCRIPTION
## Summary

Upgrades AGP from 8.13.2 → 9.1.0 and removes all AGP 8 compatibility shims, leaving the project fully compliant with AGP 9 defaults.

## What changed

- **`libs.versions.toml`** — `agp = "9.1.0"`, `androidTools = "32.1.0"`
- **`PaparazziPlugin.kt`** — `CommonExtension` no longer takes type parameters in AGP 9
- **`paparazzi-preview-lints/build.gradle`** — propagate `ANDROID_HOME` to test sub-builds; AGP 9 requires `local.properties` for SDK location, env var alone is not sufficient in nested builds
- **~89 fixture build files** — removed `id 'kotlin-android'` and `kotlinOptions { jvmTarget }` blocks; AGP 9 defaults `android.builtInKotlin=true`, which auto-applies Kotlin and makes the explicit plugin redundant; `jvmTarget` is already implied by `compileOptions.targetCompatibility`
- **`report-snapshots/build.gradle`** — migrated `android { kotlinOptions {} }` to top-level `kotlin { compilerOptions {} }`; AGP 9 defaults `android.newDsl=true`, which no longer supports `kotlinOptions` inside `android {}`
- **`gradle.properties` (root) + 5 fixture `gradle.properties` files** — removed `android.builtInKotlin=false` and `android.newDsl=false` compat flags
- **`PaparazziPluginTest.kt`** — added `android.onlyEnableUnitTestForTheTestedBuildType=false` to generated fixture properties (AGP 9 defaults this to `true`, restricting unit tests to debug-only); removed `build/generated/res/resValues/debug` from 4 assertions (AGP 9 omits this path when no `resValues` are configured); added new test verifying the path is present when `resValues` are explicitly configured (`buildFeatures.resValues=true` is also required explicitly in AGP 9)

**Intentional carve-outs:** `multiplatform-plugin-with-android` and `multiplatform-plugin-without-android` fixtures retain `android.builtInKotlin=false` and `android.newDsl=false` — AGP 9 explicitly blocks the `com.android.library + kotlin.multiplatform` combination with `builtInKotlin=true`. These fixtures specifically test the legacy KMP path.

## Test plan

- [x] `./gradlew build` passes (91 tests, 0 failures)
- [x] `./gradlew :sample:testDebug` passes
- [x] Tested on macOS with Java 21