### PR TITLE
Generate the HTML report in verify mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ paparazzi.gif {
 }
 ```
 
+### Fixed
+* Generate the HTML report in verify mode, and include the expected/actual/delta images of failing snapshots in it (#167)
+
 ## [2.0.0-alpha05] - 2026-05-20
 
 This release supports pre-AGP 9.0 consumers.

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1628,6 +1628,35 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun verifyReportGeneratedOnFailure() {
+    val fixtureRoot = File("src/test/projects/report-snapshots")
+
+    val result = gradleRunner
+      .withArguments("verifyPaparazziDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { buildAndFail() }
+
+    assertThat(result.task(":testDebugUnitTest")?.outcome).isEqualTo(TaskOutcome.FAILED)
+
+    val reportDir = File(fixtureRoot, "build/reports/paparazzi/debug").registerForDeletionOnExit()
+    assertThat(File(reportDir, "index.html").exists()).isTrue()
+
+    // Each test class writes its own run file, and an earlier test on this fixture may have
+    // left one behind, so pick the newest run that belongs to SimpleTest.
+    val simpleTestRunJs = File(reportDir, "runs").listFiles()!!
+      .filter { it.extension == "js" && it.readText().contains("SimpleTest") }
+      .maxByOrNull { it.lastModified() }
+    assertThat(simpleTestRunJs).isNotNull()
+    val runJsText = simpleTestRunJs!!.readText()
+    assertThat(runJsText).contains("expectedFile")
+    assertThat(runJsText).contains("deltaFile")
+
+    val imageName = "app.cash.paparazzi.plugin.test_SimpleTest_compose.png"
+    assertThat(File(reportDir, "images/expected-$imageName")).exists()
+    assertThat(File(reportDir, "images/actual-$imageName")).exists()
+    assertThat(File(reportDir, "images/delta-$imageName")).exists()
+  }
+
+  @Test
   fun configIsUpdatable() {
     val fixtureRoot = File("src/test/projects/update-paparazzi-config")
 

--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -234,11 +234,13 @@ public abstract interface class app/cash/paparazzi/RenderExtension {
 
 public final class app/cash/paparazzi/Snapshot {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;)Lapp/cash/paparazzi/Snapshot;
-	public static synthetic fun copy$default (Lapp/cash/paparazzi/Snapshot;Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/paparazzi/Snapshot;
+	public fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lapp/cash/paparazzi/Snapshot;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/Snapshot;Ljava/lang/String;Lapp/cash/paparazzi/TestName;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/paparazzi/Snapshot;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeltaFile ()Ljava/lang/String;
+	public final fun getExpectedFile ()Ljava/lang/String;
 	public final fun getFile ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTags ()Ljava/util/List;

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -18,17 +18,20 @@ package app.cash.paparazzi
 import app.cash.paparazzi.SnapshotHandler.FrameHandler
 import app.cash.paparazzi.internal.ImageUtils
 import app.cash.paparazzi.internal.PaparazziJson
+import app.cash.paparazzi.internal.apng.ApngVerifier
 import app.cash.paparazzi.internal.apng.ApngWriter
 import com.google.common.base.CharMatcher
 import com.google.common.io.Files
 import okio.BufferedSink
 import okio.HashingSink
+import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 import okio.blackholeSink
 import okio.buffer
 import okio.sink
 import okio.source
 import java.awt.image.BufferedImage
+import java.awt.image.BufferedImage.TYPE_INT_ARGB
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -43,6 +46,11 @@ import javax.imageio.ImageIO
  * contents. Note that the images/ directory includes the individual frames of each video.
  *
  * Runs are named by their date.
+ *
+ * When `paparazzi.test.verify` is set, snapshots are compared against their golden instead of being recorded.
+ * The report is still generated for the run: failed snapshots write expected/actual/delta images into the report's
+ * images/ directory (referenced from the run data) and the failure delta into the failures directory, and the test
+ * fails with an [AssertionError].
  *
  * ```
  * images
@@ -78,6 +86,8 @@ public class HtmlReportWriter @JvmOverloads constructor(
 
   private val isRecording: Boolean =
     System.getProperty("paparazzi.test.record")?.toBoolean() == true
+  private val isVerifying: Boolean =
+    System.getProperty("paparazzi.test.verify")?.toBoolean() == true
   private val overwriteOnMaxPercentDifference: Boolean =
     System.getProperty("paparazzi.test.record.overwriteOnMaxPercentDifference")?.toBoolean() == true
 
@@ -97,37 +107,137 @@ public class HtmlReportWriter @JvmOverloads constructor(
       val hashes = mutableListOf<String>()
       val snapshotTmpFile = File(snapshotDir, snapshot.toFileName(extension = "temp.png"))
       val writer = ApngWriter(snapshotTmpFile.path.toPath(), fps)
+      var stillImage: BufferedImage? = null
+      val pngVerifier: ApngVerifier? = if (isVerifying && fps != -1) {
+        val fileName = snapshot.toFileName("_", "png")
+        ApngVerifier(
+          goldenFilePath = File(goldenDir, fileName).toOkioPath(),
+          deltaFilePath = File(failureDir, "delta-$fileName").toOkioPath(),
+          fps = fps,
+          frameCount = frameCount,
+          maxPercentDifference = maxPercentDifference,
+          differ = differ
+        )
+      } else {
+        null
+      }
 
       override fun handle(image: BufferedImage) {
         writer.writeImage(image)
+        pngVerifier?.verifyFrame(image)
         hashes += hash(image)
+        if (fps == -1) {
+          stillImage = image
+        }
       }
 
       override fun close() {
         if (hashes.isEmpty()) return
-        writer.close()
-        val snapshotFile = File(snapshotDir, "${hash(hashes)}.png")
-        Files.move(snapshotTmpFile, snapshotFile)
-        snapshotTmpFile.delete()
+        var verifyError: AssertionError? = null
+        try {
+          pngVerifier?.assertFinished()
+        } catch (error: AssertionError) {
+          verifyError = error
+        } finally {
+          pngVerifier?.close()
+          writer.close()
+          val snapshotFile = File(snapshotDir, "${hash(hashes)}.png")
+          Files.move(snapshotTmpFile, snapshotFile)
+          snapshotTmpFile.delete()
 
-        if (isRecording) {
-          val goldenFile = File(goldenDir, snapshot.toFileName("_", "png"))
-          if (!overwriteOnMaxPercentDifference || !goldenFile.exists()) {
-            snapshotFile.copyTo(target = goldenFile, overwrite = true)
-          } else {
-            val result = ImageUtils.compareImages(
-              goldenImage = ImageIO.read(goldenFile),
-              image = ImageIO.read(snapshotFile),
-              differ = differ
-            )
-            if (result.second > maxPercentDifference) {
+          if (isRecording) {
+            val goldenFile = File(goldenDir, snapshot.toFileName("_", "png"))
+            if (!overwriteOnMaxPercentDifference || !goldenFile.exists()) {
               snapshotFile.copyTo(target = goldenFile, overwrite = true)
+            } else {
+              val result = ImageUtils.compareImages(
+                goldenImage = ImageIO.read(goldenFile),
+                image = ImageIO.read(snapshotFile),
+                differ = differ
+              )
+              if (result.second > maxPercentDifference) {
+                snapshotFile.copyTo(target = goldenFile, overwrite = true)
+              }
             }
           }
-        }
 
-        shots += snapshot.copy(file = snapshotFile.toJsonPath())
+          if (isVerifying && fps == -1) {
+            verifyStillSnapshot(snapshot, snapshotFile, checkNotNull(stillImage))
+          } else if (verifyError != null) {
+            // Failed video: surface the expected/actual/delta in the report like stills do.
+            val imageName = snapshot.toFileName("_", "png")
+            val expectedFile = File(imagesDirectory, "expected-$imageName")
+            val actualFile = File(imagesDirectory, "actual-$imageName")
+            val deltaFile = File(imagesDirectory, "delta-$imageName")
+            File(goldenDir, imageName).copyTo(expectedFile, overwrite = true)
+            snapshotFile.copyTo(actualFile, overwrite = true)
+            File(failureDir, "delta-$imageName").copyTo(deltaFile, overwrite = true)
+            shots += snapshot.copy(
+              file = actualFile.toJsonPath(),
+              expectedFile = expectedFile.toJsonPath(),
+              deltaFile = deltaFile.toJsonPath()
+            )
+          } else {
+            shots += snapshot.copy(file = snapshotFile.toJsonPath())
+          }
+
+          verifyError?.let { throw it }
+        }
       }
+    }
+  }
+
+  /**
+   * Compares a still snapshot against its golden and records the outcome in the report.
+   *
+   * On failure the expected, actual and delta images are written into the report's images/
+   * directory and referenced from the run data, so failed runs can be reviewed from the HTML
+   * report. The delta and actual images are also written to the failures directory (as
+   * [ImageUtils.assertImageSimilar] does) for the Gradle test report, and an [AssertionError]
+   * is thrown to fail the test, mirroring [SnapshotVerifier].
+   */
+  private fun verifyStillSnapshot(snapshot: Snapshot, snapshotFile: File, image: BufferedImage) {
+    val goldenFile = File(goldenImagesDirectory, snapshot.toFileName("_", "png"))
+    val goldenImage = if (!goldenFile.exists()) {
+      // No golden recorded yet: compare against a blank canvas so the run is reported as a failure.
+      BufferedImage(image.width, image.height, TYPE_INT_ARGB)
+    } else {
+      ImageIO.read(goldenFile)
+    } ?: throw NullPointerException(
+      """
+      Failed to read the snapshot file from the file system.
+
+      If your project uses git LFS, it's possible that it's misconfigured on your machine and
+      Paparazzi has just loaded a pointer file instead of the real snapshot file. Follow git
+      LFS troubleshooting instructions and try again.
+
+      """.trimIndent()
+    )
+
+    try {
+      ImageUtils.assertImageSimilar(
+        relativePath = goldenFile.path,
+        image = image,
+        goldenImage = goldenImage,
+        maxPercentDifferent = maxPercentDifference,
+        failureDir = failureDir,
+        differ = differ
+      )
+      shots += snapshot.copy(file = snapshotFile.toJsonPath())
+    } catch (error: AssertionError) {
+      val imageName = snapshot.toFileName("_", "png")
+      val expectedFile = File(imagesDirectory, "expected-$imageName")
+      val actualFile = File(imagesDirectory, "actual-$imageName")
+      val deltaFile = File(imagesDirectory, "delta-$imageName")
+      ImageIO.write(goldenImage, "PNG", expectedFile)
+      snapshotFile.copyTo(actualFile, overwrite = true)
+      File(failureDir, "delta-$imageName").copyTo(deltaFile, overwrite = true)
+      shots += snapshot.copy(
+        file = actualFile.toJsonPath(),
+        expectedFile = expectedFile.toJsonPath(),
+        deltaFile = deltaFile.toJsonPath()
+      )
+      throw error
     }
   }
 
@@ -240,6 +350,16 @@ public class HtmlReportWriter @JvmOverloads constructor(
   }
 
   private fun File.toJsonPath(): String = relativeTo(rootDirectory).invariantSeparatorsPath
+
+  private companion object {
+    /** Directory where failure deltas and actual images are written, for the Gradle test report. */
+    private val failureDir: File
+      get() {
+        val path = System.getProperty("paparazzi.failures.dir")
+          ?: error("paparazzi.failures.dir system property is required in verify mode")
+        return File(path).apply { mkdirs() }
+      }
+  }
 }
 
 internal fun defaultRunName(): String {

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -211,14 +211,7 @@ public class Paparazzi @JvmOverloads constructor(
   }
 
   private companion object {
-    private val isVerifying: Boolean =
-      System.getProperty("paparazzi.test.verify")?.toBoolean() == true
-
     private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
-      if (isVerifying) {
-        SnapshotVerifier(maxPercentDifference)
-      } else {
-        HtmlReportWriter(maxPercentDifference = maxPercentDifference)
-      }
+      HtmlReportWriter(maxPercentDifference = maxPercentDifference)
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Snapshot.kt
@@ -26,15 +26,19 @@ public class Snapshot(
   public val testName: TestName,
   public val timestamp: Date,
   public val tags: List<String> = listOf(),
-  public val file: String? = null
+  public val file: String? = null,
+  public val expectedFile: String? = null,
+  public val deltaFile: String? = null
 ) {
   public fun copy(
     name: String? = this.name,
     testName: TestName = this.testName,
     timestamp: Date = this.timestamp,
     tags: List<String> = this.tags,
-    file: String? = this.file
-  ): Snapshot = Snapshot(name, testName, timestamp, tags, file)
+    file: String? = this.file,
+    expectedFile: String? = this.expectedFile,
+    deltaFile: String? = this.deltaFile
+  ): Snapshot = Snapshot(name, testName, timestamp, tags, file, expectedFile, deltaFile)
 }
 
 internal val invalidPrintableChars = CharMatcher.anyOf("<>:\"/\\|?*")

--- a/paparazzi/src/main/resources/index.html
+++ b/paparazzi/src/main/resources/index.html
@@ -18,6 +18,44 @@
       width: 300px;
     }
 
+    .test__details__selector--failed {
+      background-color: #e53935;
+    }
+
+    .screen--failed {
+      border: 2px solid #e53935;
+    }
+
+    .screen--failed::after {
+      content: "FAILED";
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: #e53935;
+      color: #fff;
+      padding: 2px 6px;
+      font-size: 11px;
+    }
+
+    .shot__diff {
+      display: none;
+      justify-content: center;
+    }
+
+    .shot__diff figure {
+      margin: 0 0.2em;
+    }
+
+    .shot__diff img {
+      width: 120px;
+    }
+
+    .shot__diff figcaption {
+      color: #fff;
+      font-size: 11px;
+      text-align: center;
+    }
+
     div.overlay__hovered {
         display: block;
     }

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -1,9 +1,13 @@
+'use strict';
+
 window.runs = {};
+
+// Root container for all rendered shots; assigned by bootstrap().
+let rootContainer;
 
 class Run {
   constructor(id, data) {
     this.id = id;
-    // TODO(oldergod) which entries are required/optional?
     this.data = data;
   }
 }
@@ -13,24 +17,57 @@ class Shot {
     this.name = name;
     this.test = test;
 
-    [, this.package, this.clazz, this.method] = Shot.TestMethodRegex.exec(test);
+    [, this.package, this.clazz, this.method] = Shot.testMethodRegex.exec(test);
 
     this.runs = [];
   }
 
-  static get TestMethodRegex() {
+  static get testMethodRegex() {
     return /^(.*)\.(.*)#(.*)$/;
   }
 
-  addRun(runId, file, timestamp) {
-    this.runs.push(
-      {
-        'id': runId,
-        'file': file,
-        'timestamp': timestamp
-      }
-    );
+  addRun(runId, file, timestamp, deltaFile, expectedFile) {
+    const run = { id: runId, file, timestamp, deltaFile, expectedFile };
+    this.runs.push(run);
+    this.displayRun(run);
 
+    const circle = el('div', 'test__details__selector');
+    if (deltaFile !== undefined) {
+      circle.classList.add('test__details__selector--failed');
+    }
+    circle.onmouseover = () => {
+      this.displayRun(run);
+      for (const shot of Object.values(paparazziRenderer.shots)) {
+        const otherRun = shot.runs.find((candidate) => candidate.id === runId);
+        shot.img.style.opacity = otherRun ? '1' : '0.3';
+        if (otherRun) {
+          shot.displayRun(otherRun);
+        }
+      }
+    };
+    this.overlayDiv.appendChild(circle);
+  }
+
+  displayRun(run) {
+    if (run.deltaFile !== undefined) {
+      // Failed run: show the expected/actual/delta comparison instead of the single image.
+      this.displayFailure(run);
+    } else {
+      this.displayMedia(run.file);
+    }
+    this.timestampP.innerText = run.timestamp;
+  }
+
+  displayFailure(run) {
+    this.screenDiv.classList.add('screen--failed');
+    this.img.style.display = 'none';
+    this.video.style.display = 'none';
+    this.renderDiff(run.expectedFile, run.file, run.deltaFile);
+  }
+
+  displayMedia(file) {
+    this.screenDiv.classList.remove('screen--failed');
+    this.hideDiff();
     if (file.endsWith('.png')) {
       this.img.src = file;
       this.img.style.display = 'inline';
@@ -40,91 +77,77 @@ class Shot {
       this.video.style.display = 'inline';
       this.img.style.display = 'none';
     }
-    this.timestampP.innerText = timestamp;
+  }
 
-    const circle = document.createElement('div');
-    circle.classList.add('test__details__selector', `run-${runId}`);
-    circle.onmouseover = function (e) {
-      if (file.endsWith('.png')) {
-        this.img.src = file;
-      } else {
-        this.video.src = file;
-      }
+  renderDiff(expectedFile, actualFile, deltaFile) {
+    if (this.diffDiv === undefined) {
+      this.diffDiv = el('div', 'shot__diff');
+      this.screenDiv.appendChild(this.diffDiv);
+    }
+    this.diffDiv.style.display = 'flex';
+    this.diffDiv.innerHTML = '';
 
-      for (let shot of Object.values(paparazziRenderer.shots)) {
-        let found = false;
-        for (let run of shot.runs) {
-          if (runId == run.id) {
-            shot.img.src = run.file;
-            shot.timestampP.innerText = run.timestamp;
+    const panels = [
+      ['expected', expectedFile],
+      ['actual', actualFile],
+      ['delta', deltaFile]
+    ];
+    for (const [label, src] of panels) {
+      const img = el('img');
+      img.src = src;
+      const figure = el('figure');
+      figure.appendChild(img);
+      figure.appendChild(el('figcaption', null, label));
+      this.diffDiv.appendChild(figure);
+    }
+  }
 
-            found = true;
-            break;
-          }
-        }
-        shot.img.style.opacity = found ? "1" : "0.3";
-      }
-    }.bind(this);
-    this.overlayDiv.appendChild(circle);
+  hideDiff() {
+    if (this.diffDiv !== undefined) {
+      this.diffDiv.style.display = 'none';
+    }
   }
 
   removeRun(runId) {
-    const index = this.runs.indexOf((run) => run.id == runId);
-    if (index == -1) return;
-
-    this.runs.splice(index, 1);
+    const index = this.runs.findIndex((run) => run.id === runId);
+    if (index !== -1) {
+      this.runs.splice(index, 1);
+    }
   }
 
   inflate() {
-    const screenDiv = document.createElement('div');
-    screenDiv.classList.add('screen');
+    const screenDiv = el('div', 'screen');
+    rootContainer.appendChild(screenDiv);
+    this.screenDiv = screenDiv;
 
-    document.rootContainer.appendChild(screenDiv);
-
-    const img = document.createElement('img');
-    const video = document.createElement('video');
+    const img = el('img');
+    const video = el('video');
     video.autoplay = 'autoplay';
     video.muted = 'muted';
     video.loop = 'loop';
 
-    const overlayDiv = document.createElement('div');
-    overlayDiv.classList.add('overlay');
-
+    const overlayDiv = el('div', 'overlay');
     screenDiv.appendChild(img);
     screenDiv.appendChild(video);
     screenDiv.appendChild(overlayDiv);
-    screenDiv.onmouseover = function (e) {
-      overlayDiv.classList.add('overlay__hovered');
-    }.bind(this);
-    screenDiv.onmouseout = function (e) {
-      overlayDiv.classList.remove('overlay__hovered');
-    }.bind(this);
 
-    const nameP = document.createElement('p');
-    nameP.classList.add('test__details', 'test__details__name');
+    screenDiv.onmouseover = () => overlayDiv.classList.add('overlay__hovered');
+    screenDiv.onmouseout = () => overlayDiv.classList.remove('overlay__hovered');
 
-    const classP = document.createElement('p');
-    classP.classList.add('test__details', 'test__details__class');
-
-    const packageP = document.createElement('p');
-    packageP.classList.add('test__details', 'test__details__package');
-
-    const timestampP = document.createElement('p');
-    timestampP.classList.add('test__details', 'test__details__timestamp');
+    const nameP = el('p', 'test__details test__details__name', this.method);
+    if (this.name !== undefined) {
+      nameP.innerText += ` ${this.name}`;
+    }
+    const classP = el('p', 'test__details test__details__class', this.clazz);
+    const packageP = el('p', 'test__details test__details__package', this.package);
+    const timestampP = el('p', 'test__details test__details__timestamp');
 
     overlayDiv.appendChild(nameP);
     overlayDiv.appendChild(classP);
     overlayDiv.appendChild(packageP);
     overlayDiv.appendChild(timestampP);
 
-    nameP.innerText = this.method;
-    if (this.name !== undefined) {
-      nameP.innerText += ` ${this.name}`;
-    }
-    classP.innerText = this.clazz;
-    packageP.innerText = this.package;
-
-    // hold references to the DOM for later updates
+    // Keep references to the DOM for later updates.
     this.img = img;
     this.video = video;
     this.timestampP = timestampP;
@@ -134,63 +157,58 @@ class Shot {
 
 class PaparazziRenderer {
   constructor() {
-    // Used for content comparison for we only re-render the updated ones.
+    // Used for content comparison so we only re-render the updated runs.
     this.currentRuns = {};
-    // Used to store runs we know won't be updated anymore.
+    // Runs we know won't be updated anymore.
     this.lockedRunIds = [];
-    this.shots = {}; // Key is `${test}${name}`, Value is a Shot.
+    this.shots = {}; // Key is `${test}${name}`, value is a Shot.
   }
 
   start() {
     this.loadRunScript('index.js');
-    for (let runId of window.all_runs) {
+    for (const runId of window.all_runs) {
       this.loadRunScript(`runs/${runId}.js`);
     }
-    setInterval(this.refresh.bind(this), 100);
+    setInterval(() => this.refresh(), 100);
   }
 
   render(run) {
-    if (this.currentRuns[run.id]
-      && JSON.stringify(this.currentRuns[run.id]) == JSON.stringify(run)) {
+    const previous = this.currentRuns[run.id];
+    if (previous && JSON.stringify(previous) === JSON.stringify(run)) {
       // This run didn't change.
       return;
     }
     this.currentRuns[run.id] = run;
-    console.log('rendering', run);
 
-    for (let datum of run.data) {
+    for (const datum of run.data) {
       const key = `${datum.testName}${datum.name}`;
       let shot = this.shots[key];
       if (!shot) {
-        console.log('New shot detected', shot);
         shot = new Shot(datum.name, datum.testName);
         this.shots[key] = shot;
         shot.inflate();
-      } else {
-        //shot.removeRun(run.id);
       }
 
-      console.log('Adding run to shot', shot);
-      shot.addRun(run.id, datum.file, datum.timestamp);
+      shot.addRun(run.id, datum.file, datum.timestamp, datum.deltaFile, datum.expectedFile);
 
-      // TODO setup listeners for filters/hovering, etc
+      // TODO: setup listeners for filters/hovering, etc.
     }
   }
 
   renderAll() {
     this.loadRunScript('index.js');
-    for (let runId of window.all_runs) {
+    for (const runId of window.all_runs) {
       if (this.lockedRunIds.includes(runId)) {
         continue;
       }
-      // The js loading is async so the rendering can happen in the next refresh
+      // Script loading is async, so the rendering happens on the next refresh.
       this.loadRunScript(`runs/${runId}.js`);
 
       this.render(new Run(runId, window.runs[runId]));
 
       const lastRunId = window.all_runs[window.all_runs.length - 1];
-      if (runId != lastRunId) {
-        // This run isn't the last run so we know it ain't gonna be updated.
+      if (runId !== lastRunId) {
+        // This run isn't the last one, so we know it won't be updated anymore.
         this.lockedRunIds.push(runId);
         delete this.currentRuns[runId];
       }
@@ -198,25 +216,33 @@ class PaparazziRenderer {
   }
 
   refresh() {
-    if (window.all_runs.length == 0) return;
-
+    if (window.all_runs.length === 0) return;
     this.renderAll();
   }
 
   loadRunScript(js) {
-    const script = document.createElement('script');
+    const script = el('script');
     script.src = js;
-    script.onload = function () {
-      this.remove();
-    }
+    script.onload = () => script.remove();
     document.head.appendChild(script);
   }
 }
 
 const paparazziRenderer = new PaparazziRenderer();
-console.log(paparazziRenderer);
 
 function bootstrap() {
-  document.rootContainer = document.getElementById('rootContainer');
+  rootContainer = document.getElementById('rootContainer');
   paparazziRenderer.start();
+}
+
+// Creates an element with an optional class name and text content.
+function el(tagName, className, text) {
+  const element = document.createElement(tagName);
+  if (className) {
+    element.className = className;
+  }
+  if (text !== undefined) {
+    element.innerText = text;
+  }
+  return element;
 }

--- a/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
@@ -30,6 +30,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.time.Instant
 import java.util.Date
+import javax.imageio.ImageIO
 
 class HtmlReportWriterTest {
   @get:Rule
@@ -592,6 +593,157 @@ class HtmlReportWriterTest {
       // reset record mode
       System.setProperty("paparazzi.test.record", "false")
       System.clearProperty("paparazzi.test.record.overwriteOnMaxPercentDifference")
+    }
+  }
+
+  @Test
+  fun verifyModeReportsFailureWithDiffImages() {
+    val oldVerify = System.getProperty("paparazzi.test.verify")
+    val oldFailureDir = System.getProperty("paparazzi.failures.dir")
+    try {
+      System.setProperty("paparazzi.test.verify", "true")
+      val failureDir = reportRoot.newFolder("failures")
+      System.setProperty("paparazzi.failures.dir", failureDir.path)
+
+      val snapshot = Snapshot(
+        name = "loading",
+        testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+        timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+      )
+      val imageName = snapshot.toFileName("_", "png")
+      val golden = File(snapshotRoot.root, "images/$imageName")
+      golden.parentFile.mkdirs()
+      ImageIO.write(anyImage, "PNG", golden)
+
+      val htmlReportWriter = HtmlReportWriter(
+        runName = "verify_run",
+        rootDirectory = reportRoot.root,
+        maxPercentDifference = 0.0,
+        differ = PixelPerfect,
+        snapshotRootDirectory = snapshotRoot.root
+      )
+      htmlReportWriter.use {
+        assertThrows(AssertionError::class.java) {
+          htmlReportWriter.newFrameHandler(snapshot = snapshot, frameCount = 1, fps = -1).use { frameHandler ->
+            frameHandler.handle(otherImage)
+          }
+        }
+      }
+
+      // The report is generated and includes the expected/actual/delta images for the failed run.
+      assertThat(File(reportRoot.root, "index.html")).exists()
+      assertThat(File(reportRoot.root, "images/expected-$imageName")).exists()
+      assertThat(File(reportRoot.root, "images/actual-$imageName")).exists()
+      assertThat(File(reportRoot.root, "images/delta-$imageName")).exists()
+
+      val runJs = File(reportRoot.root, "runs/verify_run.js").readText()
+      assertThat(runJs).contains("\"file\": \"images/actual-$imageName\"")
+      assertThat(runJs).contains("\"expectedFile\": \"images/expected-$imageName\"")
+      assertThat(runJs).contains("\"deltaFile\": \"images/delta-$imageName\"")
+
+      // The failure delta is still written to the failures dir for the Gradle test report.
+      assertThat(File(failureDir, "delta-$imageName")).exists()
+      assertThat(File(failureDir, imageName)).exists()
+    } finally {
+      System.setProperty("paparazzi.test.verify", oldVerify ?: "false")
+      if (oldFailureDir == null) {
+        System.clearProperty("paparazzi.failures.dir")
+      } else {
+        System.setProperty("paparazzi.failures.dir", oldFailureDir)
+      }
+    }
+  }
+
+  @Test
+  fun verifyModeReportsPassingSnapshot() {
+    val oldVerify = System.getProperty("paparazzi.test.verify")
+    val oldFailureDir = System.getProperty("paparazzi.failures.dir")
+    try {
+      System.setProperty("paparazzi.test.verify", "true")
+      val failureDir = reportRoot.newFolder("failures")
+      System.setProperty("paparazzi.failures.dir", failureDir.path)
+
+      val snapshot = Snapshot(
+        name = "loading",
+        testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+        timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+      )
+      val imageName = snapshot.toFileName("_", "png")
+      val golden = File(snapshotRoot.root, "images/$imageName")
+      golden.parentFile.mkdirs()
+      ImageIO.write(anyImage, "PNG", golden)
+
+      val htmlReportWriter = HtmlReportWriter(
+        runName = "verify_run",
+        rootDirectory = reportRoot.root,
+        maxPercentDifference = 0.0,
+        differ = PixelPerfect,
+        snapshotRootDirectory = snapshotRoot.root
+      )
+      htmlReportWriter.use {
+        htmlReportWriter.newFrameHandler(snapshot = snapshot, frameCount = 1, fps = -1).use { frameHandler ->
+          frameHandler.handle(anyImage)
+        }
+      }
+
+      val runJs = File(reportRoot.root, "runs/verify_run.js").readText()
+      assertThat(runJs).contains("\"file\": \"images/$anyImageHash.png\"")
+      assertThat(runJs).doesNotContain("expectedFile")
+      assertThat(runJs).doesNotContain("deltaFile")
+      assertThat(File(failureDir, "delta-$imageName")).doesNotExist()
+    } finally {
+      System.setProperty("paparazzi.test.verify", oldVerify ?: "false")
+      if (oldFailureDir == null) {
+        System.clearProperty("paparazzi.failures.dir")
+      } else {
+        System.setProperty("paparazzi.failures.dir", oldFailureDir)
+      }
+    }
+  }
+
+  @Test
+  fun verifyModeMissingGoldenFailsAndReports() {
+    val oldVerify = System.getProperty("paparazzi.test.verify")
+    val oldFailureDir = System.getProperty("paparazzi.failures.dir")
+    try {
+      System.setProperty("paparazzi.test.verify", "true")
+      val failureDir = reportRoot.newFolder("failures")
+      System.setProperty("paparazzi.failures.dir", failureDir.path)
+
+      val snapshot = Snapshot(
+        name = "loading",
+        testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+        timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+      )
+      val imageName = snapshot.toFileName("_", "png")
+      val golden = File(snapshotRoot.root, "images/$imageName")
+      assertThat(golden).doesNotExist()
+
+      val htmlReportWriter = HtmlReportWriter(
+        runName = "verify_run",
+        rootDirectory = reportRoot.root,
+        maxPercentDifference = 0.0,
+        differ = PixelPerfect,
+        snapshotRootDirectory = snapshotRoot.root
+      )
+      htmlReportWriter.use {
+        assertThrows(AssertionError::class.java) {
+          htmlReportWriter.newFrameHandler(snapshot = snapshot, frameCount = 1, fps = -1).use { frameHandler ->
+            frameHandler.handle(otherImage)
+          }
+        }
+      }
+
+      val runJs = File(reportRoot.root, "runs/verify_run.js").readText()
+      assertThat(runJs).contains("\"deltaFile\": \"images/delta-$imageName\"")
+      assertThat(File(reportRoot.root, "images/delta-$imageName")).exists()
+    } finally {
+      System.setProperty("paparazzi.test.verify", oldVerify ?: "false")
+      if (oldFailureDir == null) {
+        System.clearProperty("paparazzi.failures.dir")
+      } else {
+        System.setProperty("paparazzi.failures.dir", oldFailureDir)
+      }
     }
   }
 


### PR DESCRIPTION
I kept running `verifyPaparazziDebug` and getting the "See the Paparazzi report at: build/reports/paparazzi/debug/index.html" message at the end of the build — only to find that file didn't exist. Verify mode only ever wrote failure deltas into `build/paparazzi/failures/` for the Gradle test report, so when a snapshot failed I was digging through raw PNGs instead of just opening the report. That's #167.

This PR makes verify mode write the HTML report too, like record mode already does. When a snapshot fails, the report now shows the expected, actual and delta images side by side, so the failure is visible in the browser instead of buried in a failures directory.

## What changed

- `HtmlReportWriter` is now used for verify runs as well. Stills are compared against their golden through the same `ImageUtils.assertImageSimilar` path as before, so the delta and actual images still land in `build/paparazzi/failures/` and the test fails with the same assertion — the failure flow is untouched.
- On failure the report's `images/` directory gets `expected-<name>.png`, `actual-<name>.png` and `delta-<name>.png`, and the run data references them via `expectedFile` / `deltaFile`.
- The report viewer renders failed runs as an expected/actual/delta comparison with a FAILED badge.
- Videos are still verified frame by frame; failed videos get the same diff images.

## Evidence

A failing verify run (from the `verify-mode-failure` fixture) now produces this report entry:

| expected | actual | delta |
|---|---|---|
| ![expected](https://raw.githubusercontent.com/robto09/paparazzi/verify-report-evidence/docs/verify-report-example/expected.png) | ![actual](https://raw.githubusercontent.com/robto09/paparazzi/verify-report-evidence/docs/verify-report-example/actual.png) | ![delta](https://raw.githubusercontent.com/robto09/paparazzi/verify-report-evidence/docs/verify-report-example/delta.png) |

And the run data for that test carries the diff images:

```json
{
  "testName": "app.cash.paparazzi.plugin.test.VerifyTest#verify",
  "timestamp": "2026-08-10T05:30:51.871Z",
  "tags": [],
  "file": "images/actual-app.cash.paparazzi.plugin.test_VerifyTest_verify.png",
  "expectedFile": "images/expected-app.cash.paparazzi.plugin.test_VerifyTest_verify.png",
  "deltaFile": "images/delta-app.cash.paparazzi.plugin.test_VerifyTest_verify.png"
}
```

The full interactive report lands at `build/reports/paparazzi/<variant>/index.html` on any verify run, same as record mode.

## Tests

- `HtmlReportWriterTest`: new cases for failing, passing and missing-golden runs in verify mode.
- `PaparazziPluginTest.verifyReportGeneratedOnFailure`: end-to-end check that the report is written for a failing verify run — this test fails on master.
- The existing verify tests (`verifyFailure`, `verifySimilar`, `verifySize`, `verifyMissingGolden`, multi-module) all still pass unchanged.

Full local run: runtime suite 127/127, sample 41/41, plugin suite 90/91. The one failure is the pre-existing `robolectric` test, which needs Robolectric to download its `android-all` jars and a writable home dir — it fails the same way on master in this environment and is unrelated to this change.

Fixes #167
