### PR TITLE
Add Paparazzi.Config for code-level snapshot configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ paparazzi.gif {
 }
 ```
 
+* Add `Paparazzi.Config` for configuring record/verify mode and snapshot paths in code, so a full set of screenshots can be re-recorded after a style change without Gradle or IDE configuration (#78):
+
+```kotlin
+val PAPARAZZI_CONFIG = Paparazzi.Config(
+  mode = Paparazzi.Mode.RECORD, // or Paparazzi.Mode.VERIFY
+  screenshotsPath = "src/test/screenshots",
+)
+
+class MyTextViewTest {
+  val paparazzi = Paparazzi(PAPARAZZI_CONFIG)
+}
+```
+
+Values left unset in `Paparazzi.Config` fall back to the existing `paparazzi.*` system properties, so existing usage is unchanged.
+
 ## [2.0.0-alpha05] - 2026-05-20
 
 This release supports pre-AGP 9.0 consumers.

--- a/paparazzi/api/paparazzi.api
+++ b/paparazzi/api/paparazzi.api
@@ -138,7 +138,8 @@ public final class app/cash/paparazzi/HtmlReportWriter : app/cash/paparazzi/Snap
 	public fun <init> (Ljava/lang/String;Ljava/io/File;D)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;)V
 	public fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;DLapp/cash/paparazzi/Differ;Ljava/io/File;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
 }
@@ -166,6 +167,7 @@ public final class app/cash/paparazzi/Paparazzi : org/junit/rules/TestRule {
 	public synthetic fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZ)V
 	public synthetic fun <init> (Lapp/cash/paparazzi/Environment;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ZDLapp/cash/paparazzi/SnapshotHandler;Ljava/util/Set;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lapp/cash/paparazzi/Paparazzi$Config;)V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public final fun close ()V
 	public final fun getContext ()Landroid/content/Context;
@@ -191,6 +193,32 @@ public final class app/cash/paparazzi/Paparazzi : org/junit/rules/TestRule {
 	public final fun teardown ()V
 	public final fun unsafeUpdateConfig (Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;)V
 	public static synthetic fun unsafeUpdateConfig$default (Lapp/cash/paparazzi/Paparazzi;Lapp/cash/paparazzi/DeviceConfig;Ljava/lang/String;Lcom/android/ide/common/rendering/api/SessionParams$RenderingMode;ILjava/lang/Object;)V
+}
+
+public final class app/cash/paparazzi/Paparazzi$Config {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lapp/cash/paparazzi/Paparazzi$Mode;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lapp/cash/paparazzi/Paparazzi$Mode;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lapp/cash/paparazzi/Paparazzi$Mode;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lapp/cash/paparazzi/Paparazzi$Mode;Ljava/lang/String;Ljava/lang/String;)Lapp/cash/paparazzi/Paparazzi$Config;
+	public static synthetic fun copy$default (Lapp/cash/paparazzi/Paparazzi$Config;Lapp/cash/paparazzi/Paparazzi$Mode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/paparazzi/Paparazzi$Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailuresPath ()Ljava/lang/String;
+	public final fun getMode ()Lapp/cash/paparazzi/Paparazzi$Mode;
+	public final fun getScreenshotsPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/paparazzi/Paparazzi$Mode : java/lang/Enum {
+	public static final field RECORD Lapp/cash/paparazzi/Paparazzi$Mode;
+	public static final field VERIFY Lapp/cash/paparazzi/Paparazzi$Mode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/paparazzi/Paparazzi$Mode;
+	public static fun values ()[Lapp/cash/paparazzi/Paparazzi$Mode;
 }
 
 public final class app/cash/paparazzi/PaparazziSdk {
@@ -265,7 +293,8 @@ public final class app/cash/paparazzi/SnapshotVerifier : app/cash/paparazzi/Snap
 	public fun <init> (D)V
 	public fun <init> (DLjava/io/File;)V
 	public fun <init> (DLjava/io/File;Lapp/cash/paparazzi/Differ;)V
-	public synthetic fun <init> (DLjava/io/File;Lapp/cash/paparazzi/Differ;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (DLjava/io/File;Lapp/cash/paparazzi/Differ;Ljava/lang/String;)V
+	public synthetic fun <init> (DLjava/io/File;Lapp/cash/paparazzi/Differ;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun newFrameHandler (Lapp/cash/paparazzi/Snapshot;II)Lapp/cash/paparazzi/SnapshotHandler$FrameHandler;
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -65,7 +65,8 @@ public class HtmlReportWriter @JvmOverloads constructor(
   private val rootDirectory: File = File(System.getProperty("paparazzi.report.dir")),
   private val maxPercentDifference: Double,
   private val differ: Differ = determineDiffer(),
-  snapshotRootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir"))
+  snapshotRootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir")),
+  record: Boolean? = null
 ) : SnapshotHandler {
   private val runsDirectory: File = File(rootDirectory, "runs")
   private val imagesDirectory: File = File(rootDirectory, "images")
@@ -77,7 +78,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
   private val shots = mutableListOf<Snapshot>()
 
   private val isRecording: Boolean =
-    System.getProperty("paparazzi.test.record")?.toBoolean() == true
+    record ?: (System.getProperty("paparazzi.test.record")?.toBoolean() == true)
   private val overwriteOnMaxPercentDifference: Boolean =
     System.getProperty("paparazzi.test.record.overwriteOnMaxPercentDifference")?.toBoolean() == true
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -27,6 +27,7 @@ import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.io.File
 import java.util.Date
 
 public class Paparazzi @JvmOverloads constructor(
@@ -76,6 +77,58 @@ public class Paparazzi @JvmOverloads constructor(
   ) {
     this.validateAccessibility = validateAccessibility
   }
+
+  /**
+   * Creates a [Paparazzi] with configuration supplied in code rather than through system
+   * properties. This makes it easy to re-run a set of snapshots in a different mode (for example,
+   * to re-record all screenshots after a style change) without Gradle or IntelliJ configuration.
+   *
+   * Configuration values that are left unset fall back to the corresponding system properties,
+   * so this constructor is fully backward compatible with the default constructor.
+   */
+  public constructor(config: Config) : this(
+    environment = detectEnvironment(),
+    deviceConfig = DeviceConfig.NEXUS_5,
+    theme = "android:Theme.Material.NoActionBar.Fullscreen",
+    renderingMode = RenderingMode.NORMAL,
+    appCompatEnabled = true,
+    maxPercentDifference = detectMaxPercentDifferenceDefault(),
+    snapshotHandler = config.toSnapshotHandler(),
+    renderExtensions = setOf(),
+    supportsRtl = false,
+    showSystemUi = false,
+    useDeviceResolution = false
+  )
+
+  /** The mode in which snapshots are handled: [Mode.RECORD] writes goldens, [Mode.VERIFY] checks them. */
+  public enum class Mode {
+    RECORD,
+    VERIFY
+  }
+
+  /**
+   * Code-level configuration for [Paparazzi], as an alternative to system properties.
+   *
+   * Each property that is left `null` falls back to the corresponding system property
+   * (`paparazzi.snapshot.dir`, `paparazzi.failures.dir`, `paparazzi.test.verify`), so
+   * [Config] with no properties set behaves exactly like the default [Paparazzi] constructor.
+   *
+   * ```kotlin
+   * val PAPARAZZI_CONFIG = Paparazzi.Config(
+   *   mode = Paparazzi.Mode.RECORD,
+   *   screenshotsPath = "src/test/screenshots"
+   * )
+   * ```
+   */
+  public data class Config(
+    /** The snapshot mode. `null` defers to the `paparazzi.test.verify` system property. */
+    val mode: Mode? = null,
+    /** Directory where golden snapshots are read from and written to. */
+    val screenshotsPath: String? = null,
+    /** Directory where failure deltas and actual images are written in verify mode. */
+    val failuresPath: String? = null
+  )
+
   private lateinit var sdk: PaparazziSdk
   private lateinit var frameHandler: SnapshotHandler.FrameHandler
   private var testName: TestName? = null
@@ -211,8 +264,8 @@ public class Paparazzi @JvmOverloads constructor(
   }
 
   private companion object {
-    private val isVerifying: Boolean =
-      System.getProperty("paparazzi.test.verify")?.toBoolean() == true
+    private val isVerifying: Boolean
+      get() = System.getProperty("paparazzi.test.verify")?.toBoolean() == true
 
     private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
       if (isVerifying) {
@@ -220,5 +273,33 @@ public class Paparazzi @JvmOverloads constructor(
       } else {
         HtmlReportWriter(maxPercentDifference = maxPercentDifference)
       }
+
+    private fun Config.toSnapshotHandler(): SnapshotHandler {
+      // When mode is unset, fall back to the paparazzi.test.verify system property exactly as
+      // the default constructor does, but still honor any paths configured in code.
+      val effectiveMode = mode ?: if (isVerifying) Mode.VERIFY else Mode.RECORD
+      return when (effectiveMode) {
+        Mode.RECORD -> HtmlReportWriter(
+          // Only force recording when mode was set in code; otherwise defer to the
+          // paparazzi.test.record system property.
+          record = mode?.let { it == Mode.RECORD },
+          maxPercentDifference = detectMaxPercentDifferenceDefault(),
+          rootDirectory = File(System.getProperty("paparazzi.report.dir") ?: "paparazzi-report"),
+          snapshotRootDirectory = File(screenshotRootDirectory())
+        )
+        Mode.VERIFY -> SnapshotVerifier(
+          maxPercentDifference = detectMaxPercentDifferenceDefault(),
+          rootDirectory = File(screenshotRootDirectory()),
+          failuresPath = failuresPath
+        )
+      }
+    }
+
+    private fun Config.screenshotRootDirectory(): String =
+      screenshotsPath ?: System.getProperty("paparazzi.snapshot.dir")
+        ?: error(
+          "Paparazzi.Config.screenshotsPath is required when the " +
+            "paparazzi.snapshot.dir system property is not set"
+        )
   }
 }

--- a/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/SnapshotVerifier.kt
@@ -34,10 +34,19 @@ import javax.imageio.ImageIO
 public class SnapshotVerifier @JvmOverloads constructor(
   private val maxPercentDifference: Double,
   rootDirectory: File = File(System.getProperty("paparazzi.snapshot.dir")),
-  private val differ: Differ = determineDiffer()
+  private val differ: Differ = determineDiffer(),
+  private val failuresPath: String? = null
 ) : SnapshotHandler {
   private val imagesDirectory: File = File(rootDirectory, "images")
   private val videosDirectory: File = File(rootDirectory, "videos")
+
+  /** Directory where to write the thumbnails and deltas. */
+  private val failureDir: File
+    get() {
+      val path = failuresPath ?: System.getProperty("paparazzi.failures.dir")
+        ?: error("paparazzi.failures.dir system property is required")
+      return File(path).apply { mkdirs() }
+    }
 
   init {
     imagesDirectory.mkdirs()
@@ -97,16 +106,6 @@ public class SnapshotVerifier @JvmOverloads constructor(
   }
 
   override fun close(): Unit = Unit
-
-  private companion object {
-    /** Directory where to write the thumbnails and deltas. */
-    private val failureDir: File
-      get() {
-        val path = System.getProperty("paparazzi.failures.dir")
-          ?: error("paparazzi.failures.dir system property is required")
-        return File(path).apply { mkdirs() }
-      }
-  }
 }
 
 internal fun determineDiffer() =

--- a/paparazzi/src/test/java/app/cash/paparazzi/PaparazziConfigTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/PaparazziConfigTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi
+
+import android.widget.TextView
+import app.cash.paparazzi.FileSubject.Companion.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class PaparazziConfigTest {
+  @get:Rule
+  val folder = TemporaryFolder()
+
+  @Test
+  fun recordModeWritesGoldenToConfiguredScreenshotsPath() {
+    val screenshotsDir = folder.newFolder("screenshots")
+    val golden = File(
+      screenshotsDir,
+      "images/app.cash.paparazzi_PaparazziConfigTest_recordModeWritesGoldenToConfiguredScreenshotsPath.png"
+    )
+    assertThat(golden).doesNotExist()
+
+    runSnapshots(
+      Paparazzi.Config(mode = Paparazzi.Mode.RECORD, screenshotsPath = screenshotsDir.path),
+      "recordModeWritesGoldenToConfiguredScreenshotsPath"
+    ) { paparazzi ->
+      paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+    }
+
+    assertThat(golden).exists()
+  }
+
+  @Test
+  fun verifyModePassesWhenSnapshotsMatchGolden() {
+    val screenshotsDir = folder.newFolder("screenshots")
+    val failuresDir = folder.newFolder("failures")
+
+    runSnapshots(
+      Paparazzi.Config(mode = Paparazzi.Mode.RECORD, screenshotsPath = screenshotsDir.path),
+      "verifyModePassesWhenSnapshotsMatchGolden"
+    ) { paparazzi ->
+      paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+    }
+
+    // Verify the same view against the golden recorded above; must not throw.
+    runSnapshots(
+      Paparazzi.Config(
+        mode = Paparazzi.Mode.VERIFY,
+        screenshotsPath = screenshotsDir.path,
+        failuresPath = failuresDir.path
+      ),
+      "verifyModePassesWhenSnapshotsMatchGolden"
+    ) { paparazzi ->
+      paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+    }
+  }
+
+  @Test
+  fun verifyModeWritesDeltaToConfiguredFailuresPath() {
+    val screenshotsDir = folder.newFolder("screenshots")
+    val failuresDir = folder.newFolder("failures")
+
+    runSnapshots(
+      Paparazzi.Config(mode = Paparazzi.Mode.RECORD, screenshotsPath = screenshotsDir.path),
+      "verifyModeWritesDeltaToConfiguredFailuresPath"
+    ) { paparazzi ->
+      paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+    }
+
+    val delta = File(
+      failuresDir,
+      "delta-app.cash.paparazzi_PaparazziConfigTest_verifyModeWritesDeltaToConfiguredFailuresPath.png"
+    )
+    assertThat(delta).doesNotExist()
+
+    assertThrows(AssertionError::class.java) {
+      runSnapshots(
+        Paparazzi.Config(
+          mode = Paparazzi.Mode.VERIFY,
+          screenshotsPath = screenshotsDir.path,
+          failuresPath = failuresDir.path
+        ),
+        "verifyModeWritesDeltaToConfiguredFailuresPath"
+      ) { paparazzi ->
+        paparazzi.snapshot(TextView(paparazzi.context).apply { text = "goodbye" })
+      }
+    }
+
+    assertThat(delta).exists()
+  }
+
+  @Test
+  fun recordModeOverridesVerifySystemProperty() {
+    val oldVerify = System.getProperty("paparazzi.test.verify")
+    try {
+      // Even when the Gradle plugin sets verify mode, code-level config must win.
+      System.setProperty("paparazzi.test.verify", "true")
+      val screenshotsDir = folder.newFolder("screenshots")
+      val golden = File(
+        screenshotsDir,
+        "images/app.cash.paparazzi_PaparazziConfigTest_recordModeOverridesVerifySystemProperty.png"
+      )
+
+      runSnapshots(
+        Paparazzi.Config(mode = Paparazzi.Mode.RECORD, screenshotsPath = screenshotsDir.path),
+        "recordModeOverridesVerifySystemProperty"
+      ) { paparazzi ->
+        paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+      }
+
+      assertThat(golden).exists()
+    } finally {
+      if (oldVerify == null) {
+        System.clearProperty("paparazzi.test.verify")
+      } else {
+        System.setProperty("paparazzi.test.verify", oldVerify)
+      }
+    }
+  }
+
+  @Test
+  fun emptyConfigFallsBackToSystemProperties() {
+    val oldVerify = System.getProperty("paparazzi.test.verify")
+    val oldSnapshotDir = System.getProperty("paparazzi.snapshot.dir")
+    try {
+      // An empty config must behave exactly like the default Paparazzi constructor.
+      val screenshotsDir = folder.newFolder("screenshots")
+      System.setProperty("paparazzi.test.verify", "true")
+      System.setProperty("paparazzi.snapshot.dir", screenshotsDir.path)
+
+      assertThrows(AssertionError::class.java) {
+        runSnapshots(Paparazzi.Config(), "emptyConfigFallsBackToSystemProperties") { paparazzi ->
+          paparazzi.snapshot(TextView(paparazzi.context).apply { text = "hello" })
+        }
+      }
+    } finally {
+      if (oldVerify == null) {
+        System.clearProperty("paparazzi.test.verify")
+      } else {
+        System.setProperty("paparazzi.test.verify", oldVerify)
+      }
+      if (oldSnapshotDir == null) {
+        System.clearProperty("paparazzi.snapshot.dir")
+      } else {
+        System.setProperty("paparazzi.snapshot.dir", oldSnapshotDir)
+      }
+    }
+  }
+
+  private fun runSnapshots(config: Paparazzi.Config, testName: String, block: (Paparazzi) -> Unit) {
+    val paparazzi = Paparazzi(config)
+    try {
+      paparazzi.setup(TestName("app.cash.paparazzi", "PaparazziConfigTest", testName))
+      block(paparazzi)
+    } finally {
+      paparazzi.teardown()
+    }
+  }
+}


### PR DESCRIPTION
# Paparazzi.Config — configure record/verify and paths in code

Closes #78.

I kept finding myself editing the Gradle `systemProperties` block (or passing `-D` flags) just to re-record snapshots after a theme change. This adds what the issue sketched: a `Paparazzi.Config` you can define once in code and pass straight to `Paparazzi`.

```kotlin
val PAPARAZZI_CONFIG = Paparazzi.Config(
  mode = Paparazzi.Mode.RECORD, // or Paparazzi.Mode.VERIFY
  screenshotsPath = "src/test/screenshots",
)

class MyTextViewTest {
  val paparazzi = Paparazzi(PAPARAZZI_CONFIG)
}
```

## What changed

* `Paparazzi.Mode` (RECORD / VERIFY) and `Paparazzi.Config` (mode, screenshotsPath, failuresPath), nested on `Paparazzi`.
* A `Paparazzi(Config)` constructor that picks the snapshot handler for you.
* `HtmlReportWriter` gained a `record` override; `SnapshotVerifier` gained a `failuresPath` override. Anything you leave unset still falls back to the existing `paparazzi.*` system properties, so existing setups don't change.

I also fixed a bug I hit while testing: `paparazzi.test.verify` was read once per classloader, so flipping it at runtime (or in a test) did nothing. It's now read when the handler is resolved.

## What this unlocks

**1. Record mode, custom screenshots path**

```kotlin
Paparazzi(Paparazzi.Config(
  mode = Paparazzi.Mode.RECORD,
  screenshotsPath = "src/test/screenshots",
))
```

The golden lands in `src/test/screenshots/images/` — no Gradle config involved. That's a full rendered screen: a card with an avatar, a title/subtitle and an action button, written straight to the configured path.

![1-record-golden](https://raw.githubusercontent.com/robto09/paparazzi/evidence/paparazzi-config/docs/paparazzi-config-evidence/1-record-golden.png)

**2. Verify mode against that golden**

```kotlin
Paparazzi(Paparazzi.Config(
  mode = Paparazzi.Mode.VERIFY,
  screenshotsPath = "src/test/screenshots",
  failuresPath = "build/paparazzi/failures",
))
```

Same content renders → test passes, nothing written.

**3. Style change → verify fails, with expected / actual / delta**

I changed the theme accent color (the avatar and the button) from green to blue and re-ran the same test:

![3-verify-fails-expected-actual-delta](https://raw.githubusercontent.com/robto09/paparazzi/evidence/paparazzi-config/docs/paparazzi-config-evidence/3-verify-fails-expected-actual-delta.png)

That's the failing run's output: expected (left), the diff (middle), actual (right), written to `failuresPath`. Note the diff panel only highlights what changed — the layout and text are grayed out, the accent areas show the mismatch.

**4. Re-record after the style change**

Flip `mode` back to `RECORD`, re-run, commit the new golden:

![4-rerecord-golden](https://raw.githubusercontent.com/robto09/paparazzi/evidence/paparazzi-config/docs/paparazzi-config-evidence/4-rerecord-golden.png)

Same screen, new accent — the golden after re-recording. Then flip it back to `VERIFY` and you're done.

## Tests

5 new tests in `PaparazziConfigTest` (record writes the golden, verify passes, verify fails with delta in `failuresPath`, config overrides the verify system property, empty config falls back to system properties). The full `:paparazzi:test` suite is green.
