### PR TITLE
Add agent guidance for Layoutlib references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository guidance
+
+Paparazzi is a host-side Android screenshot-testing library built around Android's Layoutlib renderer.
+
+## Relevant upstream source
+
+When behavior depends on Android framework or rendering internals, consult:
+
+- Layoutlib renderer and delegates:
+  https://android.googlesource.com/platform/frameworks/layoutlib/
+- Android framework implementation and resources:
+  https://android.googlesource.com/platform/frameworks/base/
+
+Before investigating upstream behavior, determine the Layoutlib version pinned in
+`gradle/libs.versions.toml`. Prefer source from the corresponding Studio release tag;
+do not assume upstream `main` matches the version used by Paparazzi.
+
+Use upstream source for reference only. Do not copy upstream code into this repository.
+
+When diagnosing rendering behavior, distinguish:
+
+- Android framework behavior from `frameworks/base`
+- Host-side adaptations from `frameworks/layoutlib`
+- Paparazzi-specific orchestration, lifecycle, capture, and reporting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude instructions
+
+Follow the repository guidance in [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary

- add root-level agent guidance for consulting Layoutlib and Android framework internals
- direct agents to match upstream source to the Layoutlib version pinned by Paparazzi
- add a Claude entry point that links to the shared guidance

This change should diagnosing changes in layoutlib sources easier during agentic workflows in the paparazzi repo.

## Testing

Not run (documentation-only change).