### PR TITLE
Destroy lifecycle owner after snapshots

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/LifecycleCoroutineScopeTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/LifecycleCoroutineScopeTest.kt
@@ -1,0 +1,77 @@
+package app.cash.paparazzi.plugin.test
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.coroutineScope
+import app.cash.paparazzi.Paparazzi
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class LifecycleCoroutineScopeTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test fun lifecycleCoroutineDoesNotBlockSubsequentGifs() {
+    assertCounterAdvances()
+    assertCounterAdvances()
+  }
+
+  private fun assertCounterAdvances() {
+    var maxCounter = 0
+
+    val view = ComposeView(paparazzi.context)
+    view.setContent {
+      val counter by produceState(initialValue = 0) {
+        while (isActive) {
+          delay(100)
+          value += 1
+        }
+      }
+
+      SideEffect {
+        if (counter > maxCounter) {
+          maxCounter = counter
+        }
+      }
+
+      val lifecycleOwner = LocalLifecycleOwner.current
+      DisposableEffect(Unit) {
+        val animatable = Animatable(0f)
+        onDispose {
+          lifecycleOwner.lifecycle.coroutineScope.launch {
+            animatable.animateTo(1f)
+          }
+        }
+      }
+
+      Text(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(Color(0xFF073858))
+          .padding(16.dp),
+        text = "Counter = $counter",
+        color = Color.Yellow
+      )
+    }
+
+    paparazzi.gif(view, end = 500L, fps = 10)
+
+    assertTrue("Expected counter to advance, maxCounter=$maxCounter", maxCounter >= 1)
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -288,6 +288,8 @@ public class PaparazziSdk @JvmOverloads constructor(
       previousUncaughtExceptionHandler?.uncaughtException(thread, throwable)
     }
 
+    lateinit var lifecycleOwner: PaparazziLifecycleOwner
+
     try {
       withTime(0L) {
         // Initialize the choreographer at time=0.
@@ -314,7 +316,7 @@ public class PaparazziSdk @JvmOverloads constructor(
       }
 
       if (hasLifecycleOwnerRuntime) {
-        val lifecycleOwner = PaparazziLifecycleOwner()
+        lifecycleOwner = PaparazziLifecycleOwner()
         modifiedView.setViewTreeLifecycleOwner(lifecycleOwner)
 
         if (hasSavedStateRegistryOwnerRuntime) {
@@ -372,6 +374,9 @@ public class PaparazziSdk @JvmOverloads constructor(
         onNewFrame(scaleImage(frameImage(image)))
       }
     } finally {
+      if (hasLifecycleOwnerRuntime) {
+        lifecycleOwner.registry.currentState = Lifecycle.State.DESTROYED
+      }
       viewGroup.removeAllViews()
 
       // Remove any applied render extensions


### PR DESCRIPTION
The `PaparazziLifecycleOwner` was never being reset after each test run and ended up being stuck at `RESUMED` after the first `gif` run. Due to this, the clean up in `onDispose`, (for example in the repro given in the linked issue) would be run but the lifecycle coroutine scope stayed alive and the disposal-time animation could keep running. That leftover coroutine could interfere with the next GIF.

## Summary of changes
- move Paparazzi's synthetic lifecycle owner to DESTROYED during snapshot cleanup
- add a Compose gif regression fixture for lifecycle coroutine work launched during disposal
- add the fixture-only Compose animation dependency via the version catalog

Fixes https://github.com/cashapp/paparazzi/issues/1867