### PR TITLE
fix: Workaround WindowManagerImpl.removeView NPE during Dialog teardown (#2373)

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -55,7 +55,7 @@ import app.cash.paparazzi.internal.PaparazziSavedStateRegistryOwner
 import app.cash.paparazzi.internal.Renderer
 import app.cash.paparazzi.internal.SessionParamsBuilder
 import app.cash.paparazzi.internal.interceptors.EditModeInterceptor
-import app.cash.paparazzi.internal.interceptors.WindowManagerImplRemoveViewAdvice
+import app.cash.paparazzi.internal.interceptors.WindowManagerImplRemoveViewAdviceAccessor
 import app.cash.paparazzi.internal.parsers.LayoutPullParser
 import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.Result
@@ -582,7 +582,7 @@ public class PaparazziSdk @JvmOverloads constructor(
     InterceptorRegistrar.addAdvice(
       "android.view.WindowManagerImpl",
       "removeView",
-      WindowManagerImplRemoveViewAdvice::class.java
+      WindowManagerImplRemoveViewAdviceAccessor.adviceClass
     )
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -55,6 +55,7 @@ import app.cash.paparazzi.internal.PaparazziSavedStateRegistryOwner
 import app.cash.paparazzi.internal.Renderer
 import app.cash.paparazzi.internal.SessionParamsBuilder
 import app.cash.paparazzi.internal.interceptors.EditModeInterceptor
+import app.cash.paparazzi.internal.interceptors.WindowManagerImplRemoveViewAdvice
 import app.cash.paparazzi.internal.parsers.LayoutPullParser
 import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.Result
@@ -577,6 +578,11 @@ public class PaparazziSdk @JvmOverloads constructor(
       "android.view.View",
       "isInEditMode",
       EditModeInterceptor::class.java
+    )
+    InterceptorRegistrar.addAdvice(
+      "android.view.WindowManagerImpl",
+      "removeView",
+      WindowManagerImplRemoveViewAdvice::class.java
     )
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -31,7 +31,8 @@ internal object InterceptorRegistrar {
     addMethodInterceptors(receiverClass, setOf(methodName to interceptor))
 
   fun addMethodInterceptors(receiverClass: String, methodNamesToInterceptors: Set<Pair<String, Class<*>>>) {
-    transformations.getOrPut(receiverClass) { Transformation(receiverClass) }.methodInterceptors += methodNamesToInterceptors
+    transformations.getOrPut(receiverClass) { Transformation(receiverClass) }.methodInterceptors +=
+      methodNamesToInterceptors
   }
 
   fun addAdvice(receiverClass: String, methodName: String, adviceClass: Class<*>) {

--- a/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/agent/InterceptorRegistrar.kt
@@ -1,6 +1,7 @@
 package app.cash.paparazzi.agent
 
 import net.bytebuddy.ByteBuddy
+import net.bytebuddy.asm.Advice
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.loading.ClassReloadingStrategy
 import net.bytebuddy.implementation.MethodDelegation
@@ -13,23 +14,46 @@ internal object InterceptorRegistrar {
   private val systemTypePool = TypePool.Default.ofSystemLoader()
   private val systemClassLoader = ClassLoader.getSystemClassLoader()
 
-  private val methodInterceptors = mutableListOf<() -> Unit>()
+  /**
+   * All transformations for a single receiver class. Method delegations and advice for the
+   * same class must be applied in one redefine pass; a second redefinition of a class that
+   * is built from the original class file would undo the first pass.
+   */
+  private data class Transformation(
+    val receiverClass: String,
+    val methodInterceptors: MutableSet<Pair<String, Class<*>>> = mutableSetOf(),
+    val advice: MutableList<Pair<String, Class<*>>> = mutableListOf()
+  )
+
+  private val transformations = mutableMapOf<String, Transformation>()
 
   fun addMethodInterceptor(receiverClass: String, methodName: String, interceptor: Class<*>) =
     addMethodInterceptors(receiverClass, setOf(methodName to interceptor))
 
   fun addMethodInterceptors(receiverClass: String, methodNamesToInterceptors: Set<Pair<String, Class<*>>>) {
-    val typeResolution = systemTypePool.describe(receiverClass)
-    if (!typeResolution.isResolved) return
+    transformations.getOrPut(receiverClass) { Transformation(receiverClass) }.methodInterceptors += methodNamesToInterceptors
+  }
 
-    methodInterceptors += {
+  fun addAdvice(receiverClass: String, methodName: String, adviceClass: Class<*>) {
+    transformations.getOrPut(receiverClass) { Transformation(receiverClass) }.advice += methodName to adviceClass
+  }
+
+  fun registerMethodInterceptors() {
+    transformations.values.forEach { transformation ->
+      val typeResolution = systemTypePool.describe(transformation.receiverClass)
+      if (!typeResolution.isResolved) return@forEach
+
       var builder = byteBuddy
         .redefine<Any>(typeResolution.resolve(), systemClassFileLocator)
 
-      methodNamesToInterceptors.forEach {
+      transformation.methodInterceptors.forEach {
         builder = builder
           .method(ElementMatchers.named(it.first))
           .intercept(MethodDelegation.to(it.second))
+      }
+      transformation.advice.forEach {
+        builder = builder
+          .visit(Advice.to(it.second).on(ElementMatchers.named(it.first)))
       }
 
       builder
@@ -38,11 +62,7 @@ internal object InterceptorRegistrar {
     }
   }
 
-  fun registerMethodInterceptors() {
-    methodInterceptors.forEach { it.invoke() }
-  }
-
   fun clearMethodInterceptors() {
-    methodInterceptors.clear()
+    transformations.clear()
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdvice.java
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdvice.java
@@ -34,8 +34,11 @@ import net.bytebuddy.asm.Advice;
  * to delegate to via {@code @SuperCall}.
  *
  * <p>https://github.com/cashapp/paparazzi/issues/2373
+ *
+ * <p>Package-private so it does not become part of the public API surface, mirroring the
+ * Kotlin {@code internal} interceptor classes.
  */
-public class WindowManagerImplRemoveViewAdvice {
+class WindowManagerImplRemoveViewAdvice {
   private WindowManagerImplRemoveViewAdvice() {
     throw new AssertionError();
   }
@@ -46,7 +49,7 @@ public class WindowManagerImplRemoveViewAdvice {
    * teardown completes cleanly.
    */
   @Advice.OnMethodExit(onThrowable = NullPointerException.class)
-  public static void suppressNullPointerException(@Advice.Thrown(readOnly = false) Throwable throwable) {
+  static void suppressNullPointerException(@Advice.Thrown(readOnly = false) Throwable throwable) {
     throwable = null;
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdvice.java
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdvice.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.interceptors;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Workaround for layoutlib 16.2.1 bug where {@code WindowManagerImpl.removeView} does not
+ * null-check the result of {@code ViewGroup.buildOrderedChildList()} before calling
+ * {@code size()} on it.
+ *
+ * <p>This occurs when a Compose {@code Dialog} is torn down during lifecycle destruction:
+ * after the Dialog's view is removed from the window, {@code buildOrderedChildList()} returns
+ * null (because there are 0 children), and the subsequent {@code size()} call throws a
+ * {@link NullPointerException}. By that point the view has already been removed; only the
+ * {@code ViewRootImpl} child reassignment fails, which is safe to ignore.
+ *
+ * <p>This advice is applied via {@link Advice} as a visitor wrapper, which preserves the
+ * original method body. A {@link MethodDelegation}-based interceptor cannot be used here
+ * because {@code removeView} implements an interface method with no super implementation
+ * to delegate to via {@code @SuperCall}.
+ *
+ * <p>https://github.com/cashapp/paparazzi/issues/2373
+ */
+public class WindowManagerImplRemoveViewAdvice {
+  private WindowManagerImplRemoveViewAdvice() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Invoked when {@code removeView} exits with a {@link NullPointerException}. Nulling the
+   * thrown value (via the {@code readOnly = false} write-back) suppresses the exception so
+   * teardown completes cleanly.
+   */
+  @Advice.OnMethodExit(onThrowable = NullPointerException.class)
+  public static void suppressNullPointerException(@Advice.Thrown(readOnly = false) Throwable throwable) {
+    throwable = null;
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdviceAccessor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/WindowManagerImplRemoveViewAdviceAccessor.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.internal.interceptors
+
+/**
+ * Exposes the package-private [WindowManagerImplRemoveViewAdvice] Java class to other
+ * packages. The advice class stays package-private so it does not become part of the public
+ * API surface, mirroring the Kotlin `internal` interceptor classes.
+ */
+internal object WindowManagerImplRemoveViewAdviceAccessor {
+  val adviceClass: Class<*> = WindowManagerImplRemoveViewAdvice::class.java
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/WindowManagerRemoveViewNpeTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/WindowManagerRemoveViewNpeTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import android.content.Context
+import android.view.View
+import android.view.WindowManager
+import android.view.WindowManagerImpl
+import android.widget.TextView
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression test for https://github.com/cashapp/paparazzi/issues/2373.
+ *
+ * layoutlib 16.2.1's [WindowManagerImpl.removeView] does not null-check the result of
+ * [ViewGroup.buildOrderedChildList] before calling `size()` on it. When a window (e.g. a
+ * Compose Dialog) is dismissed and its view is removed, leaving exactly one child in the
+ * window's root view, `buildOrderedChildList()` returns null and `removeView` throws a
+ * [NullPointerException].
+ *
+ * This test reproduces that exact state without needing Compose: after a view is rendered
+ * (so the render root is attached and views have a [ViewRootImpl]), it adds two views to the
+ * window manager and removes the last one. [WindowManagerImplRemoveViewAdvice] must suppress
+ * the resulting NPE for the test to pass.
+ */
+class WindowManagerRemoveViewNpeTest {
+  @get:Rule
+  val testRule = PaparazziTestRule()
+
+  val paparazzi
+    get() = testRule.paparazzi
+
+  @Test
+  fun removeViewDoesNotCrashWhenOneChildRemains() {
+    // Render once so the render root is attached; views added to the window manager then
+    // have a ViewRootImpl, which is required for the buggy code path in removeView to run.
+    paparazzi.snapshot(TextView(paparazzi.context))
+
+    val windowManager = paparazzi.context.getSystemService(Context.WINDOW_SERVICE) as WindowManagerImpl
+
+    val first = TextView(paparazzi.context)
+    val last = TextView(paparazzi.context)
+    val layoutParams = WindowManager.LayoutParams(
+      WindowManager.LayoutParams.MATCH_PARENT,
+      WindowManager.LayoutParams.MATCH_PARENT
+    )
+
+    windowManager.addView(first, layoutParams)
+    windowManager.addView(last, layoutParams)
+
+    // Removing the last added view leaves exactly one child in the window root view, which
+    // makes ViewGroup.buildOrderedChildList() return null in the following removeView
+    // reentrant path. Without the WindowManagerImplRemoveViewAdvice workaround this throws:
+    //   NullPointerException: Cannot invoke "java.util.ArrayList.size()" because
+    //   "childrenList" is null
+    windowManager.removeView(last)
+
+    // Clean up the remaining window.
+    windowManager.removeView(first)
+  }
+}

--- a/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/agent/InterceptorRegistrarTest.kt
@@ -16,6 +16,11 @@ class InterceptorRegistrarTest {
         "log2" to Interceptor2::class.java
       )
     )
+    InterceptorRegistrar.addAdvice(
+      "app.cash.paparazzi.agent.InterceptorRegistrarTest\$Utils",
+      "log3",
+      NullPointerExceptionSuppressingAdvice::class.java
+    )
 
     ByteBuddyAgent.install()
     InterceptorRegistrar.registerMethodInterceptors()
@@ -25,8 +30,10 @@ class InterceptorRegistrarTest {
   fun test() {
     Utils.log1()
     Utils.log2()
+    // log3 throws a NullPointerException that must be suppressed by the registered advice.
+    Utils.log3()
 
-    assertThat(logs).containsExactly("intercept1", "intercept2").inOrder()
+    assertThat(logs).containsExactly("intercept1", "intercept2", "adviceLog").inOrder()
   }
 
   @After
@@ -41,6 +48,11 @@ class InterceptorRegistrarTest {
 
     fun log2() {
       logs += "original2"
+    }
+
+    fun log3() {
+      logs += "adviceLog"
+      throw NullPointerException("boom")
     }
   }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/agent/NullPointerExceptionSuppressingAdvice.java
+++ b/paparazzi/src/test/java/app/cash/paparazzi/agent/NullPointerExceptionSuppressingAdvice.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.agent;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Test advice that suppresses a {@link NullPointerException} thrown by the instrumented
+ * method, mirroring the {@code WindowManagerImpl.removeView} workaround.
+ */
+public final class NullPointerExceptionSuppressingAdvice {
+  private NullPointerExceptionSuppressingAdvice() {
+    throw new AssertionError();
+  }
+
+  @Advice.OnMethodExit(onThrowable = NullPointerException.class)
+  public static void suppressNullPointerException(@Advice.Thrown(readOnly = false) Throwable throwable) {
+    throwable = null;
+  }
+}


### PR DESCRIPTION
**Closes #2373**

**What's happening**

Rendering a Compose `Dialog` crashes during teardown with:

```
NullPointerException: Cannot invoke "java.util.ArrayList.size()" because "childrenList" is null
    at android.view.WindowManagerImpl.removeView(WindowManagerImpl.java:209)
```

That's a layoutlib 16.2.1 bug. `removeView` doesn't null-check the result of `ViewGroup.buildOrderedChildList()` before calling `size()` on it. When the dialog's view is removed from the window and one child is left behind, `buildOrderedChildList()` returns null and everything blows up.

**The fix**

I registered a `net.bytebuddy.asm.Advice` on `WindowManagerImpl.removeView` that swallows the NPE. By the time it's thrown, the view has already been removed. Only the `ViewRootImpl` child reassignment fails, so ignoring it is safe.

Side note: I first tried a `MethodDelegation` interceptor with `@SuperCall`, but ByteBuddy can't bind that here since `removeView` implements an interface method and there's no super implementation to delegate to. `@Advice` wraps the method body in place, which sidesteps that entirely.

While doing this I also restructured `InterceptorRegistrar` a bit: delegations and advice for the same class are now grouped into a single redefine pass, because two separate redefines of one class undo each other.

**Test**

Added `WindowManagerRemoveViewNpeTest`, which reproduces the exact layoutlib state: add two views to the window manager, remove the last one. It fails with the same NPE without the fix and passes with it.
