### PR TITLE
Add Gradle version compatibility integration tests

### DIFF
--- a/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi-gradle-plugin/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   implementation libs.moshi.kotlinReflect
 
   testImplementation libs.junit
+  testImplementation libs.testParameterInjector
   testImplementation libs.truth
 
   fixtureClasspath libs.plugin.kotlin

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/GradleVersionCompatibilityTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/GradleVersionCompatibilityTest.kt
@@ -1,0 +1,36 @@
+package app.cash.paparazzi.gradle
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(TestParameterInjector::class)
+class GradleVersionCompatibilityTest {
+  @TestParameter("9.1.0", "9.4.1")
+  lateinit var gradleVersion: String
+
+  private lateinit var gradleRunner: GradleRunner
+
+  @Before
+  fun setUp() {
+    gradleRunner = GradleRunner.create()
+      .withPluginClasspath()
+      .withGradleVersion(gradleVersion)
+  }
+
+  @Test
+  fun verifySuccess() {
+    val fixtureRoot = File("src/test/projects/verify-mode-success")
+
+    val result = gradleRunner
+      .withArguments("verifyPaparazziDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":testDebugUnitTest")).isNotNull()
+  }
+}

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1737,37 +1737,6 @@ class PaparazziPluginTest {
 
   private fun File.loadConfig() = source().buffer().use { CONFIG_ADAPTER.fromJson(it)!! }
 
-  private fun GradleRunner.runFixture(projectRoot: File, action: GradleRunner.() -> BuildResult): BuildResult {
-    val settings = File(projectRoot, "settings.gradle")
-    val gradleProperties = File(projectRoot, "gradle.properties")
-    var generatedSettings = false
-    var generatedGradleProperties = false
-
-    return try {
-      if (!settings.exists()) {
-        settings.createNewFile()
-        settings.writeText("apply from: \"../test.settings.gradle\"")
-        generatedSettings = true
-      }
-
-      if (!gradleProperties.exists()) {
-        gradleProperties.createNewFile()
-        gradleProperties.writeText(
-          """
-            |android.useAndroidX=true
-            |android.dependencyResolutionAtConfigurationTime.disallow=true
-          """.trimMargin()
-        )
-        generatedGradleProperties = true
-      }
-
-      withProjectDir(projectRoot).action()
-    } finally {
-      if (generatedSettings) settings.delete()
-      if (generatedGradleProperties) gradleProperties.delete()
-    }
-  }
-
   private fun File.registerForDeletionOnExit() = apply { filesToDelete += this }
 
   private fun File.listFilesSorted() = listFiles()?.sortedBy { it.lastModified() }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/TestUtils.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/TestUtils.kt
@@ -1,0 +1,36 @@
+package app.cash.paparazzi.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+
+fun GradleRunner.runFixture(projectRoot: File, action: GradleRunner.() -> BuildResult): BuildResult {
+  val settings = File(projectRoot, "settings.gradle")
+  val gradleProperties = File(projectRoot, "gradle.properties")
+  var generatedSettings = false
+  var generatedGradleProperties = false
+
+  return try {
+    if (!settings.exists()) {
+      settings.createNewFile()
+      settings.writeText("apply from: \"../test.settings.gradle\"")
+      generatedSettings = true
+    }
+
+    if (!gradleProperties.exists()) {
+      gradleProperties.createNewFile()
+      gradleProperties.writeText(
+        """
+          |android.useAndroidX=true
+          |android.dependencyResolutionAtConfigurationTime.disallow=true
+        """.trimMargin()
+      )
+      generatedGradleProperties = true
+    }
+
+    withProjectDir(projectRoot).action()
+  } finally {
+    if (generatedSettings) settings.delete()
+    if (generatedGradleProperties) gradleProperties.delete()
+  }
+}


### PR DESCRIPTION
## Background

Paparazzi `1.3.5` has an upper bound on compatibility limited by layoutlib. It is compatible up to compileSdk 35. This limits the compose versions that it is compatible with.

I added this compatibility test to ensure that Paparazzi Gradle Plugin stays compatible with Gradle 9.1.0 in order to simplify the upgrade path. Gradle 9.0.0 is currently not compatible with the current master branch of Paparazzi.

This can also be added as a method in the existing `PaparazziPluginTest` but I figured we probably want to break off a new test class since the other one is getting quite long.

## Summary
- Add a parameterized integration test (`GradleVersionCompatibilityTest`) that runs the plugin's verify workflow against Gradle 9.1.0 and 9.4.1 to catch version-specific breakage in internal Gradle APIs.
- Extract the shared `runFixture` helper from `PaparazziPluginTest` into a top-level extension function in `TestUtils.kt` to avoid duplication.
- Add `testParameterInjector` (already in the version catalog) to the plugin module's test dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)