### PR TITLE
Fix stale Main dispatcher across Paparazzi tests

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/CoroutineDelayMainTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/coroutine-delay-main/src/test/java/app/cash/paparazzi/plugin/test/CoroutineDelayMainTest.kt
@@ -1,18 +1,28 @@
 package app.cash.paparazzi.plugin.test
 
 import android.os.SystemClock
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import app.cash.paparazzi.Paparazzi
 import org.junit.Assert.assertEquals
+import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runners.MethodSorters
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.resetMain
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class CoroutineDelayMainTest {
   @get:Rule
   val paparazzi = Paparazzi()
@@ -20,6 +30,28 @@ class CoroutineDelayMainTest {
   init {
     // coroutines-test installs a TestMainDispatcher which is incompatible with ComposeUi
     Dispatchers.resetMain()
+  }
+
+  @Test fun aDirectCompositionInitializesMainDispatcher() {
+    val executions = AtomicInteger()
+
+    paparazzi.snapshot {
+      DispatcherBackedContent(executions)
+    }
+
+    assertEquals(1, executions.get())
+  }
+
+  @Test fun bScaffoldCompositionUsesMainDispatcher() {
+    val executions = AtomicInteger()
+
+    paparazzi.snapshot {
+      Scaffold {
+        DispatcherBackedContent(executions)
+      }
+    }
+
+    assertEquals(1, executions.get())
   }
 
   @Test fun delayUsesMainDispatcher() {
@@ -40,5 +72,21 @@ class CoroutineDelayMainTest {
     )
 
     assertEquals(250L, end - start)
+  }
+}
+
+@Composable
+private fun DispatcherBackedContent(executions: AtomicInteger) {
+  remember {
+    object : RememberObserver {
+      override fun onRemembered() {
+        CoroutineScope(Dispatchers.Main.immediate).launch {
+          executions.incrementAndGet()
+        }
+      }
+
+      override fun onForgotten() = Unit
+      override fun onAbandoned() = Unit
+    }
   }
 }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   api libs.androidx.annotations
   api libs.guava
   api libs.kotlinx.coroutines.android
+  implementation libs.kotlinx.coroutines.test
   api libs.okio
   api platform(libs.kotlin.bom)
   implementation libs.moshi.core

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -21,6 +21,7 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Handler_Delegate
+import android.os.Looper
 import android.util.AttributeSet
 import android.util.DisplayMetrics
 import android.view.BridgeInflater
@@ -79,7 +80,12 @@ import java.awt.geom.Ellipse2D
 import java.awt.image.BufferedImage
 import java.util.EnumSet
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.android.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 
 @OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
 public class PaparazziSdk @JvmOverloads constructor(
@@ -130,6 +136,7 @@ public class PaparazziSdk @JvmOverloads constructor(
   private val logger = PaparazziLogger()
   private lateinit var renderSession: RenderSessionImpl
   private lateinit var bridgeRenderSession: RenderSession
+  private var mainDispatcher: CoroutineDispatcher? = null
 
   public val layoutInflater: LayoutInflater
     get() = RenderAction.getCurrentContext().getSystemService("layout_inflater") as BridgeInflater
@@ -186,6 +193,7 @@ public class PaparazziSdk @JvmOverloads constructor(
   }
 
   public fun teardown() {
+    resetMainDispatcher()
     renderSession.release()
     bridgeRenderSession.dispose()
     cleanupThread()
@@ -231,6 +239,7 @@ public class PaparazziSdk @JvmOverloads constructor(
     }
 
     logger.flushErrors()
+    resetMainDispatcher()
     renderSession.release()
     bridgeRenderSession.dispose()
     cleanupThread()
@@ -263,7 +272,13 @@ public class PaparazziSdk @JvmOverloads constructor(
     bridgeRenderSession = createBridgeSession(renderSession, renderSession.inflate())
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   private fun takeSnapshots(view: View, startNanos: Long, fps: Int, frameCount: Int) {
+    if (hasComposeRuntime) {
+      val dispatcher = Handler(Looper.getMainLooper()).asCoroutineDispatcher("Paparazzi-Main")
+      Dispatchers.setMain(dispatcher)
+      mainDispatcher = dispatcher
+    }
     val viewGroup = bridgeRenderSession.rootViews[0].viewObject as ViewGroup
     val modifiedView = renderExtensions.fold(view) { currentView, renderExtension ->
       val currentSessionRenderingMode = sessionParamsBuilder.build().renderingMode
@@ -309,7 +324,7 @@ public class PaparazziSdk @JvmOverloads constructor(
         // async to our test Handler. By initializing Recomposer with Dispatchers.Main, Delay will now be backed by our test Handler,
         // synchronizing expected behavior.
         WindowRecomposerPolicy.setFactory {
-          val windowRecomposer = it.createLifecycleAwareWindowRecomposer(MAIN_DISPATCHER)
+          val windowRecomposer = it.createLifecycleAwareWindowRecomposer(checkNotNull(mainDispatcher))
           recomposer = windowRecomposer
           return@setFactory windowRecomposer
         }
@@ -428,6 +443,14 @@ public class PaparazziSdk @JvmOverloads constructor(
     val renderSession = RenderSessionImpl(sessionParams)
     renderSession.setElapsedFrameTimeNanos(0L)
     return renderSession
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private fun resetMainDispatcher() {
+    if (mainDispatcher != null) {
+      Dispatchers.resetMain()
+      mainDispatcher = null
+    }
   }
 
   private fun createBridgeSession(renderSession: RenderSessionImpl, result: Result): BridgeRenderSession {
@@ -622,10 +645,6 @@ public class PaparazziSdk @JvmOverloads constructor(
     internal val isInitialized get() = ::renderer.isInitialized
 
     internal lateinit var sessionParamsBuilder: SessionParamsBuilder
-
-    private val MAIN_DISPATCHER by lazy {
-      Handler.getMain().asCoroutineDispatcher("Paparazzi-Main")
-    }
 
     private val hasComposeRuntime: Boolean = isPresentInClasspath(
       "androidx.compose.runtime.snapshots.SnapshotKt",


### PR DESCRIPTION
Fixes #2382

- Recreate the coroutine Main dispatcher from each layoutlib session's current main `Looper`.
- Use that same dispatcher for Compose's `WindowRecomposer` and reset it before layoutlib cleanup.
- Reset the owned Main override before render-session release and layoutlib cleanup.
- Add ordered regressions for direct composition and Scaffold measure-time composition.

## Verification

- `./gradlew :paparazzi:compileKotlin :paparazzi:spotlessCheck :paparazzi-gradle-plugin:spotlessCheck`
- `./gradlew :paparazzi-gradle-plugin:test --tests 'app.cash.paparazzi.gradle.PaparazziPluginTest.verifyCoroutineDelay'`
- `git diff --check`

## Limitations

- The full cross-platform `check` matrix was not run locally; upstream CI remains authoritative.
