### PR TITLE
Fix Compose 1.12 BasicSecureTextField crash: intercept android.text.ShowSecretsSetting

### DIFF
--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -1555,6 +1555,15 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun composeSecureTextField() {
+    val fixtureRoot = File("src/test/projects/secure-text-field")
+
+    gradleRunner
+      .withArguments("testDebug", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
   fun similarImagesProduceUniqueSnapshots() {
     val fixtureRoot = File("src/test/projects/similar-images")
 

--- a/paparazzi-gradle-plugin/src/test/projects/secure-text-field/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/secure-text-field/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+  id 'com.android.library'
+  id 'org.jetbrains.kotlin.plugin.compose'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace = 'app.cash.paparazzi.plugin.test'
+
+  // BasicSecureTextField's ShowSecretsSetting integration is API 37+, so this fixture
+  // deliberately overrides the shared compileSdk to make sure the mockable android.jar
+  // contains android.text.ShowSecretsSetting.
+  compileSdk = 37
+  defaultConfig {
+    minSdk = libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+  buildFeatures {
+    compose = true
+  }
+}
+
+dependencies {
+  // The shared version catalog pins Compose to 1.11.2, which predates
+  // BasicSecureTextField's use of android.text.ShowSecretsSetting (Compose Foundation 1.12+),
+  // so this fixture declares its own newer Compose BOM instead of using the catalog entry.
+  implementation platform('androidx.compose:compose-bom:2026.08.00')
+  implementation 'androidx.compose.foundation:foundation'
+  implementation 'androidx.compose.ui:ui'
+}

--- a/paparazzi-gradle-plugin/src/test/projects/secure-text-field/src/test/java/app/cash/paparazzi/plugin/test/SecureTextFieldTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/secure-text-field/src/test/java/app/cash/paparazzi/plugin/test/SecureTextFieldTest.kt
@@ -1,0 +1,28 @@
+package app.cash.paparazzi.plugin.test
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicSecureTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class SecureTextFieldTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  // Regression test: BasicSecureTextField (Compose Foundation 1.12+) registers a callback with
+  // android.text.ShowSecretsSetting (API 37), which layoutlib doesn't implement and throws
+  // "not mocked" without Paparazzi's interceptor.
+  @Test
+  fun secureTextField() {
+    paparazzi.snapshot {
+      BasicSecureTextField(
+        state = rememberTextFieldState("hunter2"),
+        modifier = Modifier.padding(16.dp)
+      )
+    }
+  }
+}

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -55,6 +55,9 @@ import app.cash.paparazzi.internal.PaparazziSavedStateRegistryOwner
 import app.cash.paparazzi.internal.Renderer
 import app.cash.paparazzi.internal.SessionParamsBuilder
 import app.cash.paparazzi.internal.interceptors.EditModeInterceptor
+import app.cash.paparazzi.internal.interceptors.ShowSecretsSettingRegisterCallbackInterceptor
+import app.cash.paparazzi.internal.interceptors.ShowSecretsSettingShouldShowPhysicalInputInterceptor
+import app.cash.paparazzi.internal.interceptors.ShowSecretsSettingShouldShowTouchInputInterceptor
 import app.cash.paparazzi.internal.parsers.LayoutPullParser
 import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.Result
@@ -143,6 +146,7 @@ public class PaparazziSdk @JvmOverloads constructor(
   public fun setup() {
     if (!isInitialized) {
       registerViewEditModeInterception()
+      registerShowSecretsSettingInterception()
 
       ByteBuddyAgent.install()
       InterceptorRegistrar.registerMethodInterceptors()
@@ -577,6 +581,17 @@ public class PaparazziSdk @JvmOverloads constructor(
       "android.view.View",
       "isInEditMode",
       EditModeInterceptor::class.java
+    )
+  }
+
+  private fun registerShowSecretsSettingInterception() {
+    InterceptorRegistrar.addMethodInterceptors(
+      "android.text.ShowSecretsSetting",
+      setOf(
+        "shouldShowTouchInput" to ShowSecretsSettingShouldShowTouchInputInterceptor::class.java,
+        "shouldShowPhysicalInput" to ShowSecretsSettingShouldShowPhysicalInputInterceptor::class.java,
+        "registerCallback" to ShowSecretsSettingRegisterCallbackInterceptor::class.java
+      )
     )
   }
 

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
@@ -16,10 +16,7 @@ internal object ShowSecretsSettingShouldShowPhysicalInputInterceptor {
 
 internal object ShowSecretsSettingRegisterCallbackInterceptor {
   @JvmStatic
-  fun intercept(
-    @Argument(0) context: Context,
-    @Argument(1) callback: Runnable
-  ): Runnable = Runnable {}
+  fun intercept(@Argument(0) context: Context, @Argument(1) callback: Runnable): Runnable = Runnable {}
 
   @JvmStatic
   fun intercept(

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
@@ -21,9 +21,6 @@ internal object ShowSecretsSettingRegisterCallbackInterceptor {
     @Argument(1) callback: Runnable
   ): Runnable = Runnable {}
 
-  // The mockable android.jar used by unit tests also exposes a 3-arg overload
-  // (Context, Executor, Runnable) that Compose doesn't call directly, but ByteBuddy's
-  // name-based matcher intercepts both overloads, so both need a matching delegate.
   @JvmStatic
   fun intercept(
     @Argument(0) context: Context,

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
@@ -4,10 +4,6 @@ import android.content.Context
 import net.bytebuddy.implementation.bind.annotation.Argument
 import java.util.concurrent.Executor
 
-// android.text.ShowSecretsSetting was added in API 37 and is not implemented by layoutlib,
-// so calls from Compose's BasicSecureTextField (PlatformPasswordVisibilitySettingApi37) throw
-// "not mocked" on the JVM. These interceptors provide deterministic, no-op behavior for
-// screenshot rendering: secrets are always hidden and the settings observer is never invoked.
 internal object ShowSecretsSettingShouldShowTouchInputInterceptor {
   @JvmStatic
   fun intercept(@Argument(0) context: Context): Boolean = false

--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/interceptors/ShowSecretsSettingInterceptor.kt
@@ -1,0 +1,37 @@
+package app.cash.paparazzi.internal.interceptors
+
+import android.content.Context
+import net.bytebuddy.implementation.bind.annotation.Argument
+import java.util.concurrent.Executor
+
+// android.text.ShowSecretsSetting was added in API 37 and is not implemented by layoutlib,
+// so calls from Compose's BasicSecureTextField (PlatformPasswordVisibilitySettingApi37) throw
+// "not mocked" on the JVM. These interceptors provide deterministic, no-op behavior for
+// screenshot rendering: secrets are always hidden and the settings observer is never invoked.
+internal object ShowSecretsSettingShouldShowTouchInputInterceptor {
+  @JvmStatic
+  fun intercept(@Argument(0) context: Context): Boolean = false
+}
+
+internal object ShowSecretsSettingShouldShowPhysicalInputInterceptor {
+  @JvmStatic
+  fun intercept(@Argument(0) context: Context): Boolean = false
+}
+
+internal object ShowSecretsSettingRegisterCallbackInterceptor {
+  @JvmStatic
+  fun intercept(
+    @Argument(0) context: Context,
+    @Argument(1) callback: Runnable
+  ): Runnable = Runnable {}
+
+  // The mockable android.jar used by unit tests also exposes a 3-arg overload
+  // (Context, Executor, Runnable) that Compose doesn't call directly, but ByteBuddy's
+  // name-based matcher intercepts both overloads, so both need a matching delegate.
+  @JvmStatic
+  fun intercept(
+    @Argument(0) context: Context,
+    @Argument(1) executor: Executor,
+    @Argument(2) callback: Runnable
+  ): Runnable = Runnable {}
+}


### PR DESCRIPTION
## Problem

Compose Foundation 1.12 introduced `PlatformPasswordVisibilitySettingApi37`, which `BasicSecureTextField` uses on API 37+ to observe the system's "show passwords" setting via `android.text.ShowSecretsSetting`. That class isn't implemented by layoutlib, so any unit test rendering `BasicSecureTextField` through Paparazzi (with `compileSdk >= 37`) crashes with:

```
java.lang.RuntimeException: Method shouldShowTouchInput in android.text.ShowSecretsSetting not mocked.
See https://developer.android.com/r/studio-ui/build/not-mocked for details.
```

## Fix

Adds interceptors for `android.text.ShowSecretsSetting` via the existing `InterceptorRegistrar` mechanism (same pattern as the existing view-edit-mode interception), providing deterministic no-op behavior for screenshot rendering:
- `shouldShowTouchInput` / `shouldShowPhysicalInput` → always `false` (secrets stay hidden)
- `registerCallback` → no-op, returns a no-op unregister `Runnable`

`registerCallback` needed two interceptor overloads because the mockable `android.jar` exposes both a 2-arg `(Context, Runnable)` and a 3-arg `(Context, Executor, Runnable)` signature, and ByteBuddy's `ElementMatchers.named()` matches by method name only, not signature — both call sites need a compatible interceptor delegate or the redefinition fails to bind.

## Test

Added a new `secure-text-field` Gradle TestKit fixture that renders a raw `androidx.compose.foundation.text.BasicSecureTextField` through `Paparazzi()`. Since the shared version catalog pins `compileSdk = 36` and Compose to `1.11.2` (both older than what's needed to reproduce this), the fixture overrides `compileSdk = 37` and declares its own newer Compose BOM independent of the root catalog.

Verified:
- Without the interceptor fix, the test fails with the exact `ShowSecretsSetting not mocked` crash above.
- With the fix, the test passes.