### PR TITLE
fix: make test task cache key relocatable (#1874)

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -47,6 +47,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
 import org.gradle.api.tasks.options.Option
@@ -56,6 +57,7 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
+import org.gradle.process.CommandLineArgumentProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import java.util.Locale
 import javax.inject.Inject
@@ -232,12 +234,19 @@ public class PaparazziPlugin @Inject constructor(
           )
         )
 
-        test.systemProperties["paparazzi.test.resources"] =
-          writeResourcesTask.flatMap { it.paparazziResources.asFile }.get().path
-        test.systemProperties["paparazzi.project.dir"] = projectDirectory.toString()
-        test.systemProperties["paparazzi.build.dir"] = buildDirectory.get().toString()
-        test.systemProperties["paparazzi.report.dir"] = reportOutputDir.get().toString()
-        test.systemProperties["paparazzi.artifacts.cache.dir"] = gradleUserHomeDir.path
+        // Absolute paths passed via `systemProperties` (an @Input) would pollute the build-cache
+        // key and break relocatability. Supply them as @Internal JVM args instead (#1874); task
+        // content is tracked separately via the path-sensitive file inputs below.
+        val pathSystemProperties = project.objects.mapProperty(String::class.java, String::class.java)
+        pathSystemProperties.put(
+          "paparazzi.test.resources",
+          writeResourcesTask.flatMap { it.paparazziResources.asFile }.map { it.path }
+        )
+        pathSystemProperties.put("paparazzi.project.dir", projectDirectory.toString())
+        pathSystemProperties.put("paparazzi.build.dir", buildDirectory.map { it.toString() })
+        pathSystemProperties.put("paparazzi.report.dir", reportOutputDir.map { it.toString() })
+        pathSystemProperties.put("paparazzi.artifacts.cache.dir", gradleUserHomeDir.path)
+        test.jvmArgumentProviders.add(PaparazziSystemPropertiesArgumentProvider(pathSystemProperties))
 
         test.inputs.property("paparazzi.test.record", isRecordRun)
         test.inputs.property("paparazzi.test.verify", isVerifyRun)
@@ -506,6 +515,16 @@ public class PaparazziPlugin @Inject constructor(
       .toIntOrNull()
     return agpMajor != null && agpMajor >= major
   }
+}
+
+/** Passes absolute-path system properties as `-D` JVM args without adding them to the cache key (#1874). */
+internal class PaparazziSystemPropertiesArgumentProvider(
+  @get:Internal val systemProperties: Provider<Map<String, String>>
+) : CommandLineArgumentProvider {
+  override fun asArguments(): Iterable<String> =
+    systemProperties.get().entries
+      .sortedBy { it.key }
+      .map { (key, value) -> "-D$key=$value" }
 }
 
 private const val DEFAULT_COMPILE_SDK_VERSION = 36

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -323,6 +323,51 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun cacheableRelocatable() {
+    val fixtureRoot = File("src/test/projects/cacheable")
+    fixtureRoot.resolve("build").registerForDeletionOnExit()
+    fixtureRoot.resolve("build-cache").registerForDeletionOnExit()
+
+    val firstRun = gradleRunner
+      .withArguments("testDebug", "--build-cache", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+
+    with(firstRun.task(":preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isNotEqualTo(FROM_CACHE)
+    }
+    with(firstRun.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isNotEqualTo(FROM_CACHE)
+    }
+
+    // Rebuild the same project (with its populated cache) from a different directory, as CI and a
+    // local clone would. Absolute paths in the cache key would make these entries unreachable here.
+    val relocatedRoot = fixtureRoot.parentFile.resolve("cacheable-relocated").registerForDeletionOnExit()
+    relocatedRoot.deleteRecursively()
+    fixtureRoot.copyRecursively(relocatedRoot)
+    relocatedRoot.resolve("build").deleteRecursively()
+    // Pin the project name (fed into the Kotlin module name embedded in compiled classes) so it
+    // stays constant across dirs; real CI-vs-local checkouts share the same leaf directory name.
+    relocatedRoot.resolve("settings.gradle").let {
+      it.writeText("rootProject.name = 'cacheable'\n${it.readText()}")
+    }
+
+    val secondRun = gradleRunner
+      .withArguments("testDebug", "--build-cache", "--stacktrace")
+      .runFixture(relocatedRoot) { build() }
+
+    with(secondRun.task(":preparePaparazziDebugResources")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE)
+    }
+    with(secondRun.task(":testDebugUnitTest")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(FROM_CACHE)
+    }
+  }
+
+  @Test
   fun configurationCache() {
     val fixtureRoot = File("src/test/projects/configuration-cache")
 


### PR DESCRIPTION
## Problem

Fixes #1874.

The Paparazzi Gradle plugin sets five absolute-path values on the `Test` task via `test.systemProperties[...]` at configuration time:

- `paparazzi.test.resources`
- `paparazzi.project.dir`
- `paparazzi.build.dir`
- `paparazzi.report.dir`
- `paparazzi.artifacts.cache.dir`

Because `Test.getSystemProperties()` is a Gradle `@Input`, those machine- and checkout-specific absolute paths become part of the build-cache key. As a result, cache entries produced by CI (e.g. building from `/tmp/my-repository`) can never be reused by a developer whose clone lives elsewhere (e.g. `~/Projects/my-repository`) — the remote build cache is effectively useless across locations.

## Fix

This is the case Gradle's [incremental build docs](https://docs.gradle.org/current/userguide/incremental_build.html) cover: absolute paths passed as task arguments should go through a `CommandLineArgumentProvider` so the *path string* stays out of the cache key while the underlying *files* are tracked with proper path sensitivity.

The five properties are moved into a `PaparazziSystemPropertiesArgumentProvider` registered on `Test.jvmArgumentProviders`, with the path-bearing map annotated `@Internal`. They still reach the forked test JVM as `-D` args at runtime, but no longer contribute to the cache key. The content that must actually invalidate the task (resource/asset dirs, the resources JSON, snapshots) is already tracked separately on the task via `@PathSensitive(RELATIVE)`/`NONE` file inputs, so cache correctness is unchanged.

### Correctness audit (why `@Internal` is safe)

Each demoted property was traced to confirm its value cannot change rendered output without an already-tracked input also changing:

| Property | Runtime effect | Backing tracked input |
|---|---|---|
| `paparazzi.project.dir` | base for resolving project resource/asset dirs | `localResourceDirs` / `moduleResourceDirs` / asset dirs (`RELATIVE`) |
| `paparazzi.artifacts.cache.dir` | base for resolving AAR resource/asset dirs | `aarResourceDirs` / `aarAssetDirs` (`RELATIVE`) |
| `paparazzi.test.resources` | `resources.json` driving package names, target SDK, dir lists | `test.inputs.file(...)` (`NONE`, content-tracked) |
| `paparazzi.report.dir` | HTML report output location only | `test.outputs.dir(reportOutputDir)` |
| `paparazzi.build.dir` | maps to `Environment.appTestDir`, which has no runtime consumers | n/a |

Behavior-gating properties (`paparazzi.test.record`, `paparazzi.test.verify`, `paparazzi.gradleProperties`, `paparazzi.layoutlib.version`) remain registered via `test.inputs.property(...)` and are untouched.

## Impact on users

No behavior or public-API change. Screenshot rendering, record/verify semantics, and cache correctness are unchanged; the only difference is that the cache key no longer embeds absolute paths, so existing cache entries become reusable across checkout locations.

## Test

Adds `cacheableRelocatable`, which:

1. Builds the `cacheable` fixture with `--build-cache`, populating a local cache.
2. Copies the project (including its populated build-cache) to a sibling directory, pinning `rootProject.name` so the Kotlin module name — which is embedded in compiled classes — stays constant (real CI-vs-local checkouts share the same leaf directory name).
3. Builds from the new location and asserts `:preparePaparazziDebugResources` and `:testDebugUnitTest` resolve `FROM_CACHE`.

The test fails on `:testDebugUnitTest` before the fix and passes after. The full `:paparazzi-gradle-plugin:test` suite and `spotlessCheck` pass.

I also verified this end-to-end on a large multi-module Android project: populated the build cache from one checkout directory, then built the same project from a second checkout at a different absolute path. Before the change the Paparazzi test task re-executed; after it, `:…:testDebugUnitTest` resolved `FROM_CACHE` with a byte-identical build-cache key computed from both locations.