### PR TITLE
Handle missing R classes from external artifacts

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziCallback.kt
@@ -53,10 +53,14 @@ internal class PaparazziCallback(
 
   private val loadedClasses = mutableMapOf<String, Class<*>>()
 
-  @Throws(ClassNotFoundException::class)
   fun initResources() {
     for (rPackageName in resourcePackageNames) {
-      val rClass = Class.forName("$rPackageName.R")
+      val rClass = try {
+        Class.forName("$rPackageName.R")
+      } catch (e: ClassNotFoundException) {
+        logger.error(e, "R class not found %1\$s", "$rPackageName.R")
+        continue
+      }
       for (resourceClass in rClass.declaredClasses) {
         val resourceType = ResourceType.fromClassName(resourceClass.simpleName) ?: continue
 


### PR DESCRIPTION
Catch missing R classes in the same way unknown field types and malformed classes are in the function.

While this is not fixing the root issue brought up by #1968, this will at least prevent crashes in the plugin.

The issue (confirmed? because in our case it was room-ktx and it was not "dropped" as transitive dependency) seems un-fixable right now since we rely on [`org.gradle.api.artifacts.ArtifactCollection#getArtifactFiles(): FileCollection`](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts/-artifact-collection/index.html#-812691026%2FFunctions%2F-1793262594).

Although, there is a [`org.gradle.api.artifacts.ArtifactCollection#getResolvedArtifacts(): Provider<Set<ResolvedArtifactResult>>`](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts/-artifact-collection/index.html#606612266%2FFunctions%2F-1793262594) that could allow us to access the resolved artifacts. But it will require changing some exposed types.

Let me know what you think about this.

Closes #2286