### PR TITLE
Filter hidden Compose accessibility semantics

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/accessibility-rendering/src/test/java/app/cash/paparazzi/plugin/test/AccessibilityRenderingTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/accessibility-rendering/src/test/java/app/cash/paparazzi/plugin/test/AccessibilityRenderingTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.progressBarRangeInfo
@@ -238,6 +239,14 @@ class AccessibilityRenderingTest {
             modifier = Modifier
               .alpha(0f),
             text = "Text with zero alpha"
+          )
+          Box(
+            modifier = Modifier
+              .size(0.dp)
+              .clickable(enabled = false, onClick = {})
+              .semantics {
+                hideFromAccessibility()
+              }
           )
           Text(text = "Text that is visible!")
         }

--- a/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElementCollector.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/accessibility/AccessibilityElementCollector.kt
@@ -303,13 +303,15 @@ internal class AccessibilityElementCollector {
   }
 
   private fun SemanticsNode.accessibilityText(): String? {
-    val invisibleToUser = config.getOrNull(SemanticsProperties.InvisibleToUser) != null
+    val hiddenFromAccessibility =
+      config.getOrNull(SemanticsProperties.InvisibleToUser) != null ||
+        config.getOrNull(SemanticsProperties.HideFromAccessibility) != null
     val hasZeroAlphaModifier = layoutInfo.getModifierInfo().any {
       // We don't get direct access to an alpha field but we can inspect the modifiers and see if
       // a modifier of 0f was applied to the node.
       it.modifier == Modifier.alpha(0f)
     }
-    if (invisibleToUser || hasZeroAlphaModifier) {
+    if (hiddenFromAccessibility || hasZeroAlphaModifier) {
       return null
     }
 


### PR DESCRIPTION
## Summary

- filter Compose nodes annotated with `HideFromAccessibility` from accessibility snapshot legends
- retain support for the deprecated `InvisibleToUser` semantics key
- cover a disabled clickable that is hidden from accessibility, while preserving existing genuine-disabled coverage

## Motivation

Paparazzi currently filters the deprecated `InvisibleToUser` key but not its replacement, `HideFromAccessibility`. A disabled Compose node carrying the newer key can therefore add Paparazzi's `<disabled>` marker to the snapshot legend even though accessibility services should ignore that node.

## Test plan

- `./gradlew :paparazzi:compileKotlin :paparazzi:spotlessKotlinCheck :paparazzi-gradle-plugin:spotlessKotlinCheck :paparazzi:test --tests 'app.cash.paparazzi.accessibility.AccessibilityRenderExtensionTest' :paparazzi-gradle-plugin:compileTestKotlin :paparazzi-gradle-plugin:test --tests 'app.cash.paparazzi.gradle.PaparazziPluginTest.accessibilityRendering' --no-daemon --stacktrace`
  - 3 `AccessibilityRenderExtensionTest` tests passed
  - `PaparazziPluginTest.accessibilityRendering` passed
- `git diff --check`

No snapshot goldens changed.
