### PR TITLE
Generate one HTML report page per test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New
+* Generate one HTML report page per test suite, linked together from the report's `index.html` (#187)
 * Add `Paparazzi#gif` overloads that accept a `@Composable` directly, mirroring the existing `snapshot` Compose overloads:
 
 ```kotlin

--- a/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/HtmlReportWriter.kt
@@ -55,9 +55,13 @@ import javax.imageio.ImageIO
  * runs
  *   20190626002322_b9854e.js
  *   20190626002345_b1e882.js
+ * suites
+ *   app.cash.CelebrityTest.html
+ *   app.cash.HomeViewTest.html
  * index.html
  * index.js
  * paparazzi.js
+ * suites.js
  * ```
  */
 public class HtmlReportWriter @JvmOverloads constructor(
@@ -70,6 +74,7 @@ public class HtmlReportWriter @JvmOverloads constructor(
   private val runsDirectory: File = File(rootDirectory, "runs")
   private val imagesDirectory: File = File(rootDirectory, "images")
   private val videosDirectory: File = File(rootDirectory, "videos")
+  private val suitesDirectory: File = File(rootDirectory, "suites")
 
   private val goldenImagesDirectory = File(snapshotRootDirectory, "images")
   private val goldenVideosDirectory = File(snapshotRootDirectory, "videos")
@@ -85,9 +90,11 @@ public class HtmlReportWriter @JvmOverloads constructor(
     runsDirectory.mkdirs()
     imagesDirectory.mkdirs()
     videosDirectory.mkdirs()
+    suitesDirectory.mkdirs()
     writeStaticFiles()
     writeRunJs()
     writeIndexJs()
+    writeSuitesJs()
   }
 
   override fun newFrameHandler(snapshot: Snapshot, frameCount: Int, fps: Int): FrameHandler {
@@ -161,6 +168,8 @@ public class HtmlReportWriter @JvmOverloads constructor(
   /** Release all resources and block until everything has been written to the file system. */
   override fun close() {
     writeRunJs()
+    writeSuites()
+    writeSuitesJs()
   }
 
   /**
@@ -228,15 +237,87 @@ public class HtmlReportWriter @JvmOverloads constructor(
     }
   }
 
+  /**
+   * Emits one HTML page per test suite, so that large reports don't end up as a single cluttered page.
+   *
+   * Each suite page loads the shared renderer and the run data, and only renders the snapshots
+   * belonging to its suite. Pages are written once: their content doesn't depend on the run, so
+   * later runs skip suites that were already emitted.
+   */
+  private fun writeSuites() {
+    val suites = shots.map { it.testName.suiteName() }.distinct().sorted()
+    if (suites.isEmpty()) return
+    val template = HtmlReportWriter::class.java.classLoader
+      .getResourceAsStream("suite.html")
+      .source()
+      .buffer()
+      .readUtf8()
+    for (suite in suites) {
+      var suiteFile = File(suitesDirectory, "${suite.sanitizeForSuiteFilename()}.html")
+      if (suiteFile.exists() && !suiteFile.wasWrittenFor(suite)) {
+        // A different suite already claimed this file name, e.g. two suites differing only by
+        // case on a case-insensitive file system. Disambiguate with a hash of the raw name so
+        // no suite is ever dropped.
+        suiteFile = File(suitesDirectory, "${suiteFile.name.substringBeforeLast('.')}-${hashOf(suite).take(8)}.html")
+      }
+      if (suiteFile.exists()) continue
+      suiteFile.writeAtomically {
+        writeUtf8(template.replace("__SUITE_NAME__", suite))
+      }
+    }
+  }
+
+  private fun File.wasWrittenFor(suite: String): Boolean = readText().contains("""window.suite = "$suite";""")
+
+  /**
+   * Emits the suites index, which reads like JSON with an executable header.
+   *
+   * ```
+   * window.all_suites = [
+   *   "app.cash.CelebrityTest",
+   *   "app.cash.HomeViewTest"
+   * ];
+   * ```
+   */
+  private fun writeSuitesJs() {
+    val suiteNames = mutableListOf<String>()
+    val suites = suitesDirectory.list().sorted()
+    for (suite in suites) {
+      if (suite.endsWith(".html")) {
+        suiteNames += suite.substring(0, suite.length - ".html".length)
+      }
+    }
+
+    File(rootDirectory, "suites.js").writeAtomically {
+      writeUtf8("window.all_suites = ")
+      PaparazziJson.listOfStringsAdapter.toJson(this, suiteNames)
+      writeUtf8(";")
+    }
+  }
+
   private fun File.writeAtomically(writerAction: BufferedSink.() -> Unit) {
-    val tmpFile = File(parentFile, "$name.tmp")
+    // Use a unique temp name and an atomic move so concurrent writers sharing the report
+    // directory never clobber each other's temp files or leave the target missing.
+    val tmpFile = File(parentFile, "$name.${UUID.randomUUID()}.tmp")
     tmpFile.sink()
       .buffer()
       .use { sink ->
         sink.writerAction()
       }
-    delete()
-    tmpFile.renameTo(this)
+    try {
+      java.nio.file.Files.move(
+        tmpFile.toPath(),
+        toPath(),
+        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING
+      )
+    } catch (_: java.io.IOException) {
+      java.nio.file.Files.move(
+        tmpFile.toPath(),
+        toPath(),
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING
+      )
+    }
   }
 
   private fun File.toJsonPath(): String = relativeTo(rootDirectory).invariantSeparatorsPath
@@ -255,4 +336,29 @@ internal val filenameSafeChars = CharMatcher.inRange('a', 'z')
 
 internal fun String.sanitizeForFilename(): String {
   return filenameSafeChars.negate().replaceFrom(lowercase(Locale.US), '_')
+}
+
+private fun TestName.suiteName(): String = "$packageName.$className"
+
+/** Characters allowed in a test suite's file name: Java identifiers ('$' included) plus '.'. */
+private val suiteFilenameSafeChars = filenameSafeChars
+  .or(CharMatcher.inRange('A', 'Z'))
+  .or(CharMatcher.anyOf("$"))
+
+/**
+ * Maps a test suite name to a file name. Names made only of filename-safe characters map to
+ * themselves; anything else is escaped and suffixed with a hash of the original name so two
+ * distinct suites are highly unlikely to collide on the same file.
+ */
+internal fun String.sanitizeForSuiteFilename(): String {
+  val sanitized = suiteFilenameSafeChars.negate().replaceFrom(this, '_')
+  return if (sanitized == this) this else "$sanitized-${hashOf(this).take(8)}"
+}
+
+private fun hashOf(value: String): String {
+  val hashingSink = HashingSink.sha1(blackholeSink())
+  hashingSink.buffer().use { sink ->
+    sink.writeUtf8(value)
+  }
+  return hashingSink.hash.hex()
 }

--- a/paparazzi/src/main/resources/index.html
+++ b/paparazzi/src/main/resources/index.html
@@ -4,88 +4,75 @@
     <style type="text/css">
     body {
       background: #212121;
+      color: #ffffff;
+      font-family: sans-serif;
       text-align: center;
     }
 
-    .screen {
-      margin: 0.2em;
+    h1 {
+      font-weight: normal;
+    }
+
+    .suite {
       display: inline-block;
-      position: relative;
-      overflow: hidden;
+      background: #313131;
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 4px;
+      padding: 0.5em 1em;
+      margin: 0.25em;
     }
 
-    .screen img, .screen video {
-      width: 300px;
+    .suite:hover {
+      background: #424242;
     }
 
-    div.overlay__hovered {
-        display: block;
-    }
-
-    .overlay {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: rgba(25, 0, 237, .68);
-      color: #fff;
-      opacity: 0;
-      display: none;
-      transition: 150ms;
-
-       -webkit-animation-name: slideIn;
-       -webkit-animation-duration: 0.4s;
-      animation-name: slideIn;
-      animation-duration: 0.4s;
-      animation-fill-mode: forwards;
-    }
-
-    @-webkit-keyframes slideIn {
-      from {bottom: -300px; opacity: 0}
-      to {bottom: 0; opacity: 1}
-    }
-
-    @keyframes slideIn {
-      from {bottom: -300px; opacity: 0}
-      to {bottom: 0; opacity: 1}
-    }
-
-    .test__details {
-      text-align: left;
-      padding-left: 1em;
-    }
-
-    .test__details__name,
-    .test__details__class,
-    .test__details__package {
-      line-height: 0.7em;
-    }
-
-    .test__details__timestamp {
-      margin-top: 2em;
-    }
-
-    .test__details__selector {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      display: inline-block;
-      border: 2px solid #fff;
-      margin: .1em;
-      margin-bottom: 1.3em;
-      margin-top: 1em;
-    }
-
-    .test__details__selector:hover {
-      background-color: white;
+    .empty {
+      color: #9e9e9e;
     }
     </style>
 </head>
 
-<script src="index.js"></script>
-<script src="paparazzi.js"></script>
-
 <body onload="bootstrap()">
-  <span id="rootContainer"/>
+  <h1>Paparazzi report</h1>
+  <div id="rootContainer"></div>
 </body>
+
+<script>
+  function render() {
+    const container = document.getElementById('rootContainer');
+    container.textContent = '';
+
+    if (!window.all_suites || window.all_suites.length == 0) {
+      const empty = document.createElement('p');
+      empty.classList.add('empty');
+      empty.innerText = 'No snapshots recorded yet.';
+      container.appendChild(empty);
+      return;
+    }
+
+    for (let suite of window.all_suites) {
+      const link = document.createElement('a');
+      link.classList.add('suite');
+      link.href = `suites/${encodeURIComponent(suite)}.html`;
+      link.innerText = suite;
+      container.appendChild(link);
+    }
+  }
+
+  function refreshSuites() {
+    const script = document.createElement('script');
+    script.src = 'suites.js';
+    script.onload = function () {
+      render();
+      this.remove();
+    };
+    document.head.appendChild(script);
+  }
+
+  function bootstrap() {
+    refreshSuites();
+    setInterval(refreshSuites, 1000);
+  }
+</script>
 </html>

--- a/paparazzi/src/main/resources/paparazzi.js
+++ b/paparazzi/src/main/resources/paparazzi.js
@@ -1,5 +1,8 @@
 window.runs = {};
 
+// Suite pages live in the suites/ directory, so their run data and images are one level up.
+const reportBase = window.suite ? '../' : '';
+
 class Run {
   constructor(id, data) {
     this.id = id;
@@ -142,9 +145,9 @@ class PaparazziRenderer {
   }
 
   start() {
-    this.loadRunScript('index.js');
+    this.loadRunScript(`${reportBase}index.js`);
     for (let runId of window.all_runs) {
-      this.loadRunScript(`runs/${runId}.js`);
+      this.loadRunScript(`${reportBase}runs/${runId}.js`);
     }
     setInterval(this.refresh.bind(this), 100);
   }
@@ -159,6 +162,10 @@ class PaparazziRenderer {
     console.log('rendering', run);
 
     for (let datum of run.data) {
+      // When a suite page is open, only render the snapshots belonging to that test suite.
+      if (window.suite && datum.testName.substring(0, datum.testName.lastIndexOf('#')) !== window.suite) {
+        continue;
+      }
       const key = `${datum.testName}${datum.name}`;
       let shot = this.shots[key];
       if (!shot) {
@@ -171,20 +178,20 @@ class PaparazziRenderer {
       }
 
       console.log('Adding run to shot', shot);
-      shot.addRun(run.id, datum.file, datum.timestamp);
+      shot.addRun(run.id, `${reportBase}${datum.file}`, datum.timestamp);
 
       // TODO setup listeners for filters/hovering, etc
     }
   }
 
   renderAll() {
-    this.loadRunScript('index.js');
+    this.loadRunScript(`${reportBase}index.js`);
     for (let runId of window.all_runs) {
       if (this.lockedRunIds.includes(runId)) {
         continue;
       }
       // The js loading is async so the rendering can happen in the next refresh
-      this.loadRunScript(`runs/${runId}.js`);
+      this.loadRunScript(`${reportBase}runs/${runId}.js`);
 
       this.render(new Run(runId, window.runs[runId]));
 

--- a/paparazzi/src/main/resources/suite.html
+++ b/paparazzi/src/main/resources/suite.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style type="text/css">
+    body {
+      background: #212121;
+      text-align: center;
+    }
+
+    .report__header {
+      text-align: left;
+      padding: 1em;
+      color: #fff;
+      font-family: sans-serif;
+    }
+
+    .report__header a {
+      color: #fff;
+    }
+
+    .report__header h1 {
+      font-weight: normal;
+    }
+
+    .screen {
+      margin: 0.2em;
+      display: inline-block;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .screen img, .screen video {
+      width: 300px;
+    }
+
+    div.overlay__hovered {
+        display: block;
+    }
+
+    .overlay {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: rgba(25, 0, 237, .68);
+      color: #fff;
+      opacity: 0;
+      display: none;
+      transition: 150ms;
+
+       -webkit-animation-name: slideIn;
+       -webkit-animation-duration: 0.4s;
+      animation-name: slideIn;
+      animation-duration: 0.4s;
+      animation-fill-mode: forwards;
+    }
+
+    @-webkit-keyframes slideIn {
+      from {bottom: -300px; opacity: 0}
+      to {bottom: 0; opacity: 1}
+    }
+
+    @keyframes slideIn {
+      from {bottom: -300px; opacity: 0}
+      to {bottom: 0; opacity: 1}
+    }
+
+    .test__details {
+      text-align: left;
+      padding-left: 1em;
+    }
+
+    .test__details__name,
+    .test__details__class,
+    .test__details__package {
+      line-height: 0.7em;
+    }
+
+    .test__details__timestamp {
+      margin-top: 2em;
+    }
+
+    .test__details__selector {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      display: inline-block;
+      border: 2px solid #fff;
+      margin: .1em;
+      margin-bottom: 1.3em;
+      margin-top: 1em;
+    }
+
+    .test__details__selector:hover {
+      background-color: white;
+    }
+    </style>
+</head>
+
+<script>
+  window.suite = "__SUITE_NAME__";
+</script>
+<script src="../index.js"></script>
+<script src="../paparazzi.js"></script>
+
+<body onload="bootstrap()">
+  <div class="report__header">
+    <a href="../index.html">All suites</a>
+    <h1>__SUITE_NAME__</h1>
+  </div>
+  <div id="rootContainer"></div>
+</body>
+</html>

--- a/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
+++ b/paparazzi/src/test/java/app/cash/paparazzi/HtmlReportWriterTest.kt
@@ -96,6 +96,76 @@ class HtmlReportWriterTest {
   }
 
   @Test
+  fun reportGeneratesOnePagePerTestSuite() {
+    val htmlReportWriter = HtmlReportWriter(
+      runName = "run_one",
+      rootDirectory = reportRoot.root,
+      maxPercentDifference = 0.0,
+      differ = PixelPerfect,
+      snapshotRootDirectory = snapshotRoot.root
+    )
+    htmlReportWriter.use {
+      val testSettings = Instant.parse("2019-03-20T10:27:43Z").toDate()
+      for ((name, className) in listOf(
+        "loading" to "CelebrityTest",
+        "error" to "HomeViewTest",
+        "loading" to "HomeViewTest"
+      )) {
+        val frameHandler = htmlReportWriter.newFrameHandler(
+          snapshot = Snapshot(
+            name = name,
+            testName = TestName("app.cash.paparazzi", className, "testSettings"),
+            timestamp = testSettings,
+            tags = listOf("redesign")
+          ),
+          frameCount = 1,
+          fps = -1
+        )
+        frameHandler.use {
+          frameHandler.handle(anyImage)
+        }
+      }
+    }
+
+    val celebritySuitePage = File(reportRoot.root, "suites/app.cash.paparazzi.CelebrityTest.html")
+    assertThat(celebritySuitePage).exists()
+    assertThat(celebritySuitePage.readText()).contains(
+      """window.suite = "app.cash.paparazzi.CelebrityTest";"""
+    )
+    assertThat(celebritySuitePage.readText()).contains(
+      """<a href="../index.html">All suites</a>"""
+    )
+    assertThat(File(reportRoot.root, "suites/app.cash.paparazzi.HomeViewTest.html")).exists()
+
+    assertThat(File("${reportRoot.root}/suites.js")).hasContent(
+      """
+        |window.all_suites = [
+        |  "app.cash.paparazzi.CelebrityTest",
+        |  "app.cash.paparazzi.HomeViewTest"
+        |];
+      """.trimMargin()
+    )
+
+    // Each suite page is only written once, even when a later run has shots for the same suite.
+    val firstModified = celebritySuitePage.lastModified()
+    htmlReportWriter.use {
+      val frameHandler = htmlReportWriter.newFrameHandler(
+        snapshot = Snapshot(
+          name = "loading",
+          testName = TestName("app.cash.paparazzi", "CelebrityTest", "testSettings"),
+          timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+        ),
+        frameCount = 1,
+        fps = -1
+      )
+      frameHandler.use {
+        frameHandler.handle(anyImage)
+      }
+    }
+    assertThat(celebritySuitePage.lastModified()).isEqualTo(firstModified)
+  }
+
+  @Test
   fun failureActualImageMatchesRecordedGoldenImageBytes() {
     try {
       System.setProperty("paparazzi.test.record", "true")
@@ -143,6 +213,56 @@ class HtmlReportWriterTest {
     assertThat("0 Dollars".sanitizeForFilename()).isEqualTo("0_dollars")
     assertThat("`!#$%&*+=|\\'\"<>?/".sanitizeForFilename()).isEqualTo("_________________")
     assertThat("~@^()[]{}:;,.".sanitizeForFilename()).isEqualTo("~@^()[]{}:;,.")
+  }
+
+  @Test
+  fun caseVariantSuitesDontCollide() {
+    fun writeSuite(className: String, runName: String) {
+      val htmlReportWriter = HtmlReportWriter(
+        runName = runName,
+        rootDirectory = reportRoot.root,
+        maxPercentDifference = 0.0,
+        differ = PixelPerfect,
+        snapshotRootDirectory = snapshotRoot.root
+      )
+      htmlReportWriter.use {
+        val frameHandler = htmlReportWriter.newFrameHandler(
+          snapshot = Snapshot(
+            name = "loading",
+            testName = TestName("app.cash.paparazzi", className, "testSettings"),
+            timestamp = Instant.parse("2019-03-20T10:27:43Z").toDate()
+          ),
+          frameCount = 1,
+          fps = -1
+        )
+        frameHandler.use {
+          frameHandler.handle(anyImage)
+        }
+      }
+    }
+
+    writeSuite("CelebrityTest", "run_one")
+    writeSuite("CELEBRITYTEST", "run_two")
+
+    // Both suites must end up with their own page, even on case-insensitive file systems where
+    // the second suite's plain name would collide with the first one's page.
+    val suitesJs = File("${reportRoot.root}/suites.js").readText()
+    assertThat(suitesJs).contains("app.cash.paparazzi.CelebrityTest")
+    assertThat(suitesJs).contains("app.cash.paparazzi.CELEBRITYTEST")
+    assertThat(Regex("\"app\\.cash\\.paparazzi\\.").findAll(suitesJs).count()).isEqualTo(2)
+  }
+
+  @Test
+  fun sanitizeForSuiteFilename() {
+    assertThat("app.cash.paparazzi.CelebrityTest".sanitizeForSuiteFilename())
+      .isEqualTo("app.cash.paparazzi.CelebrityTest")
+    assertThat("app.cash.paparazzi.Outer\$InnerTest".sanitizeForSuiteFilename())
+      .isEqualTo("app.cash.paparazzi.Outer\$InnerTest")
+
+    // Names that aren't filename-safe are escaped and hashed so distinct suites never collide.
+    val cafe = "app.CaféTest".sanitizeForSuiteFilename()
+    assertThat(cafe).startsWith("app.Caf_Test-")
+    assertThat("app.CafèTest".sanitizeForSuiteFilename()).isNotEqualTo(cafe)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #187. Instead of dumping every snapshot from every test class onto a single `index.html`, the report now generates **one HTML page per test suite** under `suites/`, and `index.html` becomes a hub that links them all together.

This matters for real projects: a single component is often snapshotted across many state combinations and themes (dark/light), so the old one-page report became unmanageably long.

## Changes

- `HtmlReportWriter` emits one page per test suite (`suites/<package>.<Class>.html`, grouped by `packageName.className`) plus a `suites.js` index listing every suite across runs.
- `index.html` (static resource) is now the hub: it renders a link per suite and refreshes while tests are still running.
- Suite pages reuse the existing run data (`runs/*.js`) and renderer. Per-run selectors, images and videos all keep working. A `window.suite` filter limits each page to its own suite, and all report-relative paths (`index.js`, `runs/*.js`, `images/*`, `videos/*`) are resolved from the `suites/` directory.
- Suite file names preserve case and `$`, and are hash-escaped when needed so distinct suites cannot silently collide, even on case-insensitive file systems.
- Shared report files are written with a unique temp name and an atomic move, so parallel test writers sharing the report directory can't clobber each other.

## Testing

- 3 new tests in `HtmlReportWriterTest`: one page per suite + `suites.js` contents, idempotent page writes across runs, case-variant suites not colliding, and suite file-name sanitization.
- Full `:paparazzi:test` suite passes (no regressions).
- End-to-end: ran `:sample:recordPaparazziDebug` and verified in headless Chrome that the hub lists all 11 suites, each suite page renders exactly its own snapshots, and all image paths resolve.

## Screenshots

**The new `index.html` hub (11 suites):**

![index.html hub](https://raw.githubusercontent.com/robto09/paparazzi/pr-evidence-2392/pr-evidence/10-hub-index-11suites.png)

**A realistic suite page (checkout screen, 4 states x light/dark = 8 snapshots):**

![CheckoutSummaryDemoTest suite page](https://raw.githubusercontent.com/robto09/paparazzi/pr-evidence-2392/pr-evidence/11-suite-CheckoutSummaryDemoTest.png)

**Another suite page (profile screen, 6 snapshots):**

![ProfileScreenDemoTest suite page](https://raw.githubusercontent.com/robto09/paparazzi/pr-evidence-2392/pr-evidence/12-suite-ProfileScreenDemoTest.png)

## About the evidence

A full evidence package (screenshots + rendered-DOM dumps + gallery HTML, zipped) is available at `sample/build/pr-screenshots/paparazzi-pr-evidence.zip` and can be attached to this PR. For convenience, it is also published on the fork: [download paparazzi-pr-evidence.zip](https://raw.githubusercontent.com/robto09/paparazzi/pr-evidence-2392/pr-evidence/paparazzi-pr-evidence.zip), or browse the [evidence gallery](https://github.com/robto09/paparazzi/blob/pr-evidence-2392/pr-evidence/evidence.html).
