### PR TITLE
Fix short Compose V_SCROLL viewport sizing

### DIFF
--- a/paparazzi-gradle-plugin/src/test/projects/compose/src/test/java/app/cash/paparazzi/plugin/test/ComposeRenderingModeSizingTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/compose/src/test/java/app/cash/paparazzi/plugin/test/ComposeRenderingModeSizingTest.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,22 +32,36 @@ import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import java.awt.image.BufferedImage
 
 private const val EXPECTED_CURRENT_V_SCROLL_WIDTH = 514
 private const val EXPECTED_CURRENT_V_SCROLL_HEIGHT = 1000
 private const val CONTENT_HEIGHT_DP = 700
+private const val SHORT_CONTENT_TEST = "shortComposeContentFillsViewport"
+private val SHORT_CONTENT_DEVICE =
+  DeviceConfig.NEXUS_5.copy(
+    screenWidth = 500,
+    screenHeight = 1000,
+    softButtons = false
+  )
 
 class ComposeRenderingModeSizingTest {
   private val snapshotHandler = DimensionAssertingSnapshotHandler()
+  private lateinit var paparazzi: Paparazzi
 
   @get:Rule
-  val paparazzi =
-    Paparazzi(
-      deviceConfig = DeviceConfig.NEXUS_5,
-      renderingMode = RenderingMode.V_SCROLL,
-      snapshotHandler = snapshotHandler
-    )
+  val paparazziRule = TestRule { base, description ->
+    val isShortContentTest = description.methodName == SHORT_CONTENT_TEST
+    paparazzi =
+      Paparazzi(
+        deviceConfig = if (isShortContentTest) SHORT_CONTENT_DEVICE else DeviceConfig.NEXUS_5,
+        renderingMode = RenderingMode.V_SCROLL,
+        snapshotHandler = snapshotHandler,
+        useDeviceResolution = isShortContentTest
+      )
+    paparazzi.apply(base, description)
+  }
 
   @Test
   fun verticalScrollBoundedComposeRootKeepsCurrentSnapshotSize() {
@@ -95,34 +112,86 @@ class ComposeRenderingModeSizingTest {
     )
   }
 
+  @Test
+  fun shortComposeContentFillsViewport() {
+    val snapshotName = "short_compose_v_scroll"
+    snapshotHandler.expect(
+      name = snapshotName,
+      width = 500,
+      height = 1000,
+      verifySnapshot = false
+    )
+
+    val composeView =
+      ComposeView(paparazzi.context).apply {
+        setContent {
+          Column(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+            Box(modifier = Modifier.fillMaxWidth().height(64.dp)) {
+              Text("Error", color = Color.White)
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+              Column(
+                modifier =
+                Modifier
+                  .heightIn(max = 200.dp)
+                  .verticalScroll(rememberScrollState())
+              ) {
+                Text("Something went wrong", color = Color.White)
+              }
+            }
+          }
+        }
+      }
+
+    paparazzi.snapshot(composeView, name = snapshotName)
+
+    val image = snapshotHandler.image()
+    assertEquals("image width", 500, image.width)
+    assertEquals("image height", 1000, image.height)
+    assertEquals("Compose root height", image.height, composeView.height)
+    assertEquals("AndroidComposeView height", image.height, composeView.getChildAt(0).height)
+    assertEquals("bottom-center pixel", 0xff000000.toInt(), image.getRGB(image.width / 2, image.height - 1))
+  }
+
   private class DimensionAssertingSnapshotHandler : SnapshotHandler {
     private val expectedDimensions = mutableMapOf<String, Pair<Int, Int>>()
+    private val unverifiedSnapshots = mutableSetOf<String>()
+    private lateinit var capturedImage: BufferedImage
     private val snapshotHandler = if (System.getProperty("paparazzi.test.verify")?.toBoolean() == true) {
       SnapshotVerifier(maxPercentDifference = detectMaxPercentDifferenceDefault())
     } else {
       HtmlReportWriter(maxPercentDifference = detectMaxPercentDifferenceDefault())
     }
 
-    fun expect(name: String, width: Int, height: Int) {
+    fun expect(name: String, width: Int, height: Int, verifySnapshot: Boolean = true) {
       expectedDimensions[name] = width to height
+      if (!verifySnapshot) unverifiedSnapshots += name
     }
+
+    fun image(): BufferedImage = capturedImage
 
     override fun newFrameHandler(snapshot: Snapshot, frameCount: Int, fps: Int): SnapshotHandler.FrameHandler {
       val name = requireNotNull(snapshot.name)
       val expected = requireNotNull(expectedDimensions[name]) {
         "No expected dimensions registered for snapshot '$name'"
       }
-      val frameHandler = snapshotHandler.newFrameHandler(snapshot, frameCount, fps)
+      val frameHandler =
+        if (name in unverifiedSnapshots) {
+          null
+        } else {
+          snapshotHandler.newFrameHandler(snapshot, frameCount, fps)
+        }
 
       return object : SnapshotHandler.FrameHandler {
         override fun handle(image: BufferedImage) {
-          frameHandler.handle(image)
+          frameHandler?.handle(image)
+          capturedImage = image
           assertEquals("Snapshot width for '$name'", expected.first, image.width)
           assertEquals("Snapshot height for '$name'", expected.second, image.height)
         }
 
         override fun close() {
-          frameHandler.close()
+          frameHandler?.close()
         }
       }
     }

--- a/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/PaparazziSdk.kt
@@ -33,6 +33,7 @@ import android.view.View.NO_ID
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewRootImpl_Accessor
+import android.widget.FrameLayout
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.annotation.LayoutRes
 import androidx.compose.runtime.Composable
@@ -312,23 +313,37 @@ public class PaparazziSdk @JvmOverloads constructor(
         }
       }
 
+      val sessionParams = sessionParamsBuilder.build()
+      val snapshotView =
+        if (
+          sessionParams.renderingMode == RenderingMode.V_SCROLL &&
+          hasComposeRuntime &&
+          modifiedView.containsComposeView()
+        ) {
+          VScrollViewportLayout(context, sessionParams.hardwareConfig.screenHeight).apply {
+            addView(modifiedView)
+          }
+        } else {
+          modifiedView
+        }
+
       if (hasLifecycleOwnerRuntime) {
         lifecycleOwner = PaparazziLifecycleOwner()
-        modifiedView.setViewTreeLifecycleOwner(lifecycleOwner)
+        snapshotView.setViewTreeLifecycleOwner(lifecycleOwner)
 
         if (hasSavedStateRegistryOwnerRuntime) {
-          modifiedView.setViewTreeSavedStateRegistryOwner(PaparazziSavedStateRegistryOwner(lifecycleOwner))
+          snapshotView.setViewTreeSavedStateRegistryOwner(PaparazziSavedStateRegistryOwner(lifecycleOwner))
         }
         if (hasAndroidxActivityRuntime) {
-          modifiedView.setViewTreeOnBackPressedDispatcherOwner(PaparazziOnBackPressedDispatcherOwner(lifecycleOwner))
+          snapshotView.setViewTreeOnBackPressedDispatcherOwner(PaparazziOnBackPressedDispatcherOwner(lifecycleOwner))
         }
         // Must be changed after the SavedStateRegistryOwner above has finished restoring its state.
         lifecycleOwner.registry.currentState = Lifecycle.State.RESUMED
       }
 
-      viewGroup.addView(modifiedView)
+      viewGroup.addView(snapshotView)
 
-      when (sessionParamsBuilder.build().renderingMode) {
+      when (sessionParams.renderingMode) {
         // See [sizeShrinkWindowFrameToDevice]. In SHRINK mode layoutlib 16.2.3 leaves the window frame
         // collapsed to 0x0 after inflating the (empty) content, which corrupts Compose state derived
         // from the first measured size. Restore a sane window frame before the first frame is rendered.
@@ -379,6 +394,10 @@ public class PaparazziSdk @JvmOverloads constructor(
         lifecycleOwner.registry.currentState = Lifecycle.State.DESTROYED
       }
       viewGroup.removeAllViews()
+
+      if (modifiedView.parent != null) {
+        (modifiedView.parent as ViewGroup).removeView(modifiedView)
+      }
 
       // Remove any applied render extensions
       if (modifiedView !== view) {
@@ -734,6 +753,43 @@ public class PaparazziSdk @JvmOverloads constructor(
       } catch (e: ClassNotFoundException) {
         false
       }
+    }
+  }
+}
+
+/**
+ * Layoutlib probes V_SCROLL content with an unbounded height after measuring the device viewport.
+ * Compose retains that probe's short layout when Android reuses the earlier viewport measure specs.
+ * Force a final exact-height pass so short content fills the viewport and long content keeps its
+ * natural height.
+ */
+private class VScrollViewportLayout(
+  context: Context,
+  private val viewportHeight: Int
+) : FrameLayout(context) {
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+    if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED) {
+      for (index in 0 until childCount) {
+        getChildAt(index).forceLayoutRecursively()
+      }
+      super.onMeasure(
+        widthMeasureSpec,
+        MeasureSpec.makeMeasureSpec(maxOf(measuredHeight, viewportHeight), MeasureSpec.EXACTLY)
+      )
+    }
+  }
+}
+
+private fun View.containsComposeView(): Boolean =
+  this is ComposeView || (this is ViewGroup && (0 until childCount).any { getChildAt(it).containsComposeView() })
+
+private fun View.forceLayoutRecursively() {
+  forceLayout()
+  if (this is ViewGroup) {
+    for (index in 0 until childCount) {
+      getChildAt(index).forceLayoutRecursively()
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to [parent PR #2375](https://github.com/cashapp/paparazzi/pull/2375).

Layoutlib's V_SCROLL sizing can leave Compose drawing a stale unbounded measure even when the final Android view bounds match the device viewport. This scopes a viewport-floor remeasure to V_SCROLL trees containing Compose, recursively invalidating cached child layout before the exact pass while preserving naturally long content.

The regression is consolidated into the existing Compose rendering-mode sizing fixture. The final pixel assertion was red on the parent head and green with this fix, and the existing long-content sentinel remained green. The focused Compose suite passed 8 tests with 2 skipped, and formatting passed.
