### PR TITLE
Fix `cleanRecord` race condition between snapshot recording and deletion under parallel builds

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -309,6 +309,10 @@ public class PaparazziPlugin @Inject constructor(
 
       recordTaskProvider.configure { it.dependsOn(testTaskProvider) }
       verifyTaskProvider.configure { it.dependsOn(testTaskProvider) }
+      // Order the real writer after the real deleter when running with --parallel.
+      // The mustRunAfter between recordPaparazzi<Variant> and deletePaparazziSnapshots does not
+      // propagate to their dependencies, so without this we could erase freshly recorded snapshots.
+      testTaskProvider.configureEach { it.mustRunAfter(deleteVariantSnapshot) }
     }
   }
 

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -908,6 +908,22 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun cleanRecordParallel() {
+    val fixtureRoot = File("src/test/projects/clean-record-parallel")
+    val snapshotsDir = File(fixtureRoot, "src/test/snapshots").registerForDeletionOnExit()
+    val snapshot = File(snapshotsDir, "images/app.cash.paparazzi.plugin.test_CleanRecordParallelTest_record.png")
+
+    val result = gradleRunner
+      .withArguments("cleanRecordPaparazziDebug", "--parallel", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":deletePaparazziSnapshots")).isNotNull()
+    assertThat(result.task(":recordPaparazziDebug")).isNotNull()
+
+    assertThat(snapshot.exists()).isTrue()
+  }
+
+  @Test
   fun widgets() {
     val fixtureRoot = File("src/test/projects/widgets")
 

--- a/paparazzi-gradle-plugin/src/test/projects/clean-record-parallel/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/clean-record-parallel/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+  id 'com.android.library'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace = 'app.cash.paparazzi.plugin.test'
+  compileSdk = libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk = libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+}
+
+/**
+ * Makes the racing condition deterministic.
+ * `shouldRunAfter` is a soft ordering that is ignored by gradle when `mustRunAfter` is specified.
+ */
+tasks.matching { it.name == "deleteDebugPaparazziSnapshots" }.configureEach {
+  shouldRunAfter("testDebugUnitTest")
+}

--- a/paparazzi-gradle-plugin/src/test/projects/clean-record-parallel/src/test/java/app/cash/paparazzi/plugin/test/CleanRecordParallelTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/clean-record-parallel/src/test/java/app/cash/paparazzi/plugin/test/CleanRecordParallelTest.kt
@@ -1,0 +1,16 @@
+package app.cash.paparazzi.plugin.test
+
+import android.widget.LinearLayout
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class CleanRecordParallelTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun record() {
+    paparazzi.snapshot(LinearLayout(paparazzi.context))
+  }
+}


### PR DESCRIPTION
## Why
Running `cleanRecordPaparazzi<Variant>` across many modules with `--parallel` can leave some modules with an empty `snapshots/images/` directory even though their tests passed. The goldens get deleted right after they're recorded.

The only ordering edge is between two lifecycle tasks that have no actions themselves:

```
recordPaparazzi<Variant> mustRunAfter deletePaparazziSnapshots
```

The real work happens one level down, in `test<Variant>UnitTest` (writes goldens) and `delete<Variant>PaparazziSnapshots` (deletes them), and `mustRunAfter` doesn't propagate to the tasks each side depends on. So the real deleter and the real writer have no ordering between them, and under `--parallel` the delete can land last. It stays hidden locally because the delete task has no dependencies and usually runs early.

```mermaid
flowchart TD
    cleanRecord["cleanRecordPaparazzi&lt;Variant&gt;"]
    record["recordPaparazzi&lt;Variant&gt;"]
    deleteAnchor["deletePaparazziSnapshots"]
    test["test&lt;Variant&gt;UnitTest<br/>writes goldens"]
    delete["delete&lt;Variant&gt;PaparazziSnapshots<br/>Delete task"]

    cleanRecord -->|dependsOn| deleteAnchor
    cleanRecord -->|dependsOn| record
    record -->|dependsOn| test
    deleteAnchor -->|dependsOn| delete
    record -.->|mustRunAfter| deleteAnchor
    delete -.->|mustRunAfter · added by this PR| test

    classDef lifecycle fill:#e0e0e0,stroke:#999,color:#000
    classDef worker fill:#ffb347,stroke:#d17b00,color:#000
    class cleanRecord,record,deleteAnchor lifecycle
    class test,delete worker
```

## What
- Add `cleanRecordParallel` test, which reproduces the race. The fixture uses `shouldRunAfter` to nudge the delete to run after the test and avoid flakiness. Gradle drops that soft ordering once the fix's `mustRunAfter` is in place, so the test consistently fails without the fix and passes with it.
- Order the writer after the deleter directly: `testTaskProvider.configureEach { it.mustRunAfter(deleteVariantSnapshot) }`. `mustRunAfter` only applies when both tasks are in the graph, so `test`/`verify` runs are unaffected.
