### PR TITLE
Don't carry generated source producers into the snapshot dir

### DIFF
--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -474,11 +474,17 @@ public class PaparazziPlugin @Inject constructor(
       ?: error("No Kotlin or Java sources on ${testVariant.name}")
     val testVariantName = testVariant.name
     val projectDirectory = layout.projectDirectory
+    val buildDirectory = layout.buildDirectory
     // Only the location of the source directories matters here. Mapping `sources` would also carry
     // the tasks that produce generated source directories (eg. KSP) into the record task's outputs,
     // which can't be resolved when the configuration cache entry is stored.
     return providerFactory.provider {
-      val sourceSetRoot = sources.get().firstOrNull()?.asFile?.parentFile
+      val sourceDirs = sources.get().map { it.asFile }
+      // Generated source directories can come first (eg. on KMP), and snapshots shouldn't end up in
+      // the build directory.
+      val buildDir = buildDirectory.get().asFile
+      val sourceSetRoot = (sourceDirs.firstOrNull { !it.startsWith(buildDir) } ?: sourceDirs.firstOrNull())
+        ?.parentFile
         ?: error("No source dirs registered for $testVariantName")
       projectDirectory.dir(sourceSetRoot.path).dir("snapshots")
     }

--- a/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -472,10 +472,14 @@ public class PaparazziPlugin @Inject constructor(
     val sources = testVariant.sources.kotlin?.all
       ?: testVariant.sources.java?.all
       ?: error("No Kotlin or Java sources on ${testVariant.name}")
+    val testVariantName = testVariant.name
     val projectDirectory = layout.projectDirectory
-    return sources.map { dirs ->
-      val sourceSetRoot = dirs.firstOrNull()?.asFile?.parentFile
-        ?: error("No source dirs registered for ${testVariant.name}")
+    // Only the location of the source directories matters here. Mapping `sources` would also carry
+    // the tasks that produce generated source directories (eg. KSP) into the record task's outputs,
+    // which can't be resolved when the configuration cache entry is stored.
+    return providerFactory.provider {
+      val sourceSetRoot = sources.get().firstOrNull()?.asFile?.parentFile
+        ?: error("No source dirs registered for $testVariantName")
       projectDirectory.dir(sourceSetRoot.path).dir("snapshots")
     }
   }

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -390,6 +390,28 @@ class PaparazziPluginTest {
   }
 
   @Test
+  fun configurationCacheWorksWhenRecordingWithGeneratedTestSources() {
+    val fixtureRoot = File("src/test/projects/configuration-cache-generated-test-sources")
+    fixtureRoot.resolve("src/test/snapshots").registerForDeletionOnExit()
+
+    // Generated test sources (eg. from KSP) must not be resolved when storing the record task's
+    // outputs in the configuration cache. https://github.com/cashapp/paparazzi/issues/2374
+    gradleRunner
+      .withArguments("recordPaparazziDebug", "--configuration-cache", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
+  fun configurationCacheWorksWhenRecordingWithGeneratedTestSourcesInMultiplatform() {
+    val fixtureRoot = File("src/test/projects/configuration-cache-generated-test-sources-multiplatform")
+    fixtureRoot.resolve("src/androidHostTest/snapshots").registerForDeletionOnExit()
+
+    gradleRunner
+      .withArguments("recordPaparazziAndroidMain", "--configuration-cache", "--stacktrace")
+      .runFixture(fixtureRoot) { build() }
+  }
+
+  @Test
   fun interceptViewEditMode() {
     val fixtureRoot = File("src/test/projects/edit-mode-intercept")
 

--- a/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
+++ b/paparazzi-gradle-plugin/src/test/java/app/cash/paparazzi/gradle/PaparazziPluginTest.kt
@@ -399,16 +399,25 @@ class PaparazziPluginTest {
     gradleRunner
       .withArguments("recordPaparazziDebug", "--configuration-cache", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
+
+    val snapshot = File(fixtureRoot, "src/test/snapshots/images/app.cash.paparazzi.plugin.test_RecordTest_record.png")
+    assertThat(snapshot.exists()).isTrue()
   }
 
   @Test
   fun configurationCacheWorksWhenRecordingWithGeneratedTestSourcesInMultiplatform() {
     val fixtureRoot = File("src/test/projects/configuration-cache-generated-test-sources-multiplatform")
     fixtureRoot.resolve("src/androidHostTest/snapshots").registerForDeletionOnExit()
+    fixtureRoot.resolve("build/generated/sourceGen/snapshots").registerForDeletionOnExit()
 
     gradleRunner
       .withArguments("recordPaparazziAndroidMain", "--configuration-cache", "--stacktrace")
       .runFixture(fixtureRoot) { build() }
+
+    // Snapshots belong next to the checked-in sources, not in a generated source directory.
+    val snapshot =
+      File(fixtureRoot, "src/androidHostTest/snapshots/images/app.cash.paparazzi.plugin.test_RecordTest_record.png")
+    assertThat(snapshot.exists()).isTrue()
   }
 
   @Test

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/build.gradle
@@ -1,0 +1,50 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.android.kotlin.multiplatform.library'
+  id 'app.cash.paparazzi'
+}
+
+kotlin {
+  androidLibrary {
+    namespace = 'app.cash.paparazzi.plugin.test'
+    compileSdk = libs.versions.compileSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
+
+    withHostTest { hostTest ->
+      hostTest.targetSdk {
+        version = release(libs.versions.compileSdk.get() as int)
+      }
+      hostTest.includeAndroidResources = true
+    }
+    androidResources.enable = true
+  }
+
+  sourceSets {
+    named("androidHostTest") {
+      dependencies {
+        implementation libs.junit
+      }
+    }
+  }
+}
+
+androidComponents {
+  onVariants(selector().all()) { variant ->
+    // Generated host test sources, like the ones KSP adds, give the test source set a producer task.
+    def sourceGen = project.tasks.register("sourceGen${variant.name.capitalize()}HostTest", SourceGenTask) {
+      outputDirectory = project.layout.buildDirectory.dir("generated/sourceGen/${variant.name}HostTest")
+    }
+    variant.unitTest?.sources?.kotlin?.addGeneratedSourceDirectory(
+      sourceGen,
+      { task -> task.outputDirectory }
+    )
+  }
+}
+
+abstract class SourceGenTask extends DefaultTask {
+  @OutputDirectory
+  abstract DirectoryProperty getOutputDirectory()
+
+  @TaskAction
+  void generate() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/gradle.properties
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/src/androidHostTest/kotlin/app/cash/paparazzi/plugin/test/RecordTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/src/androidHostTest/kotlin/app/cash/paparazzi/plugin/test/RecordTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paparazzi.plugin.test
 
+import android.widget.LinearLayout
 import app.cash.paparazzi.Paparazzi
 import org.junit.Rule
 import org.junit.Test
@@ -24,5 +25,7 @@ class RecordTest {
   val paparazzi = Paparazzi()
 
   @Test
-  fun record() {}
+  fun record() {
+    paparazzi.snapshot(LinearLayout(paparazzi.context))
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/src/androidHostTest/kotlin/app/cash/paparazzi/plugin/test/RecordTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources-multiplatform/src/androidHostTest/kotlin/app/cash/paparazzi/plugin/test/RecordTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class RecordTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun record() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/build.gradle
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+  id 'com.android.library'
+  id 'app.cash.paparazzi'
+}
+
+android {
+  namespace = 'app.cash.paparazzi.plugin.test'
+  compileSdk = libs.versions.compileSdk.get() as int
+  defaultConfig {
+    minSdk = libs.versions.minSdk.get() as int
+  }
+  compileOptions {
+    sourceCompatibility = libs.versions.javaTarget.get()
+    targetCompatibility = libs.versions.javaTarget.get()
+  }
+}
+
+androidComponents {
+  onVariants(selector().all()) { variant ->
+    // Generated unit test sources, like the ones KSP adds, give the test source set a producer task.
+    def sourceGen = project.tasks.register("do${variant.name.capitalize()}UnitTestSourceGen", SourceGenTask) {
+      outputDirectory = project.layout.buildDirectory.dir("generated/sourceGen/${variant.name}UnitTest")
+    }
+    variant.unitTest?.sources?.kotlin?.addGeneratedSourceDirectory(
+      sourceGen,
+      { task -> task.outputDirectory }
+    )
+  }
+}
+
+abstract class SourceGenTask extends DefaultTask {
+  @OutputDirectory
+  abstract DirectoryProperty getOutputDirectory()
+
+  @TaskAction
+  void generate() {}
+}

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/src/test/java/app/cash/paparazzi/plugin/test/RecordTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/src/test/java/app/cash/paparazzi/plugin/test/RecordTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paparazzi.plugin.test
 
+import android.widget.LinearLayout
 import app.cash.paparazzi.Paparazzi
 import org.junit.Rule
 import org.junit.Test
@@ -24,5 +25,7 @@ class RecordTest {
   val paparazzi = Paparazzi()
 
   @Test
-  fun record() {}
+  fun record() {
+    paparazzi.snapshot(LinearLayout(paparazzi.context))
+  }
 }

--- a/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/src/test/java/app/cash/paparazzi/plugin/test/RecordTest.kt
+++ b/paparazzi-gradle-plugin/src/test/projects/configuration-cache-generated-test-sources/src/test/java/app/cash/paparazzi/plugin/test/RecordTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paparazzi.plugin.test
+
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class RecordTest {
+  @get:Rule
+  val paparazzi = Paparazzi()
+
+  @Test
+  fun record() {}
+}


### PR DESCRIPTION
Fixes #2374.

`snapshotDir()` builds the snapshot directory by mapping `sources.kotlin.all`. When the test source set has generated directories (KSP, or anything added with `addGeneratedSourceDirectory`), that provider carries the generating task as a producer, and so does anything mapped from it. During a record run the result is registered as a task output, and the configuration cache resolves outputs when it stores the entry, which fails:

```
InvalidUserCodeException: Querying the mapped value of list(interface org.gradle.api.file.Directory, item(flatmap(provider(task 'sourceGenAndroidMainHostTest', class SourceGenTask))) + flatmap(provider(?))) before task ':sourceGenAndroidMainHostTest' has completed is not supported
```

The snapshot directory only depends on where the source set lives, not on what the generating task writes, so this computes it with `providerFactory.provider { }` instead of `map`. It uses the same sources and the same "parent of the first source dir" rule, so snapshot locations don't change. The lambda only captures the variant name and the project directory.

I tried `sources.kotlin.static` first, but that list is empty for the KMP library plugin's `androidHostTest`, so it broke `kotlinMultiplatformPluginWithNewAndroidLibraryPlugin`.

Two new fixtures reproduce it without KSP on the fixture classpath, both registering a generated Kotlin dir on the unit test through the variant API:
- `configuration-cache-generated-test-sources`: Android library, `recordPaparazziDebug --configuration-cache`
- `configuration-cache-generated-test-sources-multiplatform`: KMP library plugin, `recordPaparazziAndroidMain --configuration-cache`

Both fail on master with the error above and pass with this change.

Locally I also ran the existing plugin tests that touch the snapshot directory or the configuration cache (`kotlinMultiplatformPluginWithNewAndroidLibraryPlugin`, `configurationCache*`, `record*`, `cleanRecord`, `deleteSnapshots`, `verifyMissingGolden`, `rerun*`, `customBuildDir`, `customReportDir`, `snapshotReport`, and a few others), plus `spotlessCheck`. All pass.
