### PR TITLE
Use unit test variant's runtimeConfiguration instead of main variant's

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/AndroidVariantSources.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/AndroidVariantSources.kt
@@ -1,8 +1,10 @@
 package app.cash.paparazzi.gradle
 
 import app.cash.paparazzi.gradle.utils.artifactsFor
+import com.android.build.api.variant.UnitTest
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.publishing.AndroidArtifacts
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
@@ -12,7 +14,8 @@ import org.gradle.api.provider.Provider
  * All the relevant sources for a given Android variant.
  */
 internal class AndroidVariantSources(
-  private val variant: Variant
+  private val variant: Variant,
+  private val unitTest: UnitTest
 ) {
   val localResourceDirs: Provider<List<Directory>>? by lazy {
     variant.sources.res?.all?.map { layers -> layers.flatten() }?.map { it.asReversed() }
@@ -20,13 +23,13 @@ internal class AndroidVariantSources(
 
   // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
   val moduleResourceDirs: FileCollection by lazy {
-    variant.runtimeConfiguration
+    unitTest.runtimeConfiguration
       .artifactsFor(AndroidArtifacts.ArtifactType.ANDROID_RES.type) { it is ProjectComponentIdentifier }
       .artifactFiles
   }
 
   val aarExplodedDirs: FileCollection by lazy {
-    variant.runtimeConfiguration
+    unitTest.runtimeConfiguration
       .artifactsFor(AndroidArtifacts.ArtifactType.ANDROID_RES.type) { it !is ProjectComponentIdentifier }
       .artifactFiles
   }
@@ -37,19 +40,19 @@ internal class AndroidVariantSources(
 
   // https://android.googlesource.com/platform/tools/base/+/96015063acd3455a76cdf1cc71b23b0828c0907f/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt#875
   val moduleAssetDirs: FileCollection by lazy {
-    variant.runtimeConfiguration
+    unitTest.runtimeConfiguration
       .artifactsFor(AndroidArtifacts.ArtifactType.ASSETS.type) { it is ProjectComponentIdentifier }
       .artifactFiles
   }
 
   val aarAssetDirs: FileCollection by lazy {
-    variant.runtimeConfiguration
+    unitTest.runtimeConfiguration
       .artifactsFor(AndroidArtifacts.ArtifactType.ASSETS.type) { it !is ProjectComponentIdentifier }
       .artifactFiles
   }
 
   val packageAwareArtifactFiles: FileCollection by lazy {
-    variant.runtimeConfiguration
+    unitTest.runtimeConfiguration
       .artifactsFor(AndroidArtifacts.ArtifactType.SYMBOL_LIST_WITH_PACKAGE_NAME.type)
       .artifactFiles
   }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -159,7 +159,7 @@ public class PaparazziPlugin @Inject constructor(
         FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
       )
 
-      val sources = AndroidVariantSources(variant)
+      val sources = AndroidVariantSources(variant, unitTest = testVariant)
 
       val writeResourcesTask = project.tasks.register(
         "preparePaparazzi${variantSlug}Resources",

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PrepareResourcesTask.kt
@@ -75,7 +75,7 @@ public abstract class PrepareResourcesTask : DefaultTask() {
         artifactFiles.files.forEach { file ->
           add(file.useLines { lines -> lines.first() })
         }
-      }
+      }.distinct()
     } else {
       listOf(mainPackage)
     }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -946,6 +946,7 @@ class PaparazziPluginTest {
     assertThat(config.mainPackage).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(config.resourcePackageNames).containsExactly(
       "app.cash.paparazzi.plugin.test",
+      "app.cash.paparazzi.plugin.test",
       "com.example.mylibrary",
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
@@ -956,6 +957,7 @@ class PaparazziPluginTest {
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
@@ -981,6 +983,7 @@ class PaparazziPluginTest {
     assertThat(config.mainPackage).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(config.resourcePackageNames).containsExactly(
       "app.cash.paparazzi.plugin.test",
+      "app.cash.paparazzi.plugin.test",
       "com.example.mylibrary",
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
@@ -991,6 +994,7 @@ class PaparazziPluginTest {
       "build/generated/res/extra"
     )
     assertThat(config.moduleResourceDirs).containsExactly(
+      "build/intermediates/packaged_res/debug/packageDebugResources",
       "../module1/build/intermediates/packaged_res/debug/packageDebugResources",
       "../module2/build/intermediates/packaged_res/debug/packageDebugResources"
     )
@@ -1096,7 +1100,10 @@ class PaparazziPluginTest {
 
     var config = resourcesFile.loadConfig()
     assertThat(config.moduleResourceDirs)
-      .containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
+      .containsExactly(
+        "build/intermediates/packaged_res/debug/packageDebugResources",
+        "../producer/build/intermediates/packaged_res/debug/packageDebugResources"
+      )
 
     buildDir.deleteRecursively()
 
@@ -1119,7 +1126,10 @@ class PaparazziPluginTest {
 
     config = resourcesFile.loadConfig()
     assertThat(config.moduleResourceDirs)
-      .containsExactly("../producer/build/intermediates/packaged_res/debug/packageDebugResources")
+      .containsExactly(
+        "build/intermediates/packaged_res/debug/packageDebugResources",
+        "../producer/build/intermediates/packaged_res/debug/packageDebugResources"
+      )
   }
 
   @Test
@@ -1219,7 +1229,11 @@ class PaparazziPluginTest {
     val resourcesFile = File(fixtureRoot, "build/intermediates/paparazzi/debug/resources.json")
 
     var config = resourcesFile.loadConfig()
-    assertThat(config.projectAssetDirs).containsExactly("src/main/assets", "src/debug/assets")
+    assertThat(config.projectAssetDirs).containsExactly(
+      "src/main/assets",
+      "src/debug/assets",
+      "build/intermediates/assets/debug/mergeDebugAssets"
+    )
 
     buildDir.deleteRecursively()
 
@@ -1242,7 +1256,11 @@ class PaparazziPluginTest {
     }
 
     config = resourcesFile.loadConfig()
-    assertThat(config.projectAssetDirs).containsExactly("src/main/assets", "src/debug/assets")
+    assertThat(config.projectAssetDirs).containsExactly(
+      "src/main/assets",
+      "src/debug/assets",
+      "build/intermediates/assets/debug/mergeDebugAssets"
+    )
   }
 
   @Test
@@ -1283,6 +1301,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
+      "build/intermediates/assets/debug/mergeDebugAssets",
       "../producer/build/intermediates/assets/debug/mergeDebugAssets"
     )
 
@@ -1310,6 +1329,7 @@ class PaparazziPluginTest {
     assertThat(config.projectAssetDirs).containsExactly(
       "src/main/assets",
       "src/debug/assets",
+      "build/intermediates/assets/debug/mergeDebugAssets",
       "../producer/build/intermediates/assets/debug/mergeDebugAssets"
     )
   }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -946,7 +946,6 @@ class PaparazziPluginTest {
     assertThat(config.mainPackage).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(config.resourcePackageNames).containsExactly(
       "app.cash.paparazzi.plugin.test",
-      "app.cash.paparazzi.plugin.test",
       "com.example.mylibrary",
       "app.cash.paparazzi.plugin.test.module1",
       "app.cash.paparazzi.plugin.test.module2"
@@ -982,7 +981,6 @@ class PaparazziPluginTest {
     val config = resourcesFile.loadConfig()
     assertThat(config.mainPackage).isEqualTo("app.cash.paparazzi.plugin.test")
     assertThat(config.resourcePackageNames).containsExactly(
-      "app.cash.paparazzi.plugin.test",
       "app.cash.paparazzi.plugin.test",
       "com.example.mylibrary",
       "app.cash.paparazzi.plugin.test.module1",


### PR DESCRIPTION
This ensures only the resolved runtime **unit test** dependencies are used.

<img width="362" height="351" alt="image" src="https://github.com/user-attachments/assets/25957a42-3d55-48d9-96af-41718e4e00b6" />

Fixes #1968
Fixes #2286