### PR TITLE
No more infinite loop when verifying single frame goldens

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngVerifier.kt
@@ -39,6 +39,7 @@ internal class ApngVerifier(
   private val blankFrame by lazy { createBlankFrame(pngReader.width, pngReader.height) }
 
   private var deltaWriter: ApngWriter? = null
+  private var goldenFps: Int = -1
   private var commonFrameRate: Int = -1
   private var actualDeltasPerFrame: Int = 1
   private var expectedDeltasPerFrame: Int = 1
@@ -46,11 +47,17 @@ internal class ApngVerifier(
   private var invalidFrames = 0
 
   init {
+    require(fps > 0) { "fps must be positive, was: $fps" }
     currentGoldenFrame = pngReader.readNextFrame()
-    commonFrameRate = leastCommonMultiple(fps, pngReader.getFps())
+    // A single-frame golden is written as a still PNG with no animation chunks, dropping the fps
+    // it was recorded with, so ApngReader reports an fps of 0. Fall back to the actual fps: any
+    // fps describes the same single-frame file, and 0 would make the frame-rate math below loop
+    // forever or divide by zero.
+    goldenFps = pngReader.getFps().takeIf { it > 0 } ?: fps
+    commonFrameRate = leastCommonMultiple(fps, goldenFps)
     actualDeltasPerFrame = commonFrameRate / fps
-    expectedDeltasPerFrame = commonFrameRate / pngReader.getFps()
-    if (frameCount != pngReader.frameCount || fps != pngReader.getFps()) {
+    expectedDeltasPerFrame = commonFrameRate / goldenFps
+    if (frameCount != pngReader.frameCount || fps != goldenFps) {
       deltaWriter = ApngWriter(deltaFilePath, commonFrameRate, fileSystem)
     }
   }
@@ -113,8 +120,8 @@ internal class ApngVerifier(
           "$invalidFrames frames differed by more than %f%%".format(maxPercentDifference)
         )
       }
-      if (pngReader.getFps() != fps) {
-        appendLine("Mismatched video fps expected: ${pngReader.getFps()} actual: $fps")
+      if (goldenFps != fps) {
+        appendLine("Mismatched video fps expected: $goldenFps actual: $fps")
       }
       if (pngReader.frameCount != frameCount) {
         appendLine("Mismatched frame count expected: ${pngReader.frameCount} actual: $frameCount")
@@ -192,17 +199,8 @@ internal class ApngVerifier(
     return (first * second) / greatestCommonDenominator(first, second)
   }
 
-  private fun greatestCommonDenominator(first: Int, second: Int): Int {
-    var first = first
-    var second = second
-    while (first != second) {
-      if (first > second) {
-        first -= second
-      } else {
-        second -= first
-      }
-    }
-    return first
+  private tailrec fun greatestCommonDenominator(first: Int, second: Int): Int {
+    return if (second == 0) first else greatestCommonDenominator(second, first % second)
   }
 
   private fun BufferedImage.updateSize(targetWidth: Int, targetHeight: Int) =

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngVerifierTest.kt
@@ -65,6 +65,61 @@ class ApngVerifierTest {
   }
 
   @Test
+  fun validatesSingleFrameGoldenSuccessfully() {
+    // A single-frame golden is written as a still PNG with no animation chunks, so its recorded
+    // fps is lost and ApngReader reports 0. Verification used to loop forever computing a common
+    // frame rate with 0; it should pass regardless of the requested fps.
+    val goldenFile = File(tempDir.newFolder(), "golden.png")
+    ApngWriter(goldenFile.toOkioPath(), fps = 1).use { it.writeImage(firstFrame) }
+    val deltaFile = File(tempDir.newFolder(), "delta.png")
+
+    ApngVerifier(
+      goldenFilePath = goldenFile.toOkioPath(),
+      deltaFilePath = deltaFile.toOkioPath(),
+      fps = 1,
+      frameCount = 1,
+      maxPercentDifference = 0.01,
+      withErrorText = false,
+      differ = OffByTwo
+    ).use {
+      it.verifyFrame(firstFrame)
+
+      it.assertFinished()
+    }
+    assertThat(deltaFile.exists()).isFalse()
+  }
+
+  @Test
+  fun failsWhenSingleFrameGoldenDiffers() {
+    val goldenFile = File(tempDir.newFolder(), "golden.png")
+    ApngWriter(goldenFile.toOkioPath(), fps = 1).use { it.writeImage(firstFrame) }
+    val deltaFile = File(tempDir.newFolder(), "delta.png")
+
+    ApngVerifier(
+      goldenFilePath = goldenFile.toOkioPath(),
+      deltaFilePath = deltaFile.toOkioPath(),
+      fps = 1,
+      frameCount = 1,
+      maxPercentDifference = 0.01,
+      withErrorText = false,
+      differ = OffByTwo
+    ).use {
+      it.verifyFrame(secondFrame)
+
+      try {
+        it.assertFinished()
+        fail("Should have already failed")
+      } catch (e: AssertionError) {
+        assertThat(e.message).isEqualTo(
+          "1 frames differed by more than 0.010000%\n" +
+            " - see details in file://${deltaFile.path}\n\n"
+        )
+      }
+    }
+    assertThat(deltaFile.exists()).isTrue()
+  }
+
+  @Test
   fun failsWhenFpsDoesNotMatch() {
     val file = javaClass.classLoader.getResource("simple_animation.png")
     val deltaFolder = tempDir.newFolder()


### PR DESCRIPTION
Fixes https://github.com/cashapp/paparazzi/issues/2378