### PR TITLE
Make verifyPaparazziDebug actual.png identical to recorded png

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt
@@ -20,6 +20,8 @@ import app.cash.paparazzi.Differ
 import app.cash.paparazzi.Differ.DiffResult.Different
 import app.cash.paparazzi.Differ.DiffResult.Identical
 import app.cash.paparazzi.Differ.DiffResult.Similar
+import app.cash.paparazzi.internal.apng.ApngWriter
+import okio.Path.Companion.toPath
 import java.awt.AlphaComposite
 import java.awt.Color
 import java.awt.Graphics2D
@@ -118,7 +120,7 @@ internal object ImageUtils {
           throw IllegalStateException("Unable to delete $actualOutput")
         }
       }
-      ImageIO.write(image, "PNG", actualOutput)
+      ApngWriter(actualOutput.path.toPath(), fps = -1).use { it.writeImage(image) }
       error += "Thumbnail for current rendering stored at file://" + actualOutput.path
       error += "\nRun the following command to accept the changes:\n"
       error += "mv ${actualOutput.absolutePath} ${File(relativePath).absolutePath}"

--- a/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
@@ -16,8 +16,10 @@
 package app.cash.paparazzi
 
 import app.cash.paparazzi.FileSubject.Companion.assertThat
+import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.differs.PixelPerfect
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -91,6 +93,49 @@ class HtmlReportWriterTest {
         |];
       """.trimMargin()
     )
+  }
+
+  @Test
+  fun failureActualImageMatchesRecordedGoldenImageBytes() {
+    try {
+      System.setProperty("paparazzi.test.record", "true")
+
+      val htmlReportWriter = HtmlReportWriter(
+        runName = "record_run",
+        rootDirectory = reportRoot.root,
+        maxPercentDifference = 0.0,
+        differ = PixelPerfect,
+        snapshotRootDirectory = snapshotRoot.root
+      )
+      val snapshot = Snapshot(
+        name = "test",
+        testName = TestName("app.cash.paparazzi", "HomeView", "testSettings"),
+        timestamp = Instant.parse("2021-02-23T10:27:43Z").toDate()
+      )
+      val golden = File("${snapshotRoot.root}/images/app.cash.paparazzi_HomeView_testSettings_test.png")
+
+      htmlReportWriter.use {
+        htmlReportWriter.newFrameHandler(snapshot = snapshot, frameCount = 1, fps = -1).use { frameHandler ->
+          frameHandler.handle(otherImage)
+        }
+      }
+
+      val failureDir = reportRoot.newFolder("failures")
+      assertThrows(AssertionError::class.java) {
+        ImageUtils.assertImageSimilar(
+          relativePath = golden.path,
+          goldenImage = anyImage,
+          image = otherImage,
+          maxPercentDifferent = 0.0,
+          failureDir = failureDir,
+          differ = PixelPerfect
+        )
+      }
+
+      assertThat(File(failureDir, golden.name).readBytes()).isEqualTo(golden.readBytes())
+    } finally {
+      System.clearProperty("paparazzi.test.record")
+    }
   }
 
   @Test


### PR DESCRIPTION
Fix for #2322

Simple fix, just use `ApngWriter` to write the actual png.