### PR TITLE
Filter benign ImageReader maxImages log

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziLogger.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/PaparazziLogger.kt
@@ -24,6 +24,10 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import java.util.logging.Logger.getLogger
 
+private const val IMAGE_READER_JNI = "ImageReader_JNI"
+private const val IMAGE_READER_MAX_IMAGES_MESSAGE =
+  "Unable to acquire a buffer item, very likely client tried to acquire more than maxImages buffers"
+
 /**
  * This logger delegates to java.util.Logging.
  */
@@ -70,6 +74,10 @@ internal class PaparazziLogger : ILayoutLog, ILogger {
   }
 
   override fun logAndroidFramework(priority: Int, tag: String?, message: String?) {
+    if (tag == IMAGE_READER_JNI && message == IMAGE_READER_MAX_IMAGES_MESSAGE) {
+      return
+    }
+
     logger.log(Level.INFO, "$tag [$priority]: $message")
   }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/PaparazziLoggerTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/PaparazziLoggerTest.kt
@@ -1,10 +1,14 @@
 package app.cash.paparazzi.internal
 
+import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.internal.PaparazziLogger.MultipleFailuresException
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.FileNotFoundException
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import java.util.logging.Logger
 
 class PaparazziLoggerTest {
   @Test
@@ -54,5 +58,59 @@ class PaparazziLoggerTest {
     logger.error(FileNotFoundException("error1"), null)
     logger.flushErrors()
     logger.assertNoErrors()
+  }
+
+  @Test
+  fun filtersExpectedImageReaderMaxImagesFrameworkLog() {
+    val logger = PaparazziLogger()
+    val messages = capturePaparazziLogMessages {
+      logger.logAndroidFramework(
+        priority = 3,
+        tag = "ImageReader_JNI",
+        message = "Unable to acquire a buffer item, very likely client tried to acquire more than maxImages buffers"
+      )
+    }
+
+    assertThat(messages).isEmpty()
+  }
+
+  @Test
+  fun stillLogsOtherImageReaderFrameworkMessages() {
+    val logger = PaparazziLogger()
+    val messages = capturePaparazziLogMessages {
+      logger.logAndroidFramework(
+        priority = 3,
+        tag = "ImageReader_JNI",
+        message = "Input BufferItem or output LockedImage is NULL!"
+      )
+    }
+
+    assertThat(messages).containsExactly(
+      "ImageReader_JNI [3]: Input BufferItem or output LockedImage is NULL!"
+    )
+  }
+
+  private fun capturePaparazziLogMessages(block: () -> Unit): List<String> {
+    val javaLogger = Logger.getLogger(Paparazzi::class.java.name)
+    val messages = mutableListOf<String>()
+    val handler = object : Handler() {
+      override fun publish(record: LogRecord) {
+        messages += record.message
+      }
+
+      override fun flush() = Unit
+
+      override fun close() = Unit
+    }
+    val previousUseParentHandlers = javaLogger.useParentHandlers
+    javaLogger.useParentHandlers = false
+    javaLogger.addHandler(handler)
+    return try {
+      block()
+      messages
+    } finally {
+      javaLogger.removeHandler(handler)
+      javaLogger.useParentHandlers = previousUseParentHandlers
+    }
   }
 }


### PR DESCRIPTION
## Why
Layoutlib emits a noisy `ImageReader_JNI` maxImages warning during Paparazzi renders even when snapshots pass. The warning comes from layoutlib's ImageReader path while Paparazzi is capturing rendered frames, where `acquireLatestImage()` can attempt an extra buffer acquire with `maxImages=1` while draining stale images.

This filters that known benign framework log so it does not clutter test output.

## What
- Suppress the exact `ImageReader_JNI` maxImages framework log in `PaparazziLogger`
- Add logger tests for the filtered message and for preserving other `ImageReader_JNI` messages