### PR TITLE
Fix flaky overwriteSnapshotOnMaxPercentDiff test

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1725,7 +1725,7 @@ class PaparazziPluginTest {
     val dontRecordLastModified = dontRecordFile.lastModified()
     val recordFile =
       File(fixtureRoot, "src/test/snapshots/images/app.cash.paparazzi.plugin.test_RecordSnapshotTest_record.png")
-    val recordLastModified = dontRecordFile.lastModified()
+    val recordLastModified = recordFile.lastModified()
 
     gradleRunner
       .withArguments("recordPaparazziDebug", "--stacktrace")


### PR DESCRIPTION
## Summary

- `overwriteSnapshotOnMaxPercentDiff` had a copy-paste bug where `recordLastModified` was capturing `dontRecordFile.lastModified()` instead of `recordFile.lastModified()`
- This caused a flaky assertion on CI: when both files share the same checkout timestamp (as they always do on a fresh `git checkout`), and the build completes within the same filesystem timestamp resolution, the `isNotEqualTo` check would spuriously fail
- One-line fix: capture the correct file's timestamp

## Test plan

- [ ] Verify `overwriteSnapshotOnMaxPercentDiff` passes consistently across all platforms/JDK combos in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)