### PR TITLE
Note the sRGB color space in PNG and APNG output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New
+* Note the sRGB color space in PNG and APNG output (#40)
 * Add `Paparazzi#gif` overloads that accept a `@Composable` directly, mirroring the existing `snapshot` Compose overloads:
 
 ```kotlin

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngReader.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngReader.kt
@@ -23,6 +23,7 @@ import app.cash.paparazzi.internal.apng.PngConstants.Header.FDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IEND
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IHDR
+import app.cash.paparazzi.internal.apng.PngConstants.Header.SRGB
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_COLOR_TYPE_RGB
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_COLOR_TYPE_RGBA
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_SIG
@@ -120,6 +121,7 @@ internal class ApngReader(
         IHDR -> data.readIHDR()
         ACTL -> data.readACTL()
         FCTL -> data.readFCTL()
+        SRGB -> {} // Color space declaration, no action needed
         IDAT -> data.readIDAT()
         FDAT -> data.readFDAT()
         IEND -> throw IOException("PNG ended while processing to $header")

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/ApngWriter.kt
@@ -25,9 +25,11 @@ import app.cash.paparazzi.internal.apng.PngConstants.Header.FDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IEND
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IHDR
+import app.cash.paparazzi.internal.apng.PngConstants.Header.SRGB
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_BITS_PER_PIXEL
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_COLOR_TYPE_RGB
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_COLOR_TYPE_RGBA
+import app.cash.paparazzi.internal.apng.PngConstants.PNG_SRGB_RENDERING_INTENT_PERCEPTUAL
 import okio.Buffer
 import okio.BufferedSink
 import okio.FileSystem
@@ -97,6 +99,7 @@ internal class ApngWriter(
         writeACTL(frameCount, 0)
         writeFCTL(0, Rectangle(maxWidth, maxHeight))
       }
+      writeSRGB()
       writeIDAT(firstFrameResized)
 
       // Copy over the subsequent frames, if we have any.
@@ -136,6 +139,14 @@ internal class ApngWriter(
       writeByte(0) // Compression
       writeByte(0) // Filter
       writeByte(0) // Interlace
+    }
+  }
+
+  private fun BufferedSink.writeSRGB() {
+    // The sRGB chunk declares the color space of the image data. Per the PNG specification
+    // it must appear before the PLTE and IDAT chunks. See https://www.w3.org/TR/png/#11sRGB
+    writeChunk(SRGB) {
+      writeByte(PNG_SRGB_RENDERING_INTENT_PERCEPTUAL.toInt())
     }
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/PngConstants.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/apng/PngConstants.kt
@@ -25,11 +25,13 @@ internal object PngConstants {
   const val PNG_COLOR_TYPE_RGB: Byte = 2
   const val PNG_COLOR_TYPE_RGBA: Byte = 6
   const val PNG_BITS_PER_PIXEL: Byte = 8
+  const val PNG_SRGB_RENDERING_INTENT_PERCEPTUAL: Byte = 0
 
   enum class Header(val bytes: ByteArray) {
     IHDR("IHDR".toByteArray()),
     ACTL("acTL".toByteArray()),
     FCTL("fcTL".toByteArray()),
+    SRGB("sRGB".toByteArray()),
     IDAT("IDAT".toByteArray()),
     FDAT("fdAT".toByteArray()),
     IEND("IEND".toByteArray())

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngReaderTest.kt
@@ -17,6 +17,8 @@
 package app.cash.paparazzi.internal.apng
 
 import app.cash.paparazzi.internal.ImageUtils
+import app.cash.paparazzi.internal.apng.PngTestUtils.DEFAULT_SIZE
+import app.cash.paparazzi.internal.apng.PngTestUtils.createImage
 import app.cash.paparazzi.internal.differs.OffByTwo
 import com.google.common.truth.Truth.assertThat
 import okio.FileSystem
@@ -25,6 +27,7 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.awt.Point
 import java.io.File
 import java.io.IOException
 import javax.imageio.ImageIO
@@ -83,6 +86,22 @@ class ApngReaderTest {
       fail("File has invalid CRC, should fail")
     } catch (e: IOException) {
       assertThat(e).hasMessageThat().isEqualTo("CRC Mismatch decoding IHDR, invalid data")
+    }
+  }
+
+  @Test
+  fun decodesPNGWithSRGBColorSpaceChunk() {
+    val testPath = tempDir.newFile("decodesPNGWithSRGBColorSpaceChunk.png").path.toPath()
+    ApngWriter(testPath, 1).use { writer ->
+      writer.writeImage(createImage(squareOffset = Point(5, 5)))
+    }
+
+    ApngReader(FileSystem.SYSTEM.openReadOnly(testPath)).use { reader ->
+      val image = requireNotNull(reader.readNextFrame())
+      assertThat(image.width).isEqualTo(DEFAULT_SIZE)
+      assertThat(image.height).isEqualTo(DEFAULT_SIZE)
+      assertThat(reader.isFinished()).isTrue()
+      assertThat(reader.frameCount).isEqualTo(reader.frameNumber)
     }
   }
 

--- a/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/internal/apng/ApngWriterTest.kt
@@ -23,9 +23,11 @@ import app.cash.paparazzi.internal.apng.PngConstants.Header.FCTL
 import app.cash.paparazzi.internal.apng.PngConstants.Header.FDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IDAT
 import app.cash.paparazzi.internal.apng.PngConstants.Header.IHDR
+import app.cash.paparazzi.internal.apng.PngConstants.Header.SRGB
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_BITS_PER_PIXEL
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_COLOR_TYPE_RGBA
 import app.cash.paparazzi.internal.apng.PngConstants.PNG_SIG
+import app.cash.paparazzi.internal.apng.PngConstants.PNG_SRGB_RENDERING_INTENT_PERCEPTUAL
 import app.cash.paparazzi.internal.apng.PngTestUtils.BACKGROUND_COLOR
 import app.cash.paparazzi.internal.apng.PngTestUtils.DEFAULT_SIZE
 import app.cash.paparazzi.internal.apng.PngTestUtils.createImage
@@ -91,11 +93,34 @@ class ApngWriterTest {
       testHandle.source(0L).buffer().use { buffer ->
         buffer.skip(PNG_SIG.size.toLong()) // Header
         assertThat(buffer.assertNextChunk().first).isEqualTo(IHDR)
+        assertThat(buffer.assertNextChunk().first).isEqualTo(SRGB)
 
         val (idat, idatData) = buffer.assertNextChunk()
         assertThat(idat).isEqualTo(IDAT)
         val imageData = idatData.decompress()
         assertThat(imageData.size).isEqualTo((DEFAULT_SIZE * DEFAULT_SIZE * 4L) + DEFAULT_SIZE)
+      }
+    }
+  }
+
+  @Test
+  fun writesSRGBColorSpaceChunkAfterIHDR() {
+    val testPath = tempFolderRule.newFile("writesSRGBColorSpaceChunkAfterIHDR.png").path.toPath()
+    ApngWriter(testPath, 1).use { writer ->
+      writer.writeImage(createImage(squareOffset = Point(5, 5)))
+    }
+
+    FileSystem.SYSTEM.openReadOnly(testPath).use { testHandle ->
+      testHandle.source(0L).buffer().use { buffer ->
+        buffer.skip(PNG_SIG.size.toLong()) // Header
+        assertThat(buffer.assertNextChunk().first).isEqualTo(IHDR)
+
+        val (sRGB, sRGBData) = buffer.assertNextChunk()
+        assertThat(sRGB).isEqualTo(SRGB)
+        assertThat(sRGBData.readByte()).isEqualTo(PNG_SRGB_RENDERING_INTENT_PERCEPTUAL)
+        assertThat(sRGBData.exhausted()).isTrue()
+
+        assertThat(buffer.assertNextChunk().first).isEqualTo(IDAT)
       }
     }
   }
@@ -163,6 +188,7 @@ class ApngWriterTest {
         assertThat(buffer.assertNextChunk().first).isEqualTo(IHDR)
         assertThat(buffer.assertNextChunk().first).isEqualTo(ACTL)
         assertThat(buffer.assertNextChunk().first).isEqualTo(FCTL)
+        assertThat(buffer.assertNextChunk().first).isEqualTo(SRGB)
         assertThat(buffer.assertNextChunk().first).isEqualTo(IDAT)
 
         val (header, data) = buffer.assertNextChunk()
@@ -191,6 +217,7 @@ class ApngWriterTest {
         assertThat(buffer.assertNextChunk().first).isEqualTo(IHDR)
         assertThat(buffer.assertNextChunk().first).isEqualTo(ACTL)
         assertThat(buffer.assertNextChunk().first).isEqualTo(FCTL)
+        assertThat(buffer.assertNextChunk().first).isEqualTo(SRGB)
         assertThat(buffer.assertNextChunk().first).isEqualTo(IDAT)
 
         val (header, data) = buffer.assertNextChunk()
@@ -232,6 +259,7 @@ class ApngWriterTest {
 
         assertThat(buffer.assertNextChunk().first).isEqualTo(ACTL)
         assertThat(buffer.assertNextChunk().first).isEqualTo(FCTL)
+        assertThat(buffer.assertNextChunk().first).isEqualTo(SRGB)
 
         val (idat, idatData) = buffer.assertNextChunk()
         assertThat(idat).isEqualTo(IDAT)


### PR DESCRIPTION
### Summary

Paparazzi writes snapshot images as PNG and APNG files whose pixels are in the sRGB color space, but the files never declared it. Decoders have to guess the color space of every snapshot. I made the color space explicit by writing the PNG `sRGB` chunk with the Perceptual rendering intent, as the first step toward wide color screenshots (see #40).

### What I changed

- `PngConstants`: added the `SRGB` chunk header and a constant for the Perceptual rendering intent (value 0).
- `ApngWriter`: every PNG now carries an `sRGB` chunk with a one byte payload. I placed the chunk after the header chunks (IHDR, and acTL/fcTL for animated output) and before IDAT, which is where the PNG specification requires it.
- `ApngReader`: I taught the reader to accept the `sRGB` chunk and skip its payload, so files written by the updated writer round trip cleanly. Without this branch the code does not compile, because the chunk dispatcher requires exhaustive handling of every known chunk.
- `CHANGELOG.md`: added an entry under Unreleased.

### Why a real chunk and not a workaround

I used the `sRGB` chunk because it is the standard PNG mechanism for declaring the color space of image data, defined in the PNG 1.2 specification. Any conforming decoder, including `ImageIO` and Android's `BitmapFactory`, understands it. This keeps every snapshot self-describing and gives us a solid baseline when we add wide color gamut support later.

### How I tested it

- Added `ApngWriterTest.writesSRGBColorSpaceChunkAfterIHDR`, which asserts the chunk id, its position between IHDR and IDAT, the Perceptual intent byte, and a valid CRC.
- Added `ApngReaderTest.decodesPNGWithSRGBColorSpaceChunk`, which writes a PNG with the updated writer and decodes it with the reader.
- Updated the four existing chunk sequence tests to include the new chunk.
- APNG suite: 20 tests, 0 failures.
- Full `:paparazzi:test` suite: 126 tests, 0 failures.
- I also validated the output independently: a Python PNG chunk parser reports `IHDR, sRGB, IDAT, IEND` with intent byte 0 and valid CRCs, and macOS `sips` decodes the file.

### Follow ups

- The `delta-*.png` diagnostics written via `ImageIO.write` in `ImageUtils` are a separate output path and I left them unchanged; they can get the same treatment later.
- Third party PNGs with unknown ancillary chunks (gAMA, PLTE, tEXt) still fail in `ApngReader` because `Header.valueOf` throws for chunk types outside the enum; a graceful skip for unknown chunks would be a good follow up.

Fixes #40
