### PR TITLE
Trim redundant inputs, inline failure-dir cleanup

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -229,21 +229,11 @@ public class PaparazziPlugin @Inject constructor(
       val paparazziGradlePropertiesProvider =
         project.providers.gradlePropertiesPrefixedBy("app.cash.paparazzi")
       val failureDir = buildDirectory.dir("paparazzi/failures/${variant.name}")
-      val deleteFailuresTaskProvider = project.tasks.register(
-        "deletePaparazzi${variantSlug}Failures",
-        Delete::class.java
-      ) {
-        it.group = VERIFICATION_GROUP
-        it.description = "Delete failed screenshot comparison images for variant '${variant.name}'"
-        it.delete(failureDir)
-        it.onlyIf { isVerifyRun.get() }
-      }
       val testTaskProvider = testTasks.withType(Test::class.java)
       testTaskProvider.configureEach { test ->
         val localResourceDirs = sources.localResourceDirs ?: providerFactory.provider { emptyList() }
         val localAssetDirs = sources.localAssetDirs ?: providerFactory.provider { emptyList() }
 
-        test.dependsOn(deleteFailuresTaskProvider)
         test.setTestReporter(
           PaparazziTestReporter(
             buildOperationRunner = buildOperationRunner,
@@ -262,7 +252,10 @@ public class PaparazziPlugin @Inject constructor(
         test.inputs.property("paparazzi.test.record", isRecordRun)
         test.inputs.property("paparazzi.test.verify", isVerifyRun)
         test.inputs.property("paparazzi.gradleProperties", paparazziGradlePropertiesProvider)
+        test.inputs.property("paparazzi.layoutlib.version", NATIVE_LIB_VERSION)
 
+        // Source dirs catch in-place content edits. PrepareResourcesTask tracks paths only and
+        // its JSON output is byte-identical when contents change, so it can't invalidate the test.
         test.inputs.files(localResourceDirs)
           .withPropertyName("paparazzi.localResourceDirs")
           .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -281,17 +274,11 @@ public class PaparazziPlugin @Inject constructor(
         test.inputs.files(sources.aarAssetDirs)
           .withPropertyName("paparazzi.aarAssetDirs")
           .withPathSensitivity(PathSensitivity.RELATIVE)
-        test.inputs.files(layoutlibNativeRuntimeFileCollection)
-          .withPropertyName("paparazzi.nativeRuntime")
-          .withPathSensitivity(PathSensitivity.NONE)
-        test.inputs.files(layoutlibResourcesFileCollection)
-          .withPropertyName("paparazzi.layoutlib.resources")
-          .withPathSensitivity(PathSensitivity.NONE)
+
+        // Declared so Test Distribution ships the file (#1790); also catches path-structure changes.
         test.inputs.file(writeResourcesTask.flatMap { it.paparazziResources })
           .withPropertyName("paparazzi.test.resources")
           .withPathSensitivity(PathSensitivity.NONE)
-        test.inputs.property("paparazzi.test.overwriteOnMaxPercentDifference", overwriteOnMaxPercentDifferenceProvider)
-          .optional(true)
 
         test.inputs.dir(snapshotOutputDir.presentWhen(isVerifyRun))
           .withPropertyName("paparazzi.snapshot.input.dir")
@@ -308,11 +295,9 @@ public class PaparazziPlugin @Inject constructor(
           .optional()
 
         test.doFirst {
+          if (isVerifyRun.get()) failureDir.get().asFile.deleteRecursively()
           // Note: these are lazy properties that are not resolvable in the Gradle configuration phase.
           // They need special handling, so they're added as inputs.property above, and systemProperty here.
-          if (isVerifyRun.get()) {
-            failureDir.get().asFile.deleteRecursively()
-          }
           test.systemProperties.putAll(paparazziGradlePropertiesProvider.get())
           test.systemProperties["paparazzi.layoutlib.runtime.root"] =
             layoutlibNativeRuntimeFileCollection.singleFile.absolutePath

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -728,18 +728,35 @@ class PaparazziPluginTest {
   }
 
   @Test
-  fun verifyDeletesStaleFailures() {
+  fun verifyDeletesFailures() {
     val fixtureRoot = File("src/test/projects/verify-mode-success")
     val failureDir = File(fixtureRoot, "build/paparazzi/failures/debug").registerForDeletionOnExit()
-    val staleDelta = File(failureDir, "delta-stale.png")
     failureDir.mkdirs()
-    staleDelta.writeText("stale")
+    val stale = File(failureDir, "stale.txt")
+    stale.writeText("stale")
 
-    gradleRunner
+    val result = gradleRunner
       .withArguments("verifyPaparazziDebug", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
 
-    assertThat(staleDelta.exists()).isFalse()
+    assertThat(result.task(":testDebugUnitTest")?.outcome).isEqualTo(SUCCESS)
+    assertThat(stale.exists()).isFalse()
+  }
+
+  @Test
+  fun recordPreservesFailures() {
+    val fixtureRoot = File("src/test/projects/verify-mode-success")
+    val failureDir = File(fixtureRoot, "build/paparazzi/failures/debug").registerForDeletionOnExit()
+    failureDir.mkdirs()
+    val stale = File(failureDir, "stale.txt")
+    stale.writeText("stale")
+
+    val result = gradleRunner
+      .withArguments("recordPaparazziDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":testDebugUnitTest")?.outcome).isEqualTo(SUCCESS)
+    assertThat(stale.exists()).isTrue()
   }
 
   @Test

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -142,6 +142,10 @@ tasks.withType(Test).configureEach {
     project.layout.buildDirectory.get().toString()
   )
   systemProperty(
+    "paparazzi.failures.dir",
+    project.layout.buildDirectory.dir("paparazzi/failures").get().toString()
+  )
+  systemProperty(
     "paparazzi.report.dir",
     project.extensions.getByType(ReportingExtension).baseDirectory.dir("paparazzi").get().toString()
   )

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -102,10 +102,9 @@ public class SnapshotVerifier @JvmOverloads constructor(
     /** Directory where to write the thumbnails and deltas. */
     private val failureDir: File
       get() {
-        val failureDir = System.getProperty("paparazzi.failures.dir")?.let(::File)
-          ?: File(System.getProperty("paparazzi.build.dir"), "paparazzi/failures")
-        failureDir.mkdirs()
-        return failureDir
+        val path = System.getProperty("paparazzi.failures.dir")
+          ?: error("paparazzi.failures.dir system property is required")
+        return File(path).apply { mkdirs() }
       }
   }
 }


### PR DESCRIPTION
- Inline failure-dir cleanup into the existing `test.doFirst`; remove the dedicated `deletePaparazzi{Variant}Failures` task.
- Replace `inputs.files(layoutlibNativeRuntime)` + `inputs.files(layoutlibResources)` with `inputs.property("paparazzi.layoutlib.version", NATIVE_LIB_VERSION)`. Content is version-determined; avoids fingerprinting multi-MB binaries on every up-to-date check.
- Drop redundant `inputs.property("paparazzi.test.overwriteOnMaxPercentDifference", ...)` — already covered by `paparazziGradlePropertiesProvider`.
- `SnapshotVerifier`: require `paparazzi.failures.dir` with a clear error; drop the `paparazzi.build.dir` fallback that NPE'd on null anyway.
- Comment the two-layer (source-dir / metadata-file) input design so future readers don't try to consolidate it away.
- Tests: tighten `verifyDeletesFailures` (assert task outcome, drop the misleading `.png` filename); add `recordPreservesFailures` to pin the verify-only scoping.

Refs: #2205, #2329